### PR TITLE
Support to use a data disk as the ephemeral disk.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ See [development doc](docs/development.md).
 
 ## CHANGELOG
 ```
+# 2015-04-25
+- CPI changes
+  - Support to use a data disk as the ephemeral disk.
+
 # 2015-04-20
 - CPI changes
   - Upgrade azure-sdk-for-ruby version to 0.7.4.

--- a/src/bosh_azure_cpi/README.md
+++ b/src/bosh_azure_cpi/README.md
@@ -88,6 +88,12 @@ These options are specified under `cloud_properties` in the `resource_pools` sec
 * `security_group` (optional)
   which [security group](https://azure.microsoft.com/en-us/documentation/articles/virtual-networks-nsg/) to apply for all VMs that are in this resource pool. Default to the security group specified by default_security_group in the global CPI settings unless a security group is specified on one of the VM networks. The security group can be specified either on a resource pool or on a network.
 
+* `ephemeral_disk/use_temporary_disk` (optional)
+  Whether to use Azure temporary  disk as the ephemeral disk to apply for all VMs that are in this resource pool. Default is false.
+
+* `ephemeral_disk/size` (optional)
+  The size of the ephemeral disk to apply for all VMs that are in this resource pool in megabytes. Default is 15_000 megabytes. This value is only valid when use_temporary_disk is set to false. The size of the ephemeral disk for the BOSH VM should be larger or equal than 15_000 megabytes.
+
 ### Network options
 
 These options are specified under `cloud_properties` in the `networks` section of a BOSH deployment manifest.

--- a/src/bosh_azure_cpi/lib/cloud/azure/azure_client2.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/azure_client2.rb
@@ -126,6 +126,9 @@ module Bosh::AzureCloud
     # * +:image_uri+            - String. The URI of the image.
     # * +:os_disk_name+         - String. The name of the OS disk for the virtual machine instance.
     # * +:os_vhd_uri+           - String. The URI of the OS disk for the virtual machine instance.
+    # * +:ephemeral_disk_name+  - String. The name of the ephemeral disk for the virtual machine instance.
+    # * +:ephemeral_disk_uri+   - String. The URI of the ephemeral disk for the virtual machine instance.
+    # * +:ephemeral_disk_size+  - Integer. The size in GiB of the ephemeral disk for the virtual machine instance.
     # * #:caching+              - String. The caching option of the OS disk. Caching option: None, ReadOnly or ReadWrite
     # * +:ssh_cert_data+        - String. The content of SSH certificate.
     #
@@ -169,6 +172,7 @@ module Bosh::AzureCloud
                 'uri' => vm_params[:os_vhd_uri]
               }
             },
+            'dataDisks' => []
           },
           'networkProfile' => {
             'networkInterfaces' => [
@@ -184,6 +188,19 @@ module Bosh::AzureCloud
         vm['properties']['availabilitySet'] = {
           'id' => availability_set[:id]
         }
+      end
+
+      unless vm_params[:ephemeral_disk_size].nil?
+        vm['properties']['storageProfile']['dataDisks'].push({
+          'name'         => vm_params[:ephemeral_disk_name],
+          'lun'          => 0,
+          'createOption' => 'Empty',
+          'diskSizeGB'   => vm_params[:ephemeral_disk_size],
+          'caching'      => 'ReadWrite',
+          'vhd'          => {
+            'uri' => vm_params[:ephemeral_disk_uri]
+          }
+        })
       end
 
       params = {

--- a/src/bosh_azure_cpi/lib/cloud/azure/helpers.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/helpers.rb
@@ -42,6 +42,8 @@ module Bosh::AzureCloud
       }
     }
 
+    EPHEMERAL_DISK_NAME = 'ephemeral-disk'
+
     ##
     # Raises CloudError exception
     #
@@ -155,6 +157,13 @@ module Bosh::AzureCloud
 
     def get_api_version(azure_properties, resource_provider)
       AZURE_ENVIRONMENTS[azure_properties['environment']]['apiVersion'][resource_provider]
+    end
+
+    def validate_disk_size(size)
+      raise ArgumentError, 'disk size needs to be an integer' unless size.kind_of?(Integer)
+
+      cloud_error('Azure CPI minimum disk size is 1 GiB') if size < 1024
+      cloud_error('Azure CPI maximum disk size is 1 TiB') if size > 1024 * 1000
     end
 
     private

--- a/src/bosh_azure_cpi/spec/unit/azure_client2/create_virtual_machine_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client2/create_virtual_machine_spec.rb
@@ -38,7 +38,10 @@ describe Bosh::AzureCloud::AzureClient2 do
         :image_uri           => "f",
         :os_disk_name        => "g",
         :os_vhd_uri          => "h",
-        :ssh_cert_data       => "i"
+        :ssh_cert_data       => "i",
+        :ephemeral_disk_name => "j",
+        :ephemeral_disk_uri  => "k",
+        :ephemeral_disk_size => "l"
       }
     end
     let(:network_interface) { {:id => "a"} }

--- a/src/bosh_azure_cpi/spec/unit/helpers_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/helpers_spec.rb
@@ -367,4 +367,36 @@ describe Bosh::AzureCloud::Helpers do
       end
     end
   end
+
+  describe "#validate_disk_size" do
+    context "disk size is not an integer" do
+      let(:disk_size) { "fake-size" }
+
+      it "should raise an error" do
+        expect {
+          helpers_tester.validate_disk_size(disk_size)
+        }.to raise_error "disk size needs to be an integer"
+      end
+    end
+
+    context "disk size is smaller than 1 GiB" do
+      let(:disk_size) { 666 }
+
+      it "should raise an error" do
+        expect {
+          helpers_tester.validate_disk_size(disk_size)
+        }.to raise_error "Azure CPI minimum disk size is 1 GiB"
+      end
+    end
+
+    context "disk size is larger than 1s TiB" do
+      let(:disk_size) { 6666 * 1024 }
+
+      it "should raise an error" do
+        expect {
+          helpers_tester.validate_disk_size(disk_size)
+        }.to raise_error "Azure CPI maximum disk size is 1 TiB"
+      end
+    end
+  end
 end


### PR DESCRIPTION
In the cloud properties of resource pools, two options `ephemeral_disk/use_temporary_disk` and `ephemeral_disk/size` are added. Please see the example as below.
```
resource_pools:
- name: test
  cloud_properties:
    instance_type: Standard_D2
    ephemeral_disk: 
      use_temporary_disk: false
      size: 20_000
```

1. `ephemeral_disk` is not set: Use an Azure data disk as the ephemeral disk. Default size is 15 GiB.
2. `ephemeral_disk/use_temporary_disk` is not set or `ephemeral_disk/use_temporary_disk` is set to false: Use an Azure data disk as the ephemeral disk. The disk size is specified by `ephemeral_disk/size`
3. `ephemeral_disk/use_temporary_disk` is set to true: Use Azure resource disk as the ephemeral disk. The disk size depends on VM's type and size. You can see more detail about the size of Azure temporary disk [here](https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-linux-sizes/).

Suggestion:
1. Suggest to use Azure resource disk as the ephemeral disk for CF VMs. Even if the data in the resource disk is lost when Azure service healing, BOSH Resurrector can repair your CF VMs automatically.
2. Suggest to use a data disk as the ephemeral disk for BOSH VM. The data in the ephemeral disk will never be lost. You can use Azure premium storage to host your BOSH VM (e.g. Use DS3 for BOSH VM) to get better performance. The size must be larger or equal than 15 GiB for BOSH VM because it needs enough space to extract stemcells.