### PR TITLE
Use LUN and host device id as the disk identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ See [development doc](docs/development.md).
 
 ## CHANGELOG
 ```
+# 2015-05-09
+- CPI changes
+  - Remove use_temporary_disk and always use a data disk as the ephemeral disk.
+
 # 2015-04-25
 - CPI changes
   - Support to use a data disk as the ephemeral disk.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ See [development doc](docs/development.md).
 
 ## CHANGELOG
 ```
+# 2015-05-17
+- CPI changes
+  - Fix an issue in calculating the sleep interval when copying blobs
+  - Use LUN and host device id as the disk identifier
+    - Compatible Stemcell Versions: v3181 or later
+
 # 2015-05-09
 - CPI changes
   - Remove use_temporary_disk and always use a data disk as the ephemeral disk.

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -151,7 +151,7 @@ jobs:
 - name: promote-candidate
   plan:
   - aggregate:
-    - {trigger: true,  get: bosh-cpi-dev-artifacts, passed: [lifecycle, bats-ubuntu]}
+    - {trigger: false,  get: bosh-cpi-dev-artifacts, passed: [lifecycle, bats-ubuntu]}
     - {trigger: false, get: bosh-cpi-release, resource: bosh-cpi-release-out}
     - {trigger: false, get: release-version-semver, params: {bump: major}}
 

--- a/src/bosh_azure_cpi/lib/cloud/azure/blob_manager.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/blob_manager.rb
@@ -157,7 +157,7 @@ module Bosh::AzureCloud
 
             elapse_time = Time.new - start_time
             copied_bytes, total_bytes = blob_props[:copy_progress].split('/').map { |v| v.to_i }
-            interval = copied_bytes == 0 ? 5 : (total_bytes - copied_bytes) / copied_bytes * elapse_time
+            interval = copied_bytes == 0 ? 5 : (total_bytes - copied_bytes).to_f / copied_bytes * elapse_time
             interval = 30 if interval > 30
             interval = 1 if interval < 1
             sleep(interval)

--- a/src/bosh_azure_cpi/lib/cloud/azure/cloud.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/cloud.rb
@@ -68,7 +68,6 @@ module Bosh::AzureCloud
     #    "platform_fault_domain_count" => 3,
     #    "security_group" => "nsg-bosh",
     #    "ephemeral_disk" => {
-    #      "use_temporary_disk" => false,
     #      "size" => 20480, # disk size in MB
     #    }
     #  }
@@ -111,13 +110,6 @@ module Bosh::AzureCloud
           NetworkConfigurator.new(networks))
         @logger.info("Created new vm '#{instance_id}'")
 
-        ephemeral_disk = "/dev/sdc"
-        if resource_pool.has_key?('ephemeral_disk')
-          if resource_pool['ephemeral_disk']['use_temporary_disk']
-            ephemeral_disk = "/dev/sdb"
-          end
-        end
-
         begin
           registry_settings = initial_agent_settings(
             agent_id,
@@ -125,7 +117,7 @@ module Bosh::AzureCloud
             networks,
             env,
             "/dev/sda",
-            ephemeral_disk
+            "/dev/sdc"
           )
           registry.update_settings(instance_id, registry_settings)
 

--- a/src/bosh_azure_cpi/lib/cloud/azure/disk_manager.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/disk_manager.rb
@@ -1,8 +1,9 @@
 module Bosh::AzureCloud
   class DiskManager
-    DISK_CONTAINER       = 'bosh'
-    OS_DISK_PREFIX       = 'bosh-os'
-    DATA_DISK_PREFIX     = 'bosh-data'
+    DISK_CONTAINER         = 'bosh'
+    OS_DISK_PREFIX         = 'bosh-os'
+    DATA_DISK_PREFIX       = 'bosh-data'
+    EPHEMERAL_DISK_POSTFIX = 'ephemeral'
 
     include Bosh::Exec
     include Helpers
@@ -96,6 +97,11 @@ module Bosh::AzureCloud
     # bosh-os-STORAGEACCOUNTNAME-AGENTID
     def generate_os_disk_name(instance_id)
       "#{OS_DISK_PREFIX}-#{instance_id}"
+    end
+
+    # bosh-os-STORAGEACCOUNTNAME-AGENTID-ephemeral
+    def generate_ephemeral_disk_name(instance_id)
+      "#{OS_DISK_PREFIX}-#{instance_id}-#{EPHEMERAL_DISK_POSTFIX}"
     end
 
     private

--- a/src/bosh_azure_cpi/lib/cloud/azure/helpers.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/helpers.rb
@@ -42,7 +42,8 @@ module Bosh::AzureCloud
       }
     }
 
-    EPHEMERAL_DISK_NAME = 'ephemeral-disk'
+    EPHEMERAL_DISK_NAME       = 'ephemeral-disk'
+    AZURE_SCSI_HOST_DEVICE_ID = '{f8b3781b-1e82-4818-a1c3-63d806ec15bb}'
 
     ##
     # Raises CloudError exception

--- a/src/bosh_azure_cpi/lib/cloud/azure/vm_manager.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/vm_manager.rb
@@ -4,8 +4,6 @@ module Bosh::AzureCloud
 
     AZURE_TAGS = {'user-agent' => 'bosh'}
 
-    EPHEMERAL_DISK_POSTFIX = 'ephemeral'
-
     def initialize(azure_properties, registry_endpoint, disk_manager, azure_client2)
       @azure_properties = azure_properties
       @registry_endpoint = registry_endpoint
@@ -17,16 +15,12 @@ module Bosh::AzureCloud
 
     def create(uuid, storage_account, stemcell_uri, resource_pool, network_configurator)
       instance_is_created = false
-      ephemeral_disk_id = nil
       ephemeral_disk_size = 15
       if resource_pool.has_key?('ephemeral_disk')
         if resource_pool['ephemeral_disk'].has_key?('size')
           size = resource_pool['ephemeral_disk']['size']
           validate_disk_size(size)
           ephemeral_disk_size = size/1024
-        end
-        if resource_pool['ephemeral_disk']['use_temporary_disk']
-          ephemeral_disk_size = nil
         end
       end
 
@@ -103,23 +97,21 @@ module Bosh::AzureCloud
         :os_disk_name        => os_disk_name,
         :os_vhd_uri          => @disk_manager.get_disk_uri(os_disk_name),
         :caching             => caching,
-        :ssh_cert_data       => @azure_properties['ssh_public_key']
+        :ssh_cert_data       => @azure_properties['ssh_public_key'],
+        :ephemeral_disk_name => EPHEMERAL_DISK_NAME,
+        :ephemeral_disk_uri  => @disk_manager.get_disk_uri(@disk_manager.generate_ephemeral_disk_name(instance_id)),
+        :ephemeral_disk_size => ephemeral_disk_size
       }
-      unless ephemeral_disk_size.nil?
-        ephemeral_disk_id = @disk_manager.generate_os_disk_name("#{instance_id}-#{EPHEMERAL_DISK_POSTFIX}")
-
-        vm_params[:ephemeral_disk_name] = EPHEMERAL_DISK_NAME
-        vm_params[:ephemeral_disk_uri]  = @disk_manager.get_disk_uri(ephemeral_disk_id)
-        vm_params[:ephemeral_disk_size] = ephemeral_disk_size
-      end
 
       instance_is_created = true
       @azure_client2.create_virtual_machine(vm_params, network_interface, availability_set)
 
       instance_id
     rescue => e
-      @azure_client2.delete_virtual_machine(instance_id) if instance_is_created
-      @disk_manager.delete_disk(ephemeral_disk_id) unless ephemeral_disk_id.nil?
+      if instance_is_created
+        @azure_client2.delete_virtual_machine(instance_id)
+        @disk_manager.delete_disk(@disk_manager.get_disk_uri(@disk_manager.generate_ephemeral_disk_name(instance_id)))
+      end
       delete_availability_set(availability_set[:name]) unless availability_set.nil?
       @azure_client2.delete_network_interface(network_interface[:name]) unless network_interface.nil?
       # Replace vmSize with instance_type because only instance_type exists in the manifest
@@ -153,7 +145,7 @@ module Bosh::AzureCloud
       os_disk_name = @disk_manager.generate_os_disk_name(instance_id)
       @disk_manager.delete_disk(os_disk_name)
 
-      ephemeral_disk_name = @disk_manager.generate_os_disk_name("#{instance_id}-#{EPHEMERAL_DISK_POSTFIX}")
+      ephemeral_disk_name = @disk_manager.generate_ephemeral_disk_name(instance_id)
       @disk_manager.delete_disk(ephemeral_disk_name)
 
       # Cleanup invalid VM status file

--- a/src/bosh_azure_cpi/lib/cloud/azure/vm_manager.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/vm_manager.rb
@@ -168,13 +168,13 @@ module Bosh::AzureCloud
     #
     # @param [String] instance_id Instance id
     # @param [String] disk_name disk name
-    # @return [String] volume name. "/dev/sd[c-r]"
+    # @return [String] lun
     def attach_disk(instance_id, disk_name)
       @logger.info("attach_disk(#{instance_id}, #{disk_name})")
       disk_uri = @disk_manager.get_disk_uri(disk_name)
       caching = @disk_manager.get_data_disk_caching(disk_name)
       disk = @azure_client2.attach_disk_to_virtual_machine(instance_id, disk_name, disk_uri, caching)
-      "/dev/sd#{('c'.ord + disk[:lun]).chr}"
+      "#{disk[:lun]}"
     end
 
     def detach_disk(instance_id, disk_name)

--- a/src/bosh_azure_cpi/spec/integration/lifecycle_spec.rb
+++ b/src/bosh_azure_cpi/spec/integration/lifecycle_spec.rb
@@ -271,46 +271,6 @@ describe Bosh::AzureCloud::Cloud do
     end
   end
 
-  context 'Creating one VM with using the temporary disk as the ephemeral disk' do
-    let(:resource_pool) {
-      {
-        'instance_type' => instance_type,
-        'ephemeral_disk' => {
-          'use_temporary_disk' => true
-        }
-      }
-    }
-
-    it 'should exercise the vm lifecycle' do
-      vm_lifecycle(@stemcell_id, dynamic_networks, 1) do |instance_id|
-        disk_id = cpi.create_disk(2048, {}, instance_id)
-        expect(disk_id).not_to be_nil
-
-        cpi.attach_disk(instance_id, disk_id)
-
-        snapshot_metadata = vm_metadata.merge(
-          bosh_data: 'bosh data',
-          instance_id: 'instance',
-          agent_id: 'agent',
-          director_name: 'Director',
-          director_uuid: SecureRandom.uuid
-        )
-
-        snapshot_id = cpi.snapshot_disk(disk_id, snapshot_metadata)
-        expect(snapshot_id).not_to be_nil
-
-        cpi.delete_snapshot(snapshot_id)
-
-        Bosh::Common.retryable(tries: 20, on: Bosh::Clouds::DiskNotAttached, sleep: lambda { |n, _| [2**(n-1), 30].min }) do
-          cpi.detach_disk(instance_id, disk_id)
-          true
-        end
-
-        cpi.delete_disk(disk_id) if disk_id
-      end
-    end
-  end
-
   def vm_lifecycle(stemcell_id, network_spec, nums = 1)
     instance_id_pool = Array.new
     for i in 1..nums

--- a/src/bosh_azure_cpi/spec/unit/vm_manager_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/vm_manager_spec.rb
@@ -395,7 +395,7 @@ describe Bosh::AzureCloud::VMManager do
           end
         end
 
-        context "with using the temporary disk as the ephemeral disk" do
+        context "with setting the ephemeral disk size to 20 GiB" do
           let(:resource_pool) {
             {
               'instance_type' => 'Standard_D1',
@@ -406,7 +406,7 @@ describe Bosh::AzureCloud::VMManager do
               'platform_fault_domain_count' => 3,
               'load_balancer' => 'fake-lb-name',
               'ephemeral_disk' => {
-                'use_temporary_disk' => true
+                'size' => 20 * 1024
               }
             }
           }
@@ -419,62 +419,6 @@ describe Bosh::AzureCloud::VMManager do
             expect(client2).not_to receive(:delete_network_interface)
 
             vm_manager.create(uuid, storage_account, stemcell_uri, resource_pool, network_configurator)
-          end
-        end
-
-        context "with using the data disk as the ephemeral disk" do
-          context "with setting the ephemeral disk size to 20 GiB" do
-            let(:resource_pool) {
-              {
-                'instance_type' => 'Standard_D1',
-                'storage_account_name' => 'dfe03ad623f34d42999e93ca',
-                'caching' => 'ReadWrite',
-                'availability_set' => 'fake-avset',
-                'platform_update_domain_count' => 5,
-                'platform_fault_domain_count' => 3,
-                'load_balancer' => 'fake-lb-name',
-                'ephemeral_disk' => {
-                  'size' => 20 * 1024
-                }
-              }
-            }
-
-            it "should succeed" do
-              allow(client2).to receive(:create_virtual_machine)
-
-              expect(client2).not_to receive(:delete_virtual_machine)
-              expect(client2).not_to receive(:delete_availability_set)
-              expect(client2).not_to receive(:delete_network_interface)
-
-              vm_manager.create(uuid, storage_account, stemcell_uri, resource_pool, network_configurator)
-            end
-          end
-
-          context "with setting use_temporary_disk to false" do
-            let(:resource_pool) {
-              {
-                'instance_type' => 'Standard_D1',
-                'storage_account_name' => 'dfe03ad623f34d42999e93ca',
-                'caching' => 'ReadWrite',
-                'availability_set' => 'fake-avset',
-                'platform_update_domain_count' => 5,
-                'platform_fault_domain_count' => 3,
-                'load_balancer' => 'fake-lb-name',
-                'ephemeral_disk' => {
-                  'use_temporary_disk' => false
-                }
-              }
-            }
-
-            it "should succeed" do
-              allow(client2).to receive(:create_virtual_machine)
-
-              expect(client2).not_to receive(:delete_virtual_machine)
-              expect(client2).not_to receive(:delete_availability_set)
-              expect(client2).not_to receive(:delete_network_interface)
-
-              vm_manager.create(uuid, storage_account, stemcell_uri, resource_pool, network_configurator)
-            end
           end
         end
       end

--- a/src/bosh_azure_cpi/spec/unit/vm_manager_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/vm_manager_spec.rb
@@ -10,6 +10,7 @@ describe Bosh::AzureCloud::VMManager do
   let(:uuid) { 'e55144a3-0c06-4240-8f15-9a7bc7b35d1f' }
   let(:instance_id) { "#{MOCK_DEFAULT_STORAGE_ACCOUNT_NAME}-#{uuid}" }
   let(:storage_account_name) { MOCK_DEFAULT_STORAGE_ACCOUNT_NAME }
+  let(:ephemeral_disk_name) { "fake-ephemeral-disk-name" }
 
   describe "#create" do
     # Parameters
@@ -44,6 +45,7 @@ describe Bosh::AzureCloud::VMManager do
       }
     }
     let(:disk_id) { double("fake-disk-id") }
+
     before do
       allow(Bosh::AzureCloud::AzureClient2).to receive(:new).
         and_return(client2)
@@ -58,6 +60,8 @@ describe Bosh::AzureCloud::VMManager do
         and_return(network_security)
       allow(disk_manager).to receive(:delete_disk).
         and_return(nil)
+      allow(disk_manager).to receive(:generate_ephemeral_disk_name).
+        and_return(ephemeral_disk_name)
     end
 
     context "when subnet is not found" do
@@ -460,9 +464,8 @@ describe Bosh::AzureCloud::VMManager do
         and_return(os_disk_name)
       expect(disk_manager).to receive(:delete_disk).with(os_disk_name)
 
-      ephemeral_disk_name = "fake-os-ephemeral-name"
-      allow(disk_manager).to receive(:generate_os_disk_name).
-        with("#{instance_id}-ephemeral").
+      allow(disk_manager).to receive(:generate_ephemeral_disk_name).
+        with(instance_id).
         and_return(ephemeral_disk_name)
       expect(disk_manager).to receive(:delete_disk).with(ephemeral_disk_name)
 
@@ -502,7 +505,7 @@ describe Bosh::AzureCloud::VMManager do
       expect(disk_manager).to receive(:get_data_disk_caching).
         with(disk_name).
         and_return(cache)
-      expect(vm_manager.attach_disk(instance_id, disk_name)).to eq("/dev/sdd")
+      expect(vm_manager.attach_disk(instance_id, disk_name)).to eq("1")
     end
   end  
 


### PR DESCRIPTION
Close #135
4 commits:
1. Remove use_temporary_disk and always use a data disk as the ephemeral disk.
2. Fix an issue in calculating the sleep interval when copying blobs
3. Use LUN and host device id as the disk identifier
4. Do not trigger the CI job "promote" automatically