### PR TITLE
Avoid extra bash process by passing CPI input directly to exec'ed process

### DIFF
--- a/jobs/cpi/templates/cpi.erb
+++ b/jobs/cpi/templates/cpi.erb
@@ -15,8 +15,6 @@ export NO_PROXY=<%= no_proxy %>
 export no_proxy=<%= no_proxy %>
 <% end %>
 
-read INPUT
-
 BOSH_PACKAGES_DIR=${BOSH_PACKAGES_DIR:-/var/vcap/packages}
 BOSH_JOBS_DIR=${BOSH_JOBS_DIR:-/var/vcap/jobs}
 
@@ -27,7 +25,5 @@ export BUNDLE_GEMFILE=$BOSH_PACKAGES_DIR/bosh_azure_cpi/Gemfile
 
 bundle_cmd="$BOSH_PACKAGES_DIR/ruby_azure_cpi/bin/bundle"
 
-echo $INPUT | $bundle_cmd exec $BOSH_PACKAGES_DIR/bosh_azure_cpi/bin/azure_cpi \
+exec $bundle_cmd exec $BOSH_PACKAGES_DIR/bosh_azure_cpi/bin/azure_cpi \
   $BOSH_JOBS_DIR/cpi/config/cpi.json
-
-exit 0


### PR DESCRIPTION

- This avoids additional bash processes while maintaining the same
functionality
- We've made this change in the other Ruby CPIs, submitting this PR to keep things consistent

[#120627927](https://www.pivotaltracker.com/story/show/120627927)

Signed-off-by: Kam Leung <kleung@pivotal.io>