### PR TITLE
Support specifying resource_group_name in the network spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ See [development doc](docs/development.md).
 
 ## CHANGELOG
 ```
+# 2015-06-15
+- CPI changes
+  - Support specifying resource group name under network cloud properties
+
 # 2015-05-17
 - CPI changes
   - Fix an issue in calculating the sleep interval when copying blobs

--- a/ci/assets/azure/network.json
+++ b/ci/assets/azure/network.json
@@ -2,35 +2,6 @@
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
   "contentVersion": "1.0.0.0",
   "parameters": {
-    "location": {
-      "type": "string",
-      "allowedValues": [
-        "East Asia",
-        "Southeast Asia",
-        "Central US",
-        "East US",
-        "East US 2",
-        "West US",
-        "North Central US",
-        "South Central US",
-        "North Europe",
-        "West Europe",
-        "Japan West",
-        "Japan East",
-        "Brazil South",
-        "Australia East",
-        "Australia Southeast"
-      ],
-      "metadata": {
-        "description": "Location to deploy to"
-      }
-    },
-    "newStorageAccountName": {
-      "type": "string",
-      "metadata": {
-        "description": "Unique DNS Name for the Storage Account where the Virtual Machine's disks will be placed. It must be between 3 and 24 characters in length and use numbers and lower-case letters only."
-      }
-    },
     "virtualNetworkNameForBats": {
       "type": "string",
       "defaultValue": "boshvnet-bats",
@@ -82,24 +53,17 @@
     }
   },
   "variables": {
-    "pubIPBaseName" : "AzureCPICI",
-    "api-version": "2015-05-01-preview",
-    "storageAccountType": "Standard_LRS",
-    "devboxPrivateIPAddress": "10.0.0.100",
-    "imagePublisher": "Canonical",
-    "imageOffer": "UbuntuServer",
-    "ubuntuOSVersion": "14.04.2-LTS",
-    "repository": "Azure",
-    "branch": "master",
-    "boshNetworkSecurityGroup": "nsg-cpi",
-    "githubPath": "[concat('https://raw.githubusercontent.com/', variables('repository'), '/azure-quickstart-templates/', variables('branch'), '/bosh-setup/')]"
+    "apiVersion": "2015-06-15",
+    "location": "[resourceGroup().location]",
+    "pubIPBaseName": "AzureCPICI",
+    "boshNetworkSecurityGroup": "nsg-cpi"
   },
   "resources": [
     {
       "apiVersion": "[variables('apiVersion')]",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('boshNetworkSecurityGroup')]",
-      "location": "[parameters('location')]",
+      "location": "[variables('location')]",
       "properties": {
         "securityRules": [
           {
@@ -162,37 +126,10 @@
       }
     },
     {
-      "type": "Microsoft.Storage/storageAccounts",
-      "name": "[parameters('newStorageAccountName')]",
-      "apiVersion": "[variables('api-version')]",
-      "location": "[parameters('location')]",
-      "properties": {
-        "accountType": "[variables('storageAccountType')]"
-      }
-    },
-    {
-      "apiVersion": "[variables('api-version')]",
-      "type": "Microsoft.Network/publicIPAddresses",
-      "name": "[concat(variables('pubIPBaseName'),'-bosh')]",
-      "location": "[parameters('location')]",
-      "properties": {
-        "publicIPAllocationMethod": "static"
-      }
-    },
-    {
-      "apiVersion": "[variables('api-version')]",
-      "type": "Microsoft.Network/publicIPAddresses",
-      "name": "[concat(variables('pubIPBaseName'), '-cf')]",
-      "location": "[parameters('location')]",
-      "properties": {
-        "publicIPAllocationMethod": "static"
-      }
-    },
-    {
-      "apiVersion": "[variables('api-version')]",
+      "apiVersion": "[variables('apiVersion')]",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[parameters('virtualNetworkNameForBats')]",
-      "location": "[parameters('location')]",
+      "location": "[variables('location')]",
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -216,10 +153,10 @@
       }
     },
     {
-      "apiVersion": "[variables('api-version')]",
+      "apiVersion": "[variables('apiVersion')]",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[parameters('virtualNetworkNameForLifecycle')]",
-      "location": "[parameters('location')]",
+      "location": "[variables('location')]",
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -240,6 +177,33 @@
             }
           }
         ]
+      }
+    },
+    {
+      "apiVersion": "[variables('apiVersion')]",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[concat(variables('pubIPBaseName'),'-bosh')]",
+      "location": "[variables('location')]",
+      "properties": {
+        "publicIPAllocationMethod": "static"
+      }
+    },
+    {
+      "apiVersion": "[variables('apiVersion')]",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[concat(variables('pubIPBaseName'), '-cf-lifecycle')]",
+      "location": "[variables('location')]",
+      "properties": {
+        "publicIPAllocationMethod": "static"
+      }
+    },
+    {
+      "apiVersion": "[variables('apiVersion')]",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[concat(variables('pubIPBaseName'), '-cf-bats')]",
+      "location": "[variables('location')]",
+      "properties": {
+        "publicIPAllocationMethod": "static"
       }
     }
   ]

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -14,6 +14,7 @@ jobs:
   plan:
   - aggregate:
     - {trigger: false, get: bosh-cpi-release, resource: bosh-cpi-release-in}
+    - {trigger: false, get: stemcell, resource: azure-ubuntu-stemcell}
 
   - task: azure-provision
     file: bosh-cpi-release/ci/tasks/azure-provision.yml
@@ -22,14 +23,13 @@ jobs:
         AZURE_CLIENT_ID:                {{azure_client_id}}
         AZURE_CLIENT_SECRET:            {{azure_client_secret}}
         AZURE_TENANT_ID:                {{azure_tenant_id}}
-        AZURE_GROUP_NAME:               {{azure_group_name}}
+        AZURE_GROUP_NAME_FOR_VMS:       {{azure_group_name_for_vms}}
+        AZURE_GROUP_NAME_FOR_NETWORK:   {{azure_group_name_for_network}}
         AZURE_REGION_NAME:              {{azure_region_name}}
         AZURE_VNET_NAME_FOR_BATS:       {{azure_vnet_name_for_bats}}
         AZURE_VNET_NAME_FOR_LIFECYCLE:  {{azure_vnet_name_for_lifecycle}}
         AZURE_REGION_SHORT_NAME:        {{azure_region_short_name}}
         AZURE_STORAGE_ACCOUNT_NAME:     {{azure_storage_account_name}}
-        AZURE_SUBSCRIPTION_ID:          {{azure_subscription_id}}
-        AZURE_TENANT_ID:                {{azure_tenant_id}}
         AZURE_BOSH_SUBNET_NAME:         {{azure_bosh_subnet_name}}
         AZURE_CF_SUBNET_NAME:           {{azure_cf_subnet_name}}
 
@@ -46,7 +46,7 @@ jobs:
         AZURE_TENANT_ID:                {{azure_tenant_id}}
         AZURE_CLIENT_ID:                {{azure_client_id}}
         AZURE_CLIENT_SECRET:            {{azure_client_secret}}
-        AZURE_GROUP_NAME:               {{azure_group_name}}
+        AZURE_GROUP_NAME:               {{azure_group_name_for_vms}}
         AZURE_STORAGE_ACCOUNT_NAME:     {{azure_storage_account_name}}
         AZURE_VNET_NAME_FOR_BATS:       {{azure_vnet_name_for_bats}}
         AZURE_VNET_NAME_FOR_LIFECYCLE:  {{azure_vnet_name_for_lifecycle}}
@@ -75,22 +75,22 @@ jobs:
   - aggregate:
     - {trigger: true,  passed: [build-candidate], get: bosh-cpi-dev-artifacts}
     - {trigger: false, passed: [build-candidate], get: bosh-cpi-release, resource: bosh-cpi-release-in}
-    - {trigger: false,                            get: stemcell, resource: azure-ubuntu-stemcell}
 
   - task: test
     file: bosh-cpi-release/ci/tasks/run-lifecycle.yml
     config:
       params:
-        SSH_PUBLIC_KEY:                 {{ssh_public_key}}
+        AZURE_SUBSCRIPTION_ID:          {{azure_subscription_id}}
         AZURE_CLIENT_ID:                {{azure_client_id}}
         AZURE_CLIENT_SECRET:            {{azure_client_secret}}
         AZURE_TENANT_ID:                {{azure_tenant_id}}
-        AZURE_GROUP_NAME:               {{azure_group_name}}
+        AZURE_GROUP_NAME_FOR_VMS:       {{azure_group_name_for_vms}}
+        AZURE_GROUP_NAME_FOR_NETWORK:   {{azure_group_name_for_network}}
         AZURE_STORAGE_ACCOUNT_NAME:     {{azure_storage_account_name}}
-        AZURE_SUBSCRIPTION_ID:          {{azure_subscription_id}}
         AZURE_VNET_NAME_FOR_LIFECYCLE:  {{azure_vnet_name_for_lifecycle}}
         AZURE_BOSH_SUBNET_NAME:         {{azure_bosh_subnet_name}}
         AZURE_DEFAULT_SECURITY_GROUP:   {{azure_default_security_group}}
+        SSH_PUBLIC_KEY:                 {{ssh_public_key}}
 
 - name: bats-ubuntu
   serial: true
@@ -108,20 +108,21 @@ jobs:
     file: bosh-cpi-release/ci/tasks/setup-director.yml
     config:
       params:
-        BASE_OS:                    ubuntu
+        BASE_OS:                        ubuntu
+        AZURE_SUBSCRIPTION_ID:          {{azure_subscription_id}}
         AZURE_CLIENT_ID:                {{azure_client_id}}
         AZURE_CLIENT_SECRET:            {{azure_client_secret}}
         AZURE_TENANT_ID:                {{azure_tenant_id}}
-        AZURE_GROUP_NAME:               {{azure_group_name}}
+        AZURE_GROUP_NAME_FOR_VMS:       {{azure_group_name_for_vms}}
+        AZURE_GROUP_NAME_FOR_NETWORK:   {{azure_group_name_for_network}}
         AZURE_VNET_NAME_FOR_BATS:       {{azure_vnet_name_for_bats}}
         AZURE_STORAGE_ACCOUNT_NAME:     {{azure_storage_account_name}}
-        AZURE_SUBSCRIPTION_ID:          {{azure_subscription_id}}
         AZURE_BOSH_SUBNET_NAME:         {{azure_bosh_subnet_name}}
-        BAT_NETWORK_GATEWAY:            {{bat_network_gateway}}
-        SSH_PRIVATE_KEY:                {{ssh_private_key}}
-        SSH_PUBLIC_KEY:                 {{ssh_public_key}}
         AZURE_DEFAULT_SECURITY_GROUP:   {{azure_default_security_group}}
+        BAT_NETWORK_GATEWAY:            {{bat_network_gateway}}
         BAT_DIRECTOR_PASSWORD:          {{bat_director_password}}
+        SSH_PUBLIC_KEY:                 {{ssh_public_key}}
+        SSH_PRIVATE_KEY:                {{ssh_private_key}}
 
   - task: run-bats
     file: bosh-cpi-release/ci/tasks/run-bats.yml
@@ -131,19 +132,19 @@ jobs:
         AZURE_CLIENT_ID:                {{azure_client_id}}
         AZURE_CLIENT_SECRET:            {{azure_client_secret}}
         AZURE_TENANT_ID:                {{azure_tenant_id}}
-        AZURE_GROUP_NAME:               {{azure_group_name}}
-        BAT_VCAP_PASSWORD:              {{bat_vcap_password}}
-        SSH_PRIVATE_KEY:                {{ssh_private_key}}
+        AZURE_GROUP_NAME:               {{azure_group_name_for_network}}
         AZURE_VNET_NAME_FOR_BATS:       {{azure_vnet_name_for_bats}}
-        BAT_SECOND_STATIC_IP:           {{bat_second_static_ip}}
-        BAT_NETWORK_STATIC_IP:          {{bat_network_static_ip}}
+        AZURE_CF_SUBNET_NAME:           {{azure_cf_subnet_name}}
+        AZURE_DEFAULT_SECURITY_GROUP:   {{azure_default_security_group}}
         BAT_NETWORK_CIDR:               {{bat_network_cidr}}
         BAT_NETWORK_RESERVED_RANGE:     {{bat_network_reserved_range}}
         BAT_NETWORK_GATEWAY:            {{bat_network_gateway}}
         BAT_NETWORK_STATIC_RANGE:       {{bat_network_static_range}}
-        AZURE_CF_SUBNET_NAME:           {{azure_cf_subnet_name}}
-        AZURE_DEFAULT_SECURITY_GROUP:   {{azure_default_security_group}}
+        BAT_NETWORK_STATIC_IP:          {{bat_network_static_ip}}
+        BAT_SECOND_STATIC_IP:           {{bat_second_static_ip}}
         BAT_DIRECTOR_PASSWORD:          {{bat_director_password}}
+        BAT_VCAP_PASSWORD:              {{bat_vcap_password}}
+        SSH_PRIVATE_KEY:                {{ssh_private_key}}
 
   - task: teardown-director
     file: bosh-cpi-release/ci/tasks/teardown-director.yml

--- a/ci/tasks/azure-provision.yml
+++ b/ci/tasks/azure-provision.yml
@@ -2,19 +2,20 @@
 platform: linux
 image: docker:///boshcpi/azure-cpi-release
 inputs:
-  - name: bosh-cpi-release
+- name: bosh-cpi-release
+- name: stemcell
 run:
   path: bosh-cpi-release/ci/tasks/azure-provision.sh
 params:
-    AZURE_CLIENT_ID:               replace-me
-    AZURE_CLIENT_SECRET:           replace-me
-    AZURE_TENANT_ID:               replace-me
-    AZURE_GROUP_NAME:              replace-me
-    AZURE_REGION_NAME:             replace-me
-    AZURE_REGION_SHORT_NAME:       replace-me
-    AZURE_STORAGE_ACCOUNT_NAME:    replace-me
-    AZURE_SUBSCRIPTION_ID:         replace-me
-    AZURE_VNET_NAME_FOR_BATS:      replace-me
-    AZURE_VNET_NAME_FOR_LIFECYCLE: replace-me
-    AUZRE_BOSH_SUBNET_NAME:        replace-me
-    AZURE_CF_SUBNET_NAME:          replace-me
+  AZURE_CLIENT_ID:               replace-me
+  AZURE_CLIENT_SECRET:           replace-me
+  AZURE_TENANT_ID:               replace-me
+  AZURE_GROUP_NAME_FOR_VMS:      replace-me
+  AZURE_GROUP_NAME_FOR_NETWORK:  replace-me
+  AZURE_REGION_NAME:             replace-me
+  AZURE_REGION_SHORT_NAME:       replace-me
+  AZURE_STORAGE_ACCOUNT_NAME:    replace-me
+  AZURE_VNET_NAME_FOR_BATS:      replace-me
+  AZURE_VNET_NAME_FOR_LIFECYCLE: replace-me
+  AUZRE_BOSH_SUBNET_NAME:        replace-me
+  AZURE_CF_SUBNET_NAME:          replace-me

--- a/ci/tasks/reset-resources.sh
+++ b/ci/tasks/reset-resources.sh
@@ -59,7 +59,7 @@ do
   fi
 done
 
-public_ips="AzureCPICI-bosh AzureCPICI-cf"
+public_ips="AzureCPICI-bosh AzureCPICI-cf-lifecycle AzureCPICI-cf-bats"
 for public_ip in ${public_ips}
 do
   echo "azure network public-ip show --resource-group ${AZURE_GROUP_NAME} --name ${public_ip} --json | jq '.name' -r"

--- a/ci/tasks/run-bats.sh
+++ b/ci/tasks/run-bats.sh
@@ -9,26 +9,26 @@ check_param AZURE_CLIENT_ID
 check_param AZURE_CLIENT_SECRET
 check_param AZURE_TENANT_ID
 check_param AZURE_GROUP_NAME
-check_param SSH_PRIVATE_KEY
+check_param AZURE_VNET_NAME_FOR_BATS
+check_param AZURE_CF_SUBNET_NAME
+check_param AZURE_DEFAULT_SECURITY_GROUP
 check_param BAT_VCAP_PASSWORD
-check_param BAT_SECOND_STATIC_IP
 check_param BAT_NETWORK_CIDR
+check_param BAT_SECOND_STATIC_IP
 check_param BAT_NETWORK_RESERVED_RANGE
 check_param BAT_NETWORK_STATIC_RANGE
 check_param BAT_NETWORK_GATEWAY
 check_param BAT_NETWORK_STATIC_IP
 check_param BAT_STEMCELL_URL
 check_param BAT_STEMCELL_SHA
-check_param AZURE_VNET_NAME_FOR_BATS
-check_param AZURE_CF_SUBNET_NAME
-check_param AZURE_DEFAULT_SECURITY_GROUP
 check_param BAT_DIRECTOR_PASSWORD
+check_param SSH_PRIVATE_KEY
 
 azure login --service-principal -u ${AZURE_CLIENT_ID} -p ${AZURE_CLIENT_SECRET} --tenant ${AZURE_TENANT_ID}
 azure config mode arm
 
 DIRECTOR=$(azure network public-ip show ${AZURE_GROUP_NAME} AzureCPICI-bosh --json | jq '.ipAddress' -r)
-CF_IP_ADDRESS=$(azure network public-ip show ${AZURE_GROUP_NAME} AzureCPICI-cf --json | jq '.ipAddress' -r)
+CF_IP_ADDRESS=$(azure network public-ip show ${AZURE_GROUP_NAME} AzureCPICI-cf-bats --json | jq '.ipAddress' -r)
 
 source /etc/profile.d/chruby.sh
 chruby 2.1.2
@@ -43,13 +43,14 @@ ssh-add $PWD/keys/bats.pem
 
 export BAT_DIRECTOR=$DIRECTOR
 export BAT_DNS_HOST=$DIRECTOR
-export BAT_STEMCELL=`echo $PWD/stemcell/*.tgz`
+export BAT_STEMCELL=$(echo $PWD/stemcell/*.tgz)
 export BAT_DEPLOYMENT_SPEC="${PWD}/${BASE_OS}-bats-config.yml"
 export BAT_VCAP_PASSWORD=$BAT_VCAP_PASSWORD
 export BAT_VCAP_PRIVATE_KEY=$PWD/keys/bats.pem
 export BAT_INFRASTRUCTURE=azure
 export BAT_NETWORKING=manual
 export BAT_DIRECTOR_PASSWORD=$BAT_DIRECTOR_PASSWORD
+export BAT_RSPEC_FLAGS="--tag ~multiple_manual_networks --tag ~raw_ephemeral_storage"
 
 bosh -n target $BAT_DIRECTOR
 echo Using This version of bosh:
@@ -72,6 +73,7 @@ properties:
     type: manual
     static_ip: $BAT_NETWORK_STATIC_IP
     cloud_properties:
+      resource_group_name: $AZURE_GROUP_NAME
       virtual_network_name: $AZURE_VNET_NAME_FOR_BATS
       subnet_name: $AZURE_CF_SUBNET_NAME
       security_group: $AZURE_DEFAULT_SECURITY_GROUP
@@ -81,6 +83,8 @@ properties:
     gateway: $BAT_NETWORK_GATEWAY
   - name: static
     type: vip
+    cloud_properties:
+      resource_group_name: $AZURE_GROUP_NAME
   key_name: bosh
 EOF
 cat > azure.yml.erb <<EOF
@@ -126,6 +130,9 @@ networks:
     gateway: <%= network.gateway %>
     dns: <%= p('dns').inspect %>
     cloud_properties:
+      <% if network.cloud_properties.resource_group_name %>
+      resource_group_name: <%= network.cloud_properties.resource_group_name %>
+      <% end %>
       virtual_network_name: <%= network.cloud_properties.virtual_network_name %>
       subnet_name: <%= network.cloud_properties.subnet_name %>
       <% if network.cloud_properties.security_group %>
@@ -135,12 +142,20 @@ networks:
   subnets:
   - range: <%= network.cidr %>
     dns: <%= p('dns').inspect %>
+    cloud_properties:
+      <% if network.cloud_properties.resource_group_name %>
+      resource_group_name: <%= network.cloud_properties.resource_group_name %>
+      <% end %>
+      virtual_network_name: <%= network.cloud_properties.virtual_network_name %>
+      subnet_name: <%= network.cloud_properties.subnet_name %>
+      <% if network.cloud_properties.security_group %>
+      security_group: <%= network.cloud_properties.security_group %>
+      <% end %>
+  <% elsif network.type == 'vip' %>
+  <% if network.cloud_properties.resource_group_name %>
   cloud_properties:
-    virtual_network_name: <%= network.cloud_properties.virtual_network_name %>
-    subnet_name: <%= network.cloud_properties.subnet_name %>
-    <% if network.cloud_properties.security_group %>
-    security_group: <%= network.cloud_properties.security_group %>
-    <% end %>
+    resource_group_name: <%= network.cloud_properties.resource_group_name %>
+  <% end %>
   <% end %>
 <% end %>
 
@@ -202,7 +217,8 @@ properties:
     <% end %>
 EOF
 
-cd bats
-./write_gemfile
-bundle install
-bundle exec rspec spec
+pushd bats
+  ./write_gemfile
+  bundle install
+  bundle exec rspec spec ${BAT_RSPEC_FLAGS}
+popd

--- a/ci/tasks/run-bats.yml
+++ b/ci/tasks/run-bats.yml
@@ -13,16 +13,15 @@ params:
   AZURE_CLIENT_SECRET:          replace-me
   AZURE_TENANT_ID:              replace-me
   AZURE_GROUP_NAME:             replace-me
-  SSH_PRIVATE_KEY:              replace-me
-  BAT_VCAP_PASSWORD:            replace-me
+  AZURE_VNET_NAME_FOR_BATS:     replace-me
+  AZURE_CF_SUBNET_NAME:         replace-me
+  AZURE_DEFAULT_SECURITY_GROUP: replace-me
   BAT_SECOND_STATIC_IP:         replace-me
   BAT_NETWORK_STATIC_IP:        replace-me
   BAT_NETWORK_CIDR:             replace-me
   BAT_NETWORK_RESERVED_RANGE:   replace-me
   BAT_NETWORK_STATIC_RANGE:     replace-me
   BAT_NETWORK_GATEWAY:          replace-me
-  AZURE_VNET_NAME_FOR_BATS:     replace-me
-  AZURE_CF_SUBNET_NAME:         replace-me
-  AZURE_DEFAULT_SECURITY_GROUP: replace-me
+  BAT_VCAP_PASSWORD:            replace-me
   BAT_DIRECTOR_PASSWORD:        replace-me
-
+  SSH_PRIVATE_KEY:              replace-me

--- a/ci/tasks/run-lifecycle.sh
+++ b/ci/tasks/run-lifecycle.sh
@@ -4,52 +4,41 @@ set -e
 
 source bosh-cpi-release/ci/tasks/utils.sh
 
+check_param AZURE_SUBSCRIPTION_ID
 check_param AZURE_CLIENT_ID
 check_param AZURE_CLIENT_SECRET
 check_param AZURE_TENANT_ID
-check_param AZURE_GROUP_NAME
+check_param AZURE_GROUP_NAME_FOR_VMS
+check_param AZURE_GROUP_NAME_FOR_NETWORK
 check_param AZURE_STORAGE_ACCOUNT_NAME
-check_param AZURE_SUBSCRIPTION_ID
-check_param SSH_PUBLIC_KEY
 check_param AZURE_VNET_NAME_FOR_LIFECYCLE
 check_param AZURE_BOSH_SUBNET_NAME
 check_param AZURE_DEFAULT_SECURITY_GROUP
+check_param SSH_PUBLIC_KEY
 
 export BOSH_AZURE_SUBSCRIPTION_ID=${AZURE_SUBSCRIPTION_ID}
-export BOSH_AZURE_STORAGE_ACCOUNT_NAME=${AZURE_STORAGE_ACCOUNT_NAME}
-export BOSH_AZURE_RESOURCE_GROUP_NAME=${AZURE_GROUP_NAME}
 export BOSH_AZURE_TENANT_ID=${AZURE_TENANT_ID}
 export BOSH_AZURE_CLIENT_ID=${AZURE_CLIENT_ID}
 export BOSH_AZURE_CLIENT_SECRET=${AZURE_CLIENT_SECRET}
+export BOSH_AZURE_STORAGE_ACCOUNT_NAME=${AZURE_STORAGE_ACCOUNT_NAME}
+export BOSH_AZURE_RESOURCE_GROUP_NAME_FOR_VMS=${AZURE_GROUP_NAME_FOR_VMS}
+export BOSH_AZURE_RESOURCE_GROUP_NAME_FOR_NETWORK=${AZURE_GROUP_NAME_FOR_NETWORK}
 export BOSH_AZURE_VNET_NAME=${AZURE_VNET_NAME_FOR_LIFECYCLE}
 export BOSH_AZURE_SUBNET_NAME=${AZURE_BOSH_SUBNET_NAME}
 export BOSH_AZURE_SSH_PUBLIC_KEY=${SSH_PUBLIC_KEY}
 export BOSH_AZURE_DEFAULT_SECURITY_GROUP=${AZURE_DEFAULT_SECURITY_GROUP}
-
-source /etc/profile.d/chruby.sh
-chruby 2.1.2
+export BOSH_AZURE_STEMCELL_ID="bosh-stemcell-00000000-0000-0000-0000-0AZURECPICI0"
 
 azure login --service-principal -u ${AZURE_CLIENT_ID} -p ${AZURE_CLIENT_SECRET} --tenant ${AZURE_TENANT_ID}
 azure config mode arm
 
-AZURE_STORAGE_ACCESS_KEY=$(azure storage account keys list ${AZURE_STORAGE_ACCOUNT_NAME} -g ${AZURE_GROUP_NAME} --json | jq '.storageAccountKeys.key1' -r)
+export BOSH_AZURE_PRIMARY_PUBLIC_IP=$(azure network public-ip show ${AZURE_GROUP_NAME_FOR_VMS} AzureCPICI-cf-lifecycle --json | jq '.ipAddress' -r)
+export BOSH_AZURE_SECONDARY_PUBLIC_IP=$(azure network public-ip show ${AZURE_GROUP_NAME_FOR_NETWORK} AzureCPICI-cf-lifecycle --json | jq '.ipAddress' -r)
 
-export BOSH_AZURE_STEMCELL_ID="bosh-stemcell-00000000-0000-0000-0000-0AZURECPICI0"
-export AZURE_STORAGE_ACCOUNT=${AZURE_STORAGE_ACCOUNT_NAME}
-export AZURE_STORAGE_ACCESS_KEY
+source /etc/profile.d/chruby.sh
+chruby 2.1.2
 
-# Upload stemcell if it does not exist.
-# Lifycycle is used to test CPI but not stemcell so you can use any valid stemcell.
-set +e
-azure storage blob show stemcell ${BOSH_AZURE_STEMCELL_ID}.vhd
-if [ $? -eq 1 ]; then
-  tar -xf ${PWD}/stemcell/*.tgz -C /mnt/
-  tar -xf /mnt/image -C /mnt/
-  azure storage blob upload -q --blobtype PAGE /mnt/root.vhd stemcell ${BOSH_AZURE_STEMCELL_ID}.vhd
-fi
-set -e
-
-cd bosh-cpi-release/src/bosh_azure_cpi
-
-bundle install
-bundle exec rspec spec/integration
+pushd bosh-cpi-release/src/bosh_azure_cpi
+  bundle install
+  bundle exec rspec spec/integration
+popd

--- a/ci/tasks/run-lifecycle.yml
+++ b/ci/tasks/run-lifecycle.yml
@@ -3,17 +3,17 @@ platform: linux
 image: docker:///boshcpi/azure-cpi-release
 inputs:
 - name: bosh-cpi-release
-- name: stemcell
 run:
   path: bosh-cpi-release/ci/tasks/run-lifecycle.sh
 params:
+  AZURE_SUBSCRIPTION_ID:          replace-me
   AZURE_CLIENT_ID:                replace-me
   AZURE_CLIENT_SECRET:            replace-me
   AZURE_TENANT_ID:                replace-me
-  AZURE_GROUP_NAME:               replace-me
+  AZURE_GROUP_NAME_FOR_VMS:       replace-me
+  AZURE_GROUP_NAME_FOR_NETWORK:   replace-me
   AZURE_STORAGE_ACCOUNT_NAME:     replace-me
-  AZURE_SUBSCRIPTION_ID:          replace-me
-  SSH_PUBLIC_KEY:                 replace-me
   AZURE_VNET_NAME_FOR_LIFECYCLE:  replace-me
   AZURE_BOSH_SUBNET_NAME:         replace-me
   AZURE_DEFAULT_SECURITY_GROUP:   replace-me
+  SSH_PUBLIC_KEY:                 replace-me

--- a/ci/tasks/setup-director.yml
+++ b/ci/tasks/setup-director.yml
@@ -15,14 +15,15 @@ params:
   AZURE_CLIENT_ID:               replace-me
   AZURE_CLIENT_SECRET:           replace-me
   AZURE_TENANT_ID:               replace-me
-  AZURE_GROUP_NAME:              replace-me
+  AZURE_GROUP_NAME_FOR_VMS:      replace-me
+  AZURE_GROUP_NAME_FOR_NETWORK:  replace-me
   AZURE_VNET_NAME_FOR_BATS:      replace-me
   AZURE_STORAGE_ACCOUNT_NAME:    replace-me
   AZURE_SUBSCRIPTION_ID:         replace-me
   AZURE_BOSH_SUBNET_NAME:        replace-me
-  BAT_NETWORK_GATEWAY:           replace-me
-  SSH_PRIVATE_KEY:               replace-me
-  SSH_PUBLIC_KEY:                replace-me
-  BOSH_INIT_LOG_LEVEL:           warn
   AZURE_DEFAULT_SECURITY_GROUP:  replace-me
+  BAT_NETWORK_GATEWAY:           replace-me
   BAT_DIRECTOR_PASSWORD:         replace-me
+  SSH_PUBLIC_KEY:                replace-me
+  SSH_PRIVATE_KEY:               replace-me
+  BOSH_INIT_LOG_LEVEL:           warn

--- a/src/bosh_azure_cpi/lib/cloud/azure/azure_client2.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/azure_client2.rb
@@ -54,9 +54,10 @@ module Bosh::AzureCloud
     end
 
     # Common
-    def rest_api_url(resource_provider, resource_type, name = nil, others = nil)
+    def rest_api_url(resource_provider, resource_type, resource_group_name: nil, name: nil, others: nil)
       url =  "/subscriptions/#{URI.escape(@azure_properties['subscription_id'])}"
-      url += "/resourceGroups/#{URI.escape(@azure_properties['resource_group_name'])}"
+      resource_group_name = @azure_properties['resource_group_name'] if resource_group_name.nil?
+      url += "/resourceGroups/#{URI.escape(resource_group_name)}"
       url += "/providers/#{resource_provider}"
       url += "/#{resource_type}"
       url += "/#{URI.escape(name)}" unless name.nil?
@@ -133,7 +134,7 @@ module Bosh::AzureCloud
     # * +:ssh_cert_data+        - String. The content of SSH certificate.
     #
     def create_virtual_machine(vm_params, network_interface, availability_set = nil)
-      url = rest_api_url(REST_API_PROVIDER_COMPUTER, REST_API_COMPUTER_VIRTUAL_MACHINES, vm_params[:name])
+      url = rest_api_url(REST_API_PROVIDER_COMPUTER, REST_API_COMPUTER_VIRTUAL_MACHINES, name: vm_params[:name])
       vm = {
         'name'       => vm_params[:name],
         'location'   => vm_params[:location],
@@ -207,7 +208,7 @@ module Bosh::AzureCloud
     end
 
     def restart_virtual_machine(name)
-      url = rest_api_url(REST_API_PROVIDER_COMPUTER, REST_API_COMPUTER_VIRTUAL_MACHINES, name, 'restart')
+      url = rest_api_url(REST_API_PROVIDER_COMPUTER, REST_API_COMPUTER_VIRTUAL_MACHINES, name: name, others: 'restart')
       http_post(url)
     end
 
@@ -215,7 +216,7 @@ module Bosh::AzureCloud
     # @param [String] name Name of virtual machine.
     # @param [Hash] metadata metadata key/value pairs.
     def update_tags_of_virtual_machine(name, tags)
-      url = rest_api_url(REST_API_PROVIDER_COMPUTER, REST_API_COMPUTER_VIRTUAL_MACHINES, name)
+      url = rest_api_url(REST_API_PROVIDER_COMPUTER, REST_API_COMPUTER_VIRTUAL_MACHINES, name: name)
       vm = get_resource_by_id(url)
       if vm.nil?
         raise AzureNoFoundError, "update_tags_of_virtual_machine - cannot find the virtual machine by name \"#{name}\""
@@ -231,7 +232,7 @@ module Bosh::AzureCloud
     # @param [String] disk_uri URI of disk
     # @param [String] caching Caching option: None, ReadOnly or ReadWrite
     def attach_disk_to_virtual_machine(name, disk_name, disk_uri, caching)
-      url = rest_api_url(REST_API_PROVIDER_COMPUTER, REST_API_COMPUTER_VIRTUAL_MACHINES, name)
+      url = rest_api_url(REST_API_PROVIDER_COMPUTER, REST_API_COMPUTER_VIRTUAL_MACHINES, name: name)
       vm = get_resource_by_id(url)
       if vm.nil?
         raise AzureNoFoundError, "attach_disk_to_virtual_machine - cannot find the virtual machine by name `#{name}'"
@@ -273,7 +274,7 @@ module Bosh::AzureCloud
     end
 
     def detach_disk_from_virtual_machine(name, disk_name)
-      url = rest_api_url(REST_API_PROVIDER_COMPUTER, REST_API_COMPUTER_VIRTUAL_MACHINES, name)
+      url = rest_api_url(REST_API_PROVIDER_COMPUTER, REST_API_COMPUTER_VIRTUAL_MACHINES, name: name)
       vm = get_resource_by_id(url)
       if vm.nil?
         raise AzureNoFoundError, "detach_disk_from_virtual_machine - cannot find the virtual machine by name \"#{name}\""
@@ -291,7 +292,7 @@ module Bosh::AzureCloud
     end
 
     def get_virtual_machine_by_name(name)
-      url = rest_api_url(REST_API_PROVIDER_COMPUTER, REST_API_COMPUTER_VIRTUAL_MACHINES, name)
+      url = rest_api_url(REST_API_PROVIDER_COMPUTER, REST_API_COMPUTER_VIRTUAL_MACHINES, name: name)
       get_virtual_machine(url)
     end
 
@@ -338,7 +339,7 @@ module Bosh::AzureCloud
 
     def delete_virtual_machine(name)
       @logger.debug("delete_virtual_machine - trying to delete #{name}")
-      url = rest_api_url(REST_API_PROVIDER_COMPUTER, REST_API_COMPUTER_VIRTUAL_MACHINES, name)
+      url = rest_api_url(REST_API_PROVIDER_COMPUTER, REST_API_COMPUTER_VIRTUAL_MACHINES, name: name)
       http_delete(url)
     end
 
@@ -359,7 +360,7 @@ module Bosh::AzureCloud
     # * +:platform_fault_domain_count+  - Integer. Specifies the fault domain count of availability set.
     #
     def create_availability_set(avset_params)
-      url = rest_api_url(REST_API_PROVIDER_COMPUTER, REST_API_COMPUTER_AVAILABILITY_SETS, avset_params[:name])
+      url = rest_api_url(REST_API_PROVIDER_COMPUTER, REST_API_COMPUTER_AVAILABILITY_SETS, name: avset_params[:name])
       availability_set = {
         'name'       => avset_params[:name],
         'type'       => "#{REST_API_PROVIDER_COMPUTER}/#{REST_API_COMPUTER_AVAILABILITY_SETS}",
@@ -374,7 +375,7 @@ module Bosh::AzureCloud
     end
 
     def get_availability_set_by_name(name)
-      url = rest_api_url(REST_API_PROVIDER_COMPUTER, REST_API_COMPUTER_AVAILABILITY_SETS, name)
+      url = rest_api_url(REST_API_PROVIDER_COMPUTER, REST_API_COMPUTER_AVAILABILITY_SETS, name: name)
       get_availability_set(url)
     end
 
@@ -404,13 +405,13 @@ module Bosh::AzureCloud
 
     def delete_availability_set(name)
       @logger.debug("delete_availability_set - trying to delete #{name}")
-      url = rest_api_url(REST_API_PROVIDER_COMPUTER, REST_API_COMPUTER_AVAILABILITY_SETS, name)
+      url = rest_api_url(REST_API_PROVIDER_COMPUTER, REST_API_COMPUTER_AVAILABILITY_SETS, name: name)
       http_delete(url)
     end
 
     # Network/Public IP
     def create_public_ip(name, location, is_static = true)
-      url = rest_api_url(REST_API_PROVIDER_NETWORK, REST_API_NETWORK_PUBLIC_IP_ADDRESSES, name)
+      url = rest_api_url(REST_API_PROVIDER_NETWORK, REST_API_NETWORK_PUBLIC_IP_ADDRESSES, name: name)
       public_ip = {
         'name'       => name,
         'location'   => location,
@@ -422,7 +423,7 @@ module Bosh::AzureCloud
     end
 
     def get_public_ip_by_name(name)
-      url = rest_api_url(REST_API_PROVIDER_NETWORK, REST_API_NETWORK_PUBLIC_IP_ADDRESSES, name)
+      url = rest_api_url(REST_API_PROVIDER_NETWORK, REST_API_NETWORK_PUBLIC_IP_ADDRESSES, name: name)
       get_public_ip(url)
     end
 
@@ -448,9 +449,9 @@ module Bosh::AzureCloud
       ip_address
     end
 
-    def list_public_ips()
+    def list_public_ips(resource_group_name)
       ip_addresses = []
-      url = rest_api_url(REST_API_PROVIDER_NETWORK, REST_API_NETWORK_PUBLIC_IP_ADDRESSES)
+      url = rest_api_url(REST_API_PROVIDER_NETWORK, REST_API_NETWORK_PUBLIC_IP_ADDRESSES, resource_group_name: resource_group_name)
       result = get_resource_by_id(url)
       unless result.nil?
         result['value'].each do |ret|
@@ -476,13 +477,13 @@ module Bosh::AzureCloud
 
     def delete_public_ip(name)
       @logger.debug("delete_public_ip - trying to delete #{name}")
-      url = rest_api_url(REST_API_PROVIDER_NETWORK, REST_API_NETWORK_PUBLIC_IP_ADDRESSES, name)
+      url = rest_api_url(REST_API_PROVIDER_NETWORK, REST_API_NETWORK_PUBLIC_IP_ADDRESSES, name: name)
       http_delete(url)
     end
 
     # Network/Load Balancer
     def create_load_balancer(name,  public_ip, tags, tcp_endpoints = [], udp_endpoints = [])
-      url = rest_api_url(REST_API_PROVIDER_NETWORK, REST_API_NETWORK_LOAD_BALANCERS, name)
+      url = rest_api_url(REST_API_PROVIDER_NETWORK, REST_API_NETWORK_LOAD_BALANCERS, name: name)
       load_balancer = {
         'name'       => name,
         'location'   => public_ip[:location],
@@ -504,7 +505,7 @@ module Bosh::AzureCloud
         }
       }
 
-      frontend_ip_configuration_id = rest_api_url(REST_API_PROVIDER_NETWORK, REST_API_NETWORK_LOAD_BALANCERS, name, 'frontendIPConfigurations/LBFE')
+      frontend_ip_configuration_id = rest_api_url(REST_API_PROVIDER_NETWORK, REST_API_NETWORK_LOAD_BALANCERS, name: name, others: 'frontendIPConfigurations/LBFE')
       tcp_endpoints.each do |endpoint|
         ports = endpoint.split(':')
         inbound_nat_rules = {
@@ -542,7 +543,7 @@ module Bosh::AzureCloud
     end
 
     def get_load_balancer_by_name(name)
-      url = rest_api_url(REST_API_PROVIDER_NETWORK, REST_API_NETWORK_LOAD_BALANCERS, name)
+      url = rest_api_url(REST_API_PROVIDER_NETWORK, REST_API_NETWORK_LOAD_BALANCERS, name: name)
       get_load_balancer(url)
     end
 
@@ -589,7 +590,7 @@ module Bosh::AzureCloud
 
     def delete_load_balancer(name)
       @logger.debug("delete_load_balancer - trying to delete #{name}")
-      url = rest_api_url(REST_API_PROVIDER_NETWORK, REST_API_NETWORK_LOAD_BALANCERS, name)
+      url = rest_api_url(REST_API_PROVIDER_NETWORK, REST_API_NETWORK_LOAD_BALANCERS, name: name)
       http_delete(url)
     end
 
@@ -614,7 +615,7 @@ module Bosh::AzureCloud
     # * +:security_group - Hash. The network security group which the network interface is binded to.
     #
     def create_network_interface(nic_params, subnet, tags, load_balancer = nil)
-      url = rest_api_url(REST_API_PROVIDER_NETWORK, REST_API_NETWORK_INTERFACES, nic_params[:name])
+      url = rest_api_url(REST_API_PROVIDER_NETWORK, REST_API_NETWORK_INTERFACES, name: nic_params[:name])
       interface = {
         'name'       => nic_params[:name],
         'location'   => nic_params[:location],
@@ -656,7 +657,7 @@ module Bosh::AzureCloud
     end
 
     def get_network_interface_by_name(name)
-      url = rest_api_url(REST_API_PROVIDER_NETWORK, REST_API_NETWORK_INTERFACES, name)
+      url = rest_api_url(REST_API_PROVIDER_NETWORK, REST_API_NETWORK_INTERFACES, name: name)
       get_network_interface(url)
     end
 
@@ -696,13 +697,13 @@ module Bosh::AzureCloud
 
     def delete_network_interface(name)
       @logger.debug("delete_network_interface - trying to delete #{name}")
-      url = rest_api_url(REST_API_PROVIDER_NETWORK, REST_API_NETWORK_INTERFACES, name)
+      url = rest_api_url(REST_API_PROVIDER_NETWORK, REST_API_NETWORK_INTERFACES, name: name)
       http_delete(url)
     end
 
     # Network/Subnet
-    def get_network_subnet_by_name(vnet_name, subnet_name)
-      url = rest_api_url(REST_API_PROVIDER_NETWORK, REST_API_NETWORK_VNETS, vnet_name, "subnets/#{subnet_name}")
+    def get_network_subnet_by_name(resource_group_name, vnet_name, subnet_name)
+      url = rest_api_url(REST_API_PROVIDER_NETWORK, REST_API_NETWORK_VNETS, resource_group_name: resource_group_name, name: vnet_name, others: "subnets/#{subnet_name}")
       get_network_subnet(url)
     end
 
@@ -722,8 +723,8 @@ module Bosh::AzureCloud
     end
 
     # Network/Network Security Group
-    def get_network_security_group_by_name(name)
-      url = rest_api_url(REST_API_PROVIDER_NETWORK, REST_API_NETWORK_SECURITY_GROUPS, name)
+    def get_network_security_group_by_name(resource_group_name, name)
+      url = rest_api_url(REST_API_PROVIDER_NETWORK, REST_API_NETWORK_SECURITY_GROUPS, resource_group_name: resource_group_name, name: name)
       get_network_security_group(url)
     end
 
@@ -746,7 +747,7 @@ module Bosh::AzureCloud
     # Storage/StorageAccounts
     # https://msdn.microsoft.com/en-us/library/azure/mt163564.aspx
     def create_storage_account(name, location, account_type, tags)
-      url = rest_api_url(REST_API_PROVIDER_STORAGE, REST_API_STORAGE_ACCOUNTS, name)
+      url = rest_api_url(REST_API_PROVIDER_STORAGE, REST_API_STORAGE_ACCOUNTS, name: name)
       storage_account = {
         'location'   => location,
         'tags'       => tags,
@@ -821,7 +822,7 @@ module Bosh::AzureCloud
     end
 
     def get_storage_account_by_name(name)
-      url = rest_api_url(REST_API_PROVIDER_STORAGE, REST_API_STORAGE_ACCOUNTS, name)
+      url = rest_api_url(REST_API_PROVIDER_STORAGE, REST_API_STORAGE_ACCOUNTS, name: name)
       get_storage_account(url)
     end
 
@@ -848,7 +849,7 @@ module Bosh::AzureCloud
     def get_storage_account_keys_by_name(name)
       result = nil
       begin
-        url = rest_api_url(REST_API_PROVIDER_STORAGE, REST_API_STORAGE_ACCOUNTS, name, 'listKeys')
+        url = rest_api_url(REST_API_PROVIDER_STORAGE, REST_API_STORAGE_ACCOUNTS, name: name, others: 'listKeys')
         result = http_post(url)
       rescue AzureNoFoundError => e
         result = nil

--- a/src/bosh_azure_cpi/lib/cloud/azure/dynamic_network.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/dynamic_network.rb
@@ -3,21 +3,31 @@ module Bosh::AzureCloud
   class DynamicNetwork < Network
     include Helpers
 
-    attr_reader :virtual_network_name, :subnet_name
+    attr_reader :resource_group_name, :virtual_network_name, :subnet_name
 
     # create dynamic network
     # @param [String] name Network name
     # @param [Hash] spec Raw network spec
     def initialize(name, spec)
       super
-      if @cloud_properties.nil? || !@cloud_properties.has_key?("virtual_network_name")
+
+      if @cloud_properties.nil?
+        cloud_error("cloud_properties required for dynamic network")
+      end
+
+      @resource_group_name = @cloud_properties["resource_group_name"]
+
+      if @cloud_properties.has_key?("virtual_network_name")
+        @virtual_network_name = @cloud_properties["virtual_network_name"]
+      else
         cloud_error("virtual_network_name required for dynamic network")
       end
-      if @cloud_properties.nil? || !@cloud_properties.has_key?("subnet_name")
+
+      if @cloud_properties.has_key?("subnet_name")
+        @subnet_name = @cloud_properties["subnet_name"]
+      else
         cloud_error("subnet_name required for dynamic network")
       end
-      @virtual_network_name = @cloud_properties["virtual_network_name"]
-      @subnet_name = @cloud_properties["subnet_name"]
     end
 
     def vnet?

--- a/src/bosh_azure_cpi/lib/cloud/azure/manual_network.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/manual_network.rb
@@ -3,21 +3,31 @@ module Bosh::AzureCloud
   class ManualNetwork < Network
     include Helpers
 
-    attr_reader :virtual_network_name, :subnet_name
+    attr_reader :resource_group_name, :virtual_network_name, :subnet_name
 
     # create manual network
     # @param [String] name Network name
     # @param [Hash] spec Raw network spec
     def initialize(name, spec)
       super
-      if @cloud_properties.nil? || !@cloud_properties.has_key?("virtual_network_name")
+
+      if @cloud_properties.nil?
+        cloud_error("cloud_properties required for manual network")
+      end
+
+      @resource_group_name = @cloud_properties["resource_group_name"]
+
+      if @cloud_properties.has_key?("virtual_network_name")
+        @virtual_network_name = @cloud_properties["virtual_network_name"]
+      else
         cloud_error("virtual_network_name required for manual network")
       end
-      if @cloud_properties.nil? || !@cloud_properties.has_key?("subnet_name")
+
+      if @cloud_properties.has_key?("subnet_name")
+        @subnet_name = @cloud_properties["subnet_name"]
+      else
         cloud_error("subnet_name required for manual network")
       end
-      @virtual_network_name = @cloud_properties["virtual_network_name"]
-      @subnet_name = @cloud_properties["subnet_name"]
     end
 
     def private_ip

--- a/src/bosh_azure_cpi/lib/cloud/azure/network.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/network.rb
@@ -1,10 +1,8 @@
 module Bosh::AzureCloud
   class Network
     # {
-    # "bosh"=>{"netmask"=>nil, "gateway"=>nil, "ip"=>"10.0.0.4", "dns"=>["168.63.129.16"], "type"=>"manual", "default"=>["dns", "gateway"], 
-    #          "cloud_properties"=>{"virtual_network_name"=>"abel-boshvnet", "subnet_name"=>"BOSH", "security_group"=>"nsg-bosh"}}, 
-    # "vip"=>{"ip"=>"23.101.15.75", "type"=>"vip", 
-    #         "cloud_properties"=>{"virtual_network_name"=>"abel-boshvnet", "subnet_name"=>"BOSH"}}
+    # "bosh"=>{"netmask"=>nil, "gateway"=>nil, "ip"=>"10.0.0.4", "dns"=>["168.63.129.16"], "type"=>"manual", "default"=>["dns", "gateway"], "cloud_properties"=>{"resource_group_name"=>"rg-name", "virtual_network_name"=>"boshvnet", "subnet_name"=>"Bosh", "security_group"=>"nsg-bosh"}},
+    # "vip"=>{"ip"=>"23.101.15.75", "type"=>"vip", "cloud_properties"=>{"resource_group_name"=>"rg-name"}}
     #}
 
     ##

--- a/src/bosh_azure_cpi/lib/cloud/azure/network_configurator.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/network_configurator.rb
@@ -17,7 +17,7 @@ module Bosh::AzureCloud
     def initialize(spec)
       unless spec.is_a?(Hash)
         raise ArgumentError, "Invalid spec, Hash expected, " \
-                             "#{spec.class} provided"
+                             "`#{spec.class}' provided"
       end
 
       @logger = Bosh::Clouds::Config.logger
@@ -25,7 +25,7 @@ module Bosh::AzureCloud
       @vip_network = nil
       @networks_spec = spec
 
-      logger.debug ("networks: #{spec}")
+      logger.debug ("networks: `#{spec}'")
       spec.each_pair do |name, network_spec|
         network_type = network_spec["type"] || "manual"
 
@@ -39,18 +39,31 @@ module Bosh::AzureCloud
             @network = ManualNetwork.new(name, network_spec)
 
           when "vip"
-            cloud_error("More than one vip network for '#{name}'") if @vip_network
+            cloud_error("More than one vip network for `#{name}'") if @vip_network
             @vip_network = VipNetwork.new(name, network_spec)
 
           else
-            cloud_error("Invalid network type '#{network_type}' for Azure, " \
-                        "can only handle 'dynamic', 'vip', or 'manual' network types")
+            cloud_error("Invalid network type `#{network_type}' for Azure, " \
+                        "can only handle `dynamic', `vip', or `manual' network types")
         end
       end
 
       unless @network
         cloud_error("Exactly one dynamic or manual network must be defined")
       end
+    end
+
+    def resource_group_name(network_type=nil)
+      resource_group_name = nil
+      case network_type
+        when "vip"
+          resource_group_name = @vip_network.resource_group_name
+
+        else
+          resource_group_name = @network.resource_group_name
+      end
+
+      resource_group_name
     end
 
     def virtual_network_name

--- a/src/bosh_azure_cpi/lib/cloud/azure/vip_network.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/vip_network.rb
@@ -1,5 +1,7 @@
 module Bosh::AzureCloud
+
   class VipNetwork < Network
+    attr_reader :resource_group_name
 
     ##
     # Creates a new vip network
@@ -8,6 +10,8 @@ module Bosh::AzureCloud
     # @param [Hash] spec Raw network spec
     def initialize(name, spec)
       super
+      
+      @resource_group_name = @cloud_properties["resource_group_name"] unless @cloud_properties.nil?
     end
 
     def public_ip

--- a/src/bosh_azure_cpi/lib/cloud/azure/vm_manager.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/vm_manager.rb
@@ -24,66 +24,21 @@ module Bosh::AzureCloud
         end
       end
 
-      subnet = @azure_client2.get_network_subnet_by_name(network_configurator.virtual_network_name, network_configurator.subnet_name)
-      raise "Cannot find the subnet #{network_configurator.virtual_network_name}/#{network_configurator.subnet_name}" if subnet.nil?
-
-      security_group_name = @azure_properties["default_security_group"]
-      if resource_pool.has_key?("security_group")
-        security_group_name = resource_pool["security_group"]
-      elsif !network_configurator.security_group.nil?
-        security_group_name = network_configurator.security_group
-      end
-      network_security_group = @azure_client2.get_network_security_group_by_name(security_group_name)
-      raise "Cannot find the network security group #{security_group_name}" if network_security_group.nil?
-
       caching = 'ReadWrite'
       if resource_pool.has_key?('caching')
         caching = resource_pool['caching']
         validate_disk_caching(caching)
       end
 
+      subnet = get_network_subnet(network_configurator)
+      network_security_group = get_network_security_group(resource_pool, network_configurator)
+      public_ip = get_public_ip(network_configurator)
+      load_balancer = get_load_balancer(resource_pool)
+
       instance_id  = generate_instance_id(storage_account[:name], uuid)
 
-      public_ip = nil
-      unless network_configurator.vip_network.nil?
-        public_ip = @azure_client2.list_public_ips().find { |ip| ip[:ip_address] == network_configurator.public_ip}
-        cloud_error("Cannot find the public IP address #{network_configurator.public_ip}") if public_ip.nil?
-      end
-
-      load_balancer = nil
-      if resource_pool.has_key?('load_balancer')
-        load_balancer = @azure_client2.get_load_balancer_by_name(resource_pool['load_balancer'])
-        cloud_error("Cannot find the load balancer #{resource_pool['load_balancer']}") if load_balancer.nil?
-      end
-
-      nic_params = {
-        :name                => instance_id,
-        :location            => storage_account[:location],
-        :private_ip          => network_configurator.private_ip,
-        :public_ip           => public_ip,
-        :security_group      => network_security_group
-      }
-      network_tags = AZURE_TAGS
-      if resource_pool.has_key?('availability_set')
-        network_tags = network_tags.merge({'availability_set' => resource_pool['availability_set']})
-      end
-      @azure_client2.create_network_interface(nic_params, subnet, network_tags, load_balancer)
-      network_interface = @azure_client2.get_network_interface_by_name(instance_id)
-
-      availability_set = nil
-      if resource_pool.has_key?('availability_set')
-        availability_set = @azure_client2.get_availability_set_by_name(resource_pool['availability_set'])
-        if availability_set.nil?
-          avset_params = {
-            :name                         => resource_pool['availability_set'],
-            :location                     => storage_account[:location],
-            :tags                         => AZURE_TAGS,
-            :platform_update_domain_count => resource_pool['platform_update_domain_count'] || 5,
-            :platform_fault_domain_count  => resource_pool['platform_fault_domain_count'] || 3
-          }
-          availability_set = create_availability_set(avset_params)
-        end
-      end
+      network_interface = create_network_interface(instance_id, storage_account, resource_pool, network_configurator, public_ip, network_security_group, subnet, load_balancer)
+      availability_set = create_availability_set(storage_account, resource_pool)
 
       os_disk_name = @disk_manager.generate_os_disk_name(instance_id)
       vm_params = {
@@ -191,16 +146,99 @@ module Bosh::AzureCloud
       Base64.strict_encode64(JSON.dump(user_data))
     end
 
-    def create_availability_set(avset_params)
+    def get_network_subnet(network_configurator)
+      subnet = nil
+      resource_group_name = @azure_properties['resource_group_name']
+      resource_group_name = network_configurator.resource_group_name unless network_configurator.resource_group_name.nil?
+      virtual_network_name = network_configurator.virtual_network_name
+      subnet_name = network_configurator.subnet_name
+      subnet = @azure_client2.get_network_subnet_by_name(resource_group_name, virtual_network_name, subnet_name)
+      cloud_error("Cannot find the subnet `#{virtual_network_name}/#{subnet_name}' in the resource group `#{resource_group_name}'") if subnet.nil?
+      subnet
+    end
+
+    def get_network_security_group(resource_pool, network_configurator)
+      network_security_group = nil
+      resource_group_name = @azure_properties['resource_group_name']
+      resource_group_name = network_configurator.resource_group_name unless network_configurator.resource_group_name.nil?
+      security_group_name = @azure_properties["default_security_group"]
+      if resource_pool.has_key?("security_group")
+        security_group_name = resource_pool["security_group"]
+      elsif !network_configurator.security_group.nil?
+        security_group_name = network_configurator.security_group
+      end
+      network_security_group = @azure_client2.get_network_security_group_by_name(resource_group_name, security_group_name)
+      if network_security_group.nil?
+        default_resource_group_name = @azure_properties['resource_group_name']
+        if resource_group_name != default_resource_group_name
+          @logger.info("Cannot find the network security group `#{security_group_name}' in the resource group `#{resource_group_name}', trying to search it in the resource group `#{default_resource_group_name}'")
+          network_security_group = @azure_client2.get_network_security_group_by_name(default_resource_group_name, security_group_name)
+        end
+      end
+      cloud_error("Cannot find the network security group `#{security_group_name}'") if network_security_group.nil?
+      network_security_group
+    end
+
+    def get_public_ip(network_configurator)
+      public_ip = nil
+      unless network_configurator.vip_network.nil?
+        resource_group_name = @azure_properties['resource_group_name']
+        resource_group_name = network_configurator.resource_group_name('vip') unless network_configurator.resource_group_name('vip').nil?
+        public_ip = @azure_client2.list_public_ips(resource_group_name).find { |ip| ip[:ip_address] == network_configurator.public_ip }
+        cloud_error("Cannot find the public IP address `#{network_configurator.public_ip}' in the resource group `#{resource_group_name}'") if public_ip.nil?
+      end
+      public_ip
+    end
+
+    def get_load_balancer(resource_pool)
+      load_balancer = nil
+      if resource_pool.has_key?('load_balancer')
+        load_balancer_name = resource_pool['load_balancer']
+        load_balancer = @azure_client2.get_load_balancer_by_name(load_balancer_name)
+        cloud_error("Cannot find the load balancer `#{load_balancer_name}'") if load_balancer.nil?
+      end
+      load_balancer
+    end
+
+    def create_network_interface(instance_id, storage_account, resource_pool, network_configurator, public_ip, network_security_group, subnet, load_balancer)
+      network_interface = nil
+      nic_params = {
+        :name                => instance_id,
+        :location            => storage_account[:location],
+        :private_ip          => network_configurator.private_ip,
+        :public_ip           => public_ip,
+        :security_group      => network_security_group
+      }
+      network_tags = AZURE_TAGS
+      if resource_pool.has_key?('availability_set')
+        network_tags = network_tags.merge({'availability_set' => resource_pool['availability_set']})
+      end
+      @azure_client2.create_network_interface(nic_params, subnet, network_tags, load_balancer)
+      network_interface = @azure_client2.get_network_interface_by_name(instance_id)
+    end
+
+    def create_availability_set(storage_account, resource_pool)
       availability_set = nil
-      begin
-        @azure_client2.create_availability_set(avset_params)
-        availability_set = @azure_client2.get_availability_set_by_name(avset_params[:name])
-      rescue AzureConflictError => e
-        @logger.debug("create_availability_set - Another process is creating the same availability set #{avset_params[:name]}")
-        loop do
-          availability_set = @azure_client2.get_availability_set_by_name(avset_params[:name])
-          break unless availability_set.nil?
+      if resource_pool.has_key?('availability_set')
+        availability_set = @azure_client2.get_availability_set_by_name(resource_pool['availability_set'])
+        if availability_set.nil?
+          avset_params = {
+            :name                         => resource_pool['availability_set'],
+            :location                     => storage_account[:location],
+            :tags                         => AZURE_TAGS,
+            :platform_update_domain_count => resource_pool['platform_update_domain_count'] || 5,
+            :platform_fault_domain_count  => resource_pool['platform_fault_domain_count'] || 3
+          }
+          begin
+            @azure_client2.create_availability_set(avset_params)
+            availability_set = @azure_client2.get_availability_set_by_name(avset_params[:name])
+          rescue AzureConflictError => e
+            @logger.debug("create_availability_set - Another process is creating the same availability set `#{avset_params[:name]}'")
+            loop do
+              availability_set = @azure_client2.get_availability_set_by_name(avset_params[:name])
+              break unless availability_set.nil?
+            end
+          end
         end
       end
       availability_set

--- a/src/bosh_azure_cpi/spec/integration/lifecycle_spec.rb
+++ b/src/bosh_azure_cpi/spec/integration/lifecycle_spec.rb
@@ -7,15 +7,25 @@ require 'cloud'
 describe Bosh::AzureCloud::Cloud do
   before(:all) do
     @subscription_id        = ENV['BOSH_AZURE_SUBSCRIPTION_ID']         || raise("Missing BOSH_AZURE_SUBSCRIPTION_ID")
-    @storage_account_name   = ENV['BOSH_AZURE_STORAGE_ACCOUNT_NAME']    || raise("Missing BOSH_AZURE_STORAGE_ACCOUNT_NAME")
-    @resource_group_name    = ENV['BOSH_AZURE_RESOURCE_GROUP_NAME']     || raise("Missing BOSH_AZURE_RESOURCE_GROUP_NAME")
     @tenant_id              = ENV['BOSH_AZURE_TENANT_ID']               || raise("Missing BOSH_AZURE_TENANT_ID")
     @client_id              = ENV['BOSH_AZURE_CLIENT_ID']               || raise("Missing BOSH_AZURE_CLIENT_ID")
     @client_secret          = ENV['BOSH_AZURE_CLIENT_SECRET']           || raise("Missing BOSH_AZURE_CLIENT_secret")
+    @storage_account_name   = ENV['BOSH_AZURE_STORAGE_ACCOUNT_NAME']    || raise("Missing BOSH_AZURE_STORAGE_ACCOUNT_NAME")
     @stemcell_id            = ENV['BOSH_AZURE_STEMCELL_ID']             || raise("Missing BOSH_AZURE_STEMCELL_ID")
     @ssh_public_key         = ENV['BOSH_AZURE_SSH_PUBLIC_KEY']          || raise("Missing BOSH_AZURE_SSH_PUBLIC_KEY")
     @default_security_group = ENV['BOSH_AZURE_DEFAULT_SECURITY_GROUP']  || raise("Missing BOSH_AZURE_DEFAULT_SECURITY_GROUP")
+    @resource_group_name_for_vms     = ENV['BOSH_AZURE_RESOURCE_GROUP_NAME_FOR_VMS']     || raise("Missing BOSH_AZURE_RESOURCE_GROUP_NAME_FOR_VMS")
+    @resource_group_name_for_network = ENV['BOSH_AZURE_RESOURCE_GROUP_NAME_FOR_NETWORK'] || raise("Missing BOSH_AZURE_RESOURCE_GROUP_NAME_FOR_NETWORK")
+    @primary_public_ip               = ENV['BOSH_AZURE_PRIMARY_PUBLIC_IP']               || raise("Missing BOSH_AZURE_PRIMARY_PUBLIC_IP")
+    @secondary_public_ip             = ENV['BOSH_AZURE_SECONDARY_PUBLIC_IP']             || raise("Missing BOSH_AZURE_SECONDARY_PUBLIC_IP")
   end
+
+  let(:vnet_name)     { ENV.fetch('BOSH_AZURE_VNET_NAME', 'boshvnet-crp') }
+  let(:subnet_name)   { ENV.fetch('BOSH_AZURE_SUBNET_NAME', 'Bosh') }
+  let(:instance_type) { ENV.fetch('BOSH_AZURE_INSTANCE_TYPE', 'Standard_D1') }
+  let(:vm_metadata) { { deployment: 'deployment', job: 'cpi_spec', index: '0', delete_me: 'please' } }
+  let(:network_spec) { {} }
+  let(:resource_pool) { { 'instance_type' => instance_type } }
 
   subject(:cpi) do
     described_class.new(
@@ -23,7 +33,7 @@ describe Bosh::AzureCloud::Cloud do
         'environment' => ENV.fetch('BOSH_AZURE_ENVIRONMENT', 'AzureCloud'),
         'subscription_id' => @subscription_id,
         'storage_account_name' => @storage_account_name,
-        'resource_group_name' => @resource_group_name,
+        'resource_group_name' => @resource_group_name_for_vms,
         'tenant_id' => @tenant_id,
         'client_id' => @client_id,
         'client_secret' => @client_secret,
@@ -40,24 +50,6 @@ describe Bosh::AzureCloud::Cloud do
     )
   end
 
-  let(:vnet_name)       { ENV.fetch('BOSH_AZURE_VNET_NAME', 'boshvnet-crp') }
-  let(:subnet_name)     { ENV.fetch('BOSH_AZURE_SUBNET_NAME', 'Bosh') }
-  let(:dynamic_networks) {
-    {
-      'default' => {
-        'type' => 'dynamic',
-        'cloud_properties' => {
-          "virtual_network_name" => vnet_name,
-          'subnet_name' => subnet_name
-        }
-      }
-    }
-  }
-
-  let(:instance_type)   { ENV.fetch('BOSH_AZURE_INSTANCE_TYPE', 'Standard_D1') }
-  let(:resource_pool)   { { 'instance_type' => instance_type } }
-  let(:vm_metadata)   { { deployment: 'deployment', job: 'cpi_spec', index: '0', delete_me: 'please' } }
-
   before {
     Bosh::Clouds::Config.configure(double('delegate', task_checkpoint: nil))
   }
@@ -67,17 +59,35 @@ describe Bosh::AzureCloud::Cloud do
 
   before { allow(Bosh::Cpi::RegistryClient).to receive_messages(new: double('registry').as_null_object) }
 
-  before { @disk_id = nil }
-  after  { cpi.delete_disk(@disk_id) if @disk_id }
+  before { @disk_id_pool = Array.new }
+  after {
+    @disk_id_pool.each do |disk_id|
+      cpi.delete_disk(disk_id) if disk_id
+    end
+  }
 
   context 'manual networking' do
+    let(:network_spec)do
+      {
+        'network_a' => {
+          'type' => 'manual',
+          'ip' => "10.0.0.#{Random.rand(10..99)}",
+          'cloud_properties' => {
+            'virtual_network_name' => vnet_name,
+            'subnet_name' => subnet_name
+          }
+        }
+      }
+    end
+
     context 'without existing disks' do
       it 'should exercise the vm lifecycle' do
-        vm_lifecycle(@stemcell_id, get_manual_networks()) do |instance_id|
-          @disk_id = cpi.create_disk(2048, {}, instance_id)
-          expect(@disk_id).not_to be_nil
+        vm_lifecycle do |instance_id|
+          disk_id = cpi.create_disk(2048, {}, instance_id)
+          expect(disk_id).not_to be_nil
+          @disk_id_pool.push(disk_id)
 
-          cpi.attach_disk(instance_id, @disk_id)
+          cpi.attach_disk(instance_id, disk_id)
 
           snapshot_metadata = vm_metadata.merge(
             bosh_data: 'bosh data',
@@ -87,47 +97,52 @@ describe Bosh::AzureCloud::Cloud do
             director_uuid: SecureRandom.uuid
           )
 
-          snapshot_id = cpi.snapshot_disk(@disk_id, snapshot_metadata)
+          snapshot_id = cpi.snapshot_disk(disk_id, snapshot_metadata)
           expect(snapshot_id).not_to be_nil
 
           cpi.delete_snapshot(snapshot_id)
-
           Bosh::Common.retryable(tries: 20, on: Bosh::Clouds::DiskNotAttached, sleep: lambda { |n, _| [2**(n-1), 30].min }) do
-            cpi.detach_disk(instance_id, @disk_id)
+            cpi.detach_disk(instance_id, disk_id)
             true
           end
+          cpi.delete_disk(disk_id)
+          @disk_id_pool.delete(disk_id)
         end
       end
     end
 
     context 'with existing disks' do
       let!(:existing_disk_id) { cpi.create_disk(2048, {}) }
-      after  { cpi.delete_disk(existing_disk_id) if existing_disk_id }
+      after { cpi.delete_disk(existing_disk_id) if existing_disk_id }
 
       it 'can excercise the vm lifecycle and list the disks' do
-        vm_lifecycle(@stemcell_id, get_manual_networks()) do |instance_id|
-          @disk_id = cpi.create_disk(2048, {}, instance_id)
-          expect(@disk_id).not_to be_nil
+        vm_lifecycle do |instance_id|
+          disk_id = cpi.create_disk(2048, {}, instance_id)
+          expect(disk_id).not_to be_nil
+          @disk_id_pool.push(disk_id)
 
-          cpi.attach_disk(instance_id, @disk_id)
-          expect(cpi.get_disks(instance_id)).to include(@disk_id)
+          cpi.attach_disk(instance_id, disk_id)
+          expect(cpi.get_disks(instance_id)).to include(disk_id)
 
           Bosh::Common.retryable(tries: 20, on: Bosh::Clouds::DiskNotAttached, sleep: lambda { |n, _| [2**(n-1), 30].min }) do
-            cpi.detach_disk(instance_id, @disk_id)
+            cpi.detach_disk(instance_id, disk_id)
             true
           end
+          cpi.delete_disk(disk_id)
+          @disk_id_pool.delete(disk_id)
         end
       end
     end
 
     context 'when vm with a attached disk is removed' do
       it 'should attach disk to a new vm' do
-        @disk_id = cpi.create_disk(2048, {})
-        expect(@disk_id).not_to be_nil
+        disk_id = cpi.create_disk(2048, {})
+        expect(disk_id).not_to be_nil
+        @disk_id_pool.push(disk_id)
 
-        vm_lifecycle(@stemcell_id, get_manual_networks()) do |instance_id|
-          cpi.attach_disk(instance_id, @disk_id)
-          expect(cpi.get_disks(instance_id)).to include(@disk_id)
+        vm_lifecycle do |instance_id|
+          cpi.attach_disk(instance_id, disk_id)
+          expect(cpi.get_disks(instance_id)).to include(disk_id)
         end
 
         begin
@@ -135,14 +150,14 @@ describe Bosh::AzureCloud::Cloud do
             SecureRandom.uuid,
             @stemcell_id,
             resource_pool,
-            get_manual_networks()
+            network_spec
           )
 
           expect {
-            cpi.attach_disk(new_instance_id, @disk_id)
+            cpi.attach_disk(new_instance_id, disk_id)
           }.to_not raise_error
 
-          expect(cpi.get_disks(new_instance_id)).to include(@disk_id)
+          expect(cpi.get_disks(new_instance_id)).to include(disk_id)
         ensure
           cpi.delete_vm(new_instance_id) if new_instance_id
         end
@@ -151,84 +166,45 @@ describe Bosh::AzureCloud::Cloud do
   end
 
   context 'dynamic networking' do
-    context 'without existing disks' do
-      it 'should exercise the vm lifecycle' do
-        vm_lifecycle(@stemcell_id, dynamic_networks) do |instance_id|
-          @disk_id = cpi.create_disk(2048, {}, instance_id)
-          expect(@disk_id).not_to be_nil
-
-          cpi.attach_disk(instance_id, @disk_id)
-
-          snapshot_metadata = vm_metadata.merge(
-            bosh_data: 'bosh data',
-            instance_id: 'instance',
-            agent_id: 'agent',
-            director_name: 'Director',
-            director_uuid: SecureRandom.uuid
-          )
-
-          snapshot_id = cpi.snapshot_disk(@disk_id, snapshot_metadata)
-          expect(snapshot_id).not_to be_nil
-
-          cpi.delete_snapshot(snapshot_id)
-
-          Bosh::Common.retryable(tries: 20, on: Bosh::Clouds::DiskNotAttached, sleep: lambda { |n, _| [2**(n-1), 30].min }) do
-            cpi.detach_disk(instance_id, @disk_id)
-            true
-          end
-        end
-      end
+    let(:network_spec)do
+      {
+        'network_a' => {
+          'type' => 'dynamic',
+          'cloud_properties' => {
+            'virtual_network_name' => vnet_name,
+            'subnet_name' => subnet_name
+          }
+        }
+      }
     end
 
-    context 'with existing disks' do
-      let!(:existing_disk_id) { cpi.create_disk(2048, {}) }
-      after  { cpi.delete_disk(existing_disk_id) if existing_disk_id }
-
-      it 'can excercise the vm lifecycle and list the disks' do
-        vm_lifecycle(@stemcell_id, dynamic_networks) do |instance_id|
-          @disk_id = cpi.create_disk(2048, {}, instance_id)
-          expect(@disk_id).not_to be_nil
-
-          cpi.attach_disk(instance_id, @disk_id)
-          expect(cpi.get_disks(instance_id)).to include(@disk_id)
-
-          Bosh::Common.retryable(tries: 20, on: Bosh::Clouds::DiskNotAttached, sleep: lambda { |n, _| [2**(n-1), 30].min }) do
-            cpi.detach_disk(instance_id, @disk_id)
-            true
-          end
-        end
-      end
-    end
-
-    context 'when vm with a attached disk is removed' do
-      it 'should attach disk to a new vm' do
-        @disk_id = cpi.create_disk(2048, {})
-        expect(@disk_id).not_to be_nil
-
-        vm_lifecycle(@stemcell_id, dynamic_networks) do |instance_id|
-          cpi.attach_disk(instance_id, @disk_id)
-          expect(cpi.get_disks(instance_id)).to include(@disk_id)
-        end
-
-        begin
-          new_instance_id = cpi.create_vm(
-            SecureRandom.uuid,
-            @stemcell_id,
-            resource_pool,
-            get_manual_networks()
-          )
-
-          expect {
-            cpi.attach_disk(new_instance_id, @disk_id)
-          }.to_not raise_error
-
-          expect(cpi.get_disks(new_instance_id)).to include(@disk_id)
-        ensure
-          cpi.delete_vm(new_instance_id) if new_instance_id
-        end
-      end
+    it 'should exercise the vm lifecycle' do
+      vm_lifecycle
     end
   end
+
+  context 'vip networking' do
+    let(:network_spec)do
+      {
+        'network_a' => {
+          'type' => 'dynamic',
+          'cloud_properties' => {
+            'virtual_network_name' => vnet_name,
+            'subnet_name' => subnet_name
+          }
+        },
+        'network_b' => {
+          'type' => 'vip',
+          'ip' => @primary_public_ip
+        }
+      }
+    end
+
+    it 'should exercise the vm lifecycle' do
+      vm_lifecycle
+    end
+  end
+
 
   context 'Creating multiple VMs in availability sets' do
     let(:resource_pool) {
@@ -241,10 +217,23 @@ describe Bosh::AzureCloud::Cloud do
       }
     }
 
+    let(:network_spec)do
+      {
+        'network_a' => {
+          'type' => 'dynamic',
+          'cloud_properties' => {
+            'virtual_network_name' => vnet_name,
+            'subnet_name' => subnet_name
+          }
+        }
+      }
+    end
+
     it 'should exercise the vm lifecycle' do
-      vm_lifecycle(@stemcell_id, dynamic_networks, 2) do |instance_id|
+      vm_lifecycle(2) do |instance_id|
         disk_id = cpi.create_disk(2048, {}, instance_id)
         expect(disk_id).not_to be_nil
+        @disk_id_pool.push(disk_id)
 
         cpi.attach_disk(instance_id, disk_id)
 
@@ -260,33 +249,76 @@ describe Bosh::AzureCloud::Cloud do
         expect(snapshot_id).not_to be_nil
 
         cpi.delete_snapshot(snapshot_id)
-
         Bosh::Common.retryable(tries: 20, on: Bosh::Clouds::DiskNotAttached, sleep: lambda { |n, _| [2**(n-1), 30].min }) do
           cpi.detach_disk(instance_id, disk_id)
           true
         end
-
-        cpi.delete_disk(disk_id) if disk_id
+        cpi.delete_disk(disk_id)
+        @disk_id_pool.delete(disk_id)
       end
     end
   end
 
-  def vm_lifecycle(stemcell_id, network_spec, nums = 1)
+  context 'When the resource group name is specified for the vnet & security groups' do
+    let(:network_spec)do
+      {
+        'network_a' => {
+          'type' => 'dynamic',
+          'cloud_properties' => {
+            'resource_group_name' => @resource_group_name_for_network,
+            'virtual_network_name' => vnet_name,
+            'subnet_name' => subnet_name
+          }
+        }
+      }
+    end
+
+    it 'should exercise the vm lifecycle' do
+      vm_lifecycle
+    end
+  end
+
+  context 'When the resource group name is specified for the public IP' do
+    let(:network_spec)do
+      {
+        'network_a' => {
+          'type' => 'dynamic',
+          'cloud_properties' => {
+            'virtual_network_name' => vnet_name,
+            'subnet_name' => subnet_name
+          }
+        },
+        'network_b' => {
+          'type' => 'vip',
+          'ip' => @secondary_public_ip,
+          'cloud_properties' => {
+            'resource_group_name' => @resource_group_name_for_network
+          }
+        }
+      }
+    end
+
+    it 'should exercise the vm lifecycle' do
+      vm_lifecycle
+    end
+  end
+
+  def vm_lifecycle(nums = 1)
     instance_id_pool = Array.new
     for i in 1..nums
-      logger.info("Creating VM with stemcell_id=#{stemcell_id}")
+      logger.info("Creating VM with stemcell_id=`#{@stemcell_id}'")
       instance_id = cpi.create_vm(
         SecureRandom.uuid,
-        stemcell_id,
+        @stemcell_id,
         resource_pool,
         network_spec)
       expect(instance_id).to be
 
-      logger.info("Checking VM existence instance_id=#{instance_id}")
+      logger.info("Checking VM existence instance_id=`#{instance_id}'")
       expect(cpi.has_vm?(instance_id)).to be(true)
       instance_id_pool.push(instance_id)
 
-      logger.info("Setting VM metadata instance_id=#{instance_id}")
+      logger.info("Setting VM metadata instance_id=`#{instance_id}'")
       cpi.set_vm_metadata(instance_id, vm_metadata)
 
       cpi.reboot_vm(instance_id)
@@ -299,17 +331,4 @@ describe Bosh::AzureCloud::Cloud do
     end
   end
 
-  def get_manual_networks
-    manual_networks = {
-      "bosh" => {
-        "type"    => "manual",
-        "ip"      => "10.0.0.#{Random.rand(10..99)}",
-        "cloud_properties" => {
-          "virtual_network_name" => vnet_name,
-          "subnet_name" => subnet_name
-        }
-      }
-    }
-    manual_networks
-  end
 end

--- a/src/bosh_azure_cpi/spec/unit/azure_client2/azure_client2_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client2/azure_client2_spec.rb
@@ -31,50 +31,61 @@ describe Bosh::AzureCloud::AzureClient2 do
       resource_type = "b"
       name = "c"
       others = "d"
+      resource_group_name = "e"
       expect(azure_client2.rest_api_url(
         resource_provider,
         resource_type,
-        name,
-        others)
-      ).to eq("/subscriptions/#{subscription_id}/resourceGroups/#{resource_group}/providers/a/b/c/d")
+        resource_group_name: resource_group_name,
+        name: name,
+        others: others)
+      ).to eq("/subscriptions/#{subscription_id}/resourceGroups/e/providers/a/b/c/d")
     end
 
-    it "returns the right url if name is nil" do
+    it "returns the right url if resource group name is not provided" do
       resource_provider = "a"
       resource_type = "b"
-      name = nil
+      name = "c"
       others = "d"
       expect(azure_client2.rest_api_url(
         resource_provider,
         resource_type,
-        name,
-        others)
-      ).to eq("/subscriptions/#{subscription_id}/resourceGroups/#{resource_group}/providers/a/b/d")
+        name: name,
+        others: others)
+      ).to eq("/subscriptions/#{subscription_id}/resourceGroups/#{resource_group}/providers/a/b/c/d")
     end
 
-    it "returns the right url if others is nil" do
+    it "returns the right url if name is not provided" do
+      resource_provider = "a"
+      resource_type = "b"
+      others = "d"
+      resource_group_name = "e"
+      expect(azure_client2.rest_api_url(
+        resource_provider,
+        resource_type,
+        resource_group_name: resource_group_name,
+        others: others)
+      ).to eq("/subscriptions/#{subscription_id}/resourceGroups/e/providers/a/b/d")
+    end
+
+    it "returns the right url if others is not provided" do
       resource_provider = "a"
       resource_type = "b"
       name = "c"
-      others = nil
+      resource_group_name = "e"
       expect(azure_client2.rest_api_url(
         resource_provider,
         resource_type,
-        name,
-        others)
-      ).to eq("/subscriptions/#{subscription_id}/resourceGroups/#{resource_group}/providers/a/b/c")
+        resource_group_name: resource_group_name,
+        name: name)
+      ).to eq("/subscriptions/#{subscription_id}/resourceGroups/e/providers/a/b/c")
     end
 
-    it "returns the right url if name and others are both nil" do
+    it "returns the right url if resource_group_name, name and others are all not provided" do
       resource_provider = "a"
       resource_type = "b"
-      name = nil
-      others = nil
       expect(azure_client2.rest_api_url(
         resource_provider,
-        resource_type,
-        name,
-        others)
+        resource_type)
       ).to eq("/subscriptions/#{subscription_id}/resourceGroups/#{resource_group}/providers/a/b")
     end
   end

--- a/src/bosh_azure_cpi/spec/unit/azure_client2/get_operation_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client2/get_operation_spec.rb
@@ -14,7 +14,7 @@ describe Bosh::AzureCloud::AzureClient2 do
   let(:subscription_id) { mock_azure_properties['subscription_id'] }
   let(:tenant_id) { mock_azure_properties['tenant_id'] }
   let(:api_version) { '2015-05-01-preview' }
-  let(:resource_group) { mock_azure_properties['resource_group_name'] }
+  let(:resource_group_name) { mock_azure_properties['resource_group_name'] }
   let(:request_id) { "fake-request-id" }
 
   let(:token_uri) { "https://login.microsoftonline.com/#{tenant_id}/oauth2/token?api-version=#{api_version}" }
@@ -26,7 +26,7 @@ describe Bosh::AzureCloud::AzureClient2 do
 
   # Public IP
   let(:public_ip_name) { "fake-name" }
-  let(:public_ip_id) { "/subscriptions/#{subscription_id}/resourceGroups/#{resource_group}/providers/Microsoft.Network/publicIPAddresses/#{public_ip_name}" }
+  let(:public_ip_id) { "/subscriptions/#{subscription_id}/resourceGroups/#{resource_group_name}/providers/Microsoft.Network/publicIPAddresses/#{public_ip_name}" }
   let(:public_ip_uri) { "https://management.azure.com/#{public_ip_id}?api-version=#{api_version}" }
   let(:public_ip_response_body) {
     {
@@ -58,7 +58,7 @@ describe Bosh::AzureCloud::AzureClient2 do
 
   # Load Balancer
   let(:load_balancer_name) { "fake-name" }
-  let(:load_balancer_id) { "/subscriptions/#{subscription_id}/resourceGroups/#{resource_group}/providers/Microsoft.Network/loadBalancers/#{load_balancer_name}" }
+  let(:load_balancer_id) { "/subscriptions/#{subscription_id}/resourceGroups/#{resource_group_name}/providers/Microsoft.Network/loadBalancers/#{load_balancer_name}" }
   let(:load_balancer_uri) { "https://management.azure.com/#{load_balancer_id}?api-version=#{api_version}" }
   let(:load_balancer_response_body) {
     {
@@ -121,7 +121,7 @@ describe Bosh::AzureCloud::AzureClient2 do
     
   # Network Interface
   let(:nic_name) { "fake-name" }
-  let(:nic_id) { "/subscriptions/#{subscription_id}/resourceGroups/#{resource_group}/providers/Microsoft.Network/networkInterfaces/#{nic_name}" }
+  let(:nic_id) { "/subscriptions/#{subscription_id}/resourceGroups/#{resource_group_name}/providers/Microsoft.Network/networkInterfaces/#{nic_name}" }
   let(:nic_uri) { "https://management.azure.com/#{nic_id}?api-version=#{api_version}" }
 
   let(:nic_response_body) {
@@ -172,7 +172,7 @@ describe Bosh::AzureCloud::AzureClient2 do
   # Subnet
   let(:vnet_name) { "fake-name" }
   let(:subnet_name) { "bar" }
-  let(:network_subnet_uri) { "https://management.azure.com//subscriptions/#{subscription_id}/resourceGroups/#{resource_group}/providers/Microsoft.Network/virtualNetworks/#{vnet_name}/subnets/#{subnet_name}?api-version=#{api_version}" }
+  let(:network_subnet_uri) { "https://management.azure.com//subscriptions/#{subscription_id}/resourceGroups/#{resource_group_name}/providers/Microsoft.Network/virtualNetworks/#{vnet_name}/subnets/#{subnet_name}?api-version=#{api_version}" }
   let(:network_subnet_response_body) {
     {
       "id" => "fake-id",
@@ -194,7 +194,7 @@ describe Bosh::AzureCloud::AzureClient2 do
 
   # Network Security Group
   let(:nsg_name) { "fake-name" }
-  let(:nsg_id) { "/subscriptions/#{subscription_id}/resourceGroups/#{resource_group}/providers/Microsoft.Network/networkSecurityGroups/#{nsg_name}" }
+  let(:nsg_id) { "/subscriptions/#{subscription_id}/resourceGroups/#{resource_group_name}/providers/Microsoft.Network/networkSecurityGroups/#{nsg_name}" }
   let(:nsg_uri) { "https://management.azure.com/#{nsg_id}?api-version=#{api_version}" }
 
   let(:nsg_response_body) {
@@ -293,7 +293,7 @@ describe Bosh::AzureCloud::AzureClient2 do
   end
 
   describe "#list_public_ips" do
-    let(:list_public_ips_uri) { "https://management.azure.com//subscriptions/#{subscription_id}/resourceGroups/#{resource_group}/providers/Microsoft.Network/publicIPAddresses?api-version=#{api_version}" }
+    let(:list_public_ips_uri) { "https://management.azure.com//subscriptions/#{subscription_id}/resourceGroups/#{resource_group_name}/providers/Microsoft.Network/publicIPAddresses?api-version=#{api_version}" }
     let(:list_public_ips_response_body) {
       {
         "value" => [{
@@ -330,7 +330,7 @@ describe Bosh::AzureCloud::AzureClient2 do
           :body => '',
           :headers => {})
         expect(
-          azure_client2.list_public_ips()
+          azure_client2.list_public_ips(resource_group_name)
         ).to eq([])
       end
 
@@ -340,7 +340,7 @@ describe Bosh::AzureCloud::AzureClient2 do
           :body => list_public_ips_response_body,
           :headers => {})
         expect(
-          azure_client2.list_public_ips()
+          azure_client2.list_public_ips(resource_group_name)
         ).to eq(fake_public_ip)
       end
     end
@@ -414,7 +414,7 @@ describe Bosh::AzureCloud::AzureClient2 do
           :body => '',
           :headers => {})
         expect(
-          azure_client2.get_network_subnet_by_name(vnet_name, subnet_name)
+          azure_client2.get_network_subnet_by_name(resource_group_name, vnet_name, subnet_name)
         ).to be_nil
       end
 
@@ -424,15 +424,16 @@ describe Bosh::AzureCloud::AzureClient2 do
           :body => network_subnet_response_body,
           :headers => {})
         expect(
-          azure_client2.get_network_subnet_by_name(vnet_name, subnet_name)
+          azure_client2.get_network_subnet_by_name(resource_group_name, vnet_name, subnet_name)
         ).to eq(fake_network_subnet)
+
       end
     end
   end
 
   describe "#get_storage_account_by_name" do
     let(:storage_account_name) { "foo" }
-    let(:storage_account_uri) { "https://management.azure.com//subscriptions/#{subscription_id}/resourceGroups/#{resource_group}/providers/Microsoft.Storage/storageAccounts/#{storage_account_name}?api-version=#{api_version}" }
+    let(:storage_account_uri) { "https://management.azure.com//subscriptions/#{subscription_id}/resourceGroups/#{resource_group_name}/providers/Microsoft.Storage/storageAccounts/#{storage_account_name}?api-version=#{api_version}" }
 
     context "when token is valid, getting response succeeds" do
       context "if response body is null" do
@@ -550,7 +551,7 @@ describe Bosh::AzureCloud::AzureClient2 do
 
   describe "#get_virtual_machine_by_name" do
     let(:vm_name) { "fake-vm-name" }
-    let(:vm_uri) { "https://management.azure.com//subscriptions/#{subscription_id}/resourceGroups/#{resource_group}/providers/Microsoft.Compute/virtualMachines/#{vm_name}?api-version=#{api_version}" }
+    let(:vm_uri) { "https://management.azure.com//subscriptions/#{subscription_id}/resourceGroups/#{resource_group_name}/providers/Microsoft.Compute/virtualMachines/#{vm_name}?api-version=#{api_version}" }
 
     let(:response_body) {
       {
@@ -652,7 +653,7 @@ describe Bosh::AzureCloud::AzureClient2 do
           :body => '',
           :headers => {})
         expect(
-          azure_client2.get_network_security_group_by_name(nsg_name)
+          azure_client2.get_network_security_group_by_name(resource_group_name, nsg_name)
         ).to be_nil
       end
 
@@ -662,7 +663,7 @@ describe Bosh::AzureCloud::AzureClient2 do
           :body => nsg_response_body,
           :headers => {})
         expect(
-          azure_client2.get_network_security_group_by_name(nsg_name)
+          azure_client2.get_network_security_group_by_name(resource_group_name, nsg_name)
         ).to eq(fake_nsg)
       end
     end


### PR DESCRIPTION
The following resources can be in a separate resource group

1. Virtual Network and Subnets
2. Security Groups
3. Public IPs

Close #142 