### PR TITLE
*PROXY* environment variables are quoted in job's template

### DIFF
--- a/jobs/azure_cpi/templates/cpi.erb
+++ b/jobs/azure_cpi/templates/cpi.erb
@@ -1,18 +1,20 @@
 #!/bin/bash
 
+set -e
+
 <% if_p('env.http_proxy') do |http_proxy| %>
-export HTTP_PROXY=<%= http_proxy %>
-export http_proxy=<%= http_proxy %>
+export HTTP_PROXY="<%= http_proxy %>"
+export http_proxy="<%= http_proxy %>"
 <% end %>
 
 <% if_p('env.https_proxy') do |https_proxy| %>
-export HTTPS_PROXY=<%= https_proxy %>
-export https_proxy=<%= https_proxy %>
+export HTTPS_PROXY="<%= https_proxy %>"
+export https_proxy="<%= https_proxy %>"
 <% end %>
 
 <% if_p('env.no_proxy') do |no_proxy| %>
-export NO_PROXY=<%= no_proxy %>
-export no_proxy=<%= no_proxy %>
+export NO_PROXY="<%= no_proxy %>"
+export no_proxy="<%= no_proxy %>"
 <% end %>
 
 BOSH_PACKAGES_DIR=${BOSH_PACKAGES_DIR:-/var/vcap/packages}


### PR DESCRIPTION
- Also, script bails on error (`set -e`)

Fixes a bug where user had spaces in NO_PROXY in the
`env.no_proxy` property, and it was instantiated in the
template file, but `bash` ignored everything after the
first space (i.e. the resulting NO_PROXY environment
variable was truncated) and `bash` didn't error-out
as it should have (thus `set -e`), and user's deploy
failed mysteriously.

Signed-off-by: Brian Cunnie <bcunnie@pivotal.io>

[#128097379](https://www.pivotaltracker.com/story/show/128097379)