### PR TITLE
Update docs to deploy multiple haproxy

### DIFF
--- a/docs/advanced/deploy-multiple-haproxy/README.md
+++ b/docs/advanced/deploy-multiple-haproxy/README.md
@@ -11,24 +11,30 @@ Please note that this guidance focuses on CF deployment. You need to follow the 
 Below is a sample deployment, which you can adjust based on your workload and performance requirements. It is a multiple-VM Cloud Foundry with 2 HAProxy instances.
 
   ```
-  +------------------------------------+---------+------------------+-------------+
-  | Job/index                          | State   | Resource Pool    | IPs         |
-  +------------------------------------+---------+------------------+-------------+
-  | api_z1/0                           | running | resource_z1      | 10.0.16.101 |
-  | doppler_z1/0                       | running | resource_z1      | 10.0.16.103 |
-  | etcd_z1/0                          | running | resource_z1      | 10.0.16.14  |
-  | ha_proxy_z1/0                      | running | resource_haproxy | 10.0.16.4   |
-  | ha_proxy_z1/1                      | running | resource_haproxy | 10.0.16.5   |
-  | hm9000_z1/0                        | running | resource_z1      | 10.0.16.102 |
-  | loggregator_trafficcontroller_z1/0 | running | resource_z1      | 10.0.16.104 |
-  | nats_z1/0                          | running | resource_z1      | 10.0.16.13  |
-  | nfs_z1/0                           | running | resource_z1      | 10.0.16.15  |
-  | postgres_z1/0                      | running | resource_z1      | 10.0.16.11  |
-  | router_z1/0                        | running | resource_z1      | 10.0.16.12  |
-  | router_z1/1                        | running | resource_z1      | 10.0.16.22  |
-  | runner_z1/0                        | running | resource_z1      | 10.0.16.106 |
-  | uaa_z1/0                           | running | resource_z1      | 10.0.16.105 |
-  +------------------------------------+---------+------------------+-------------+
+  +---------------------------------------------------------------------------+---------+-----+------------------+-------------+
+  | VM                                                                        | State   | AZ  | VM Type          | IPs         |
+  +---------------------------------------------------------------------------+---------+-----+------------------+-------------+
+  | access_z1/0 (ab536515-3c7f-4c08-a321-c4b567926a8e)                        | running | n/a | resource_z1      | 10.0.16.110 |
+  | api_z1/0 (7ba0fa0d-db17-4844-a79c-3fa5a715b1bc)                           | running | n/a | resource_z1      | 10.0.16.102 |
+  | brain_z1/0 (5923d5f8-6b64-4659-af59-9a96a8232a65)                         | running | n/a | resource_z1      | 10.0.16.106 |
+  | cc_bridge_z1/0 (01321f22-a44f-450a-b509-4de140fc45e5)                     | running | n/a | resource_z1      | 10.0.16.109 |
+  | cell_z1/0 (d518d00d-b8c8-480a-93b9-c99b6799f668)                          | running | n/a | resource_z1      | 10.0.16.107 |
+  | cell_z1/1 (0cf93ce5-eb9b-4e91-9703-e286961508ee)                          | running | n/a | resource_z1      | 10.0.16.108 |
+  | consul_z1/0 (ea8c1b78-1fed-47c1-b6fa-0693ac8445ec)                        | running | n/a | resource_z1      | 10.0.16.16  |
+  | database_z1/0 (7dc46349-a8ea-4619-bb44-00e525160fc1)                      | running | n/a | resource_z1      | 10.0.16.105 |
+  | doppler_z1/0 (ac5c4097-71ce-4d28-bf99-3287e665047b)                       | running | n/a | resource_z1      | 10.0.16.103 |
+  | etcd_z1/0 (51fa4ec2-cde4-4e49-bd92-de1a27823b1a)                          | running | n/a | resource_z1      | 10.0.16.14  |
+  | ha_proxy_z1/0 (44d728d9-ff4d-4bee-b89e-21d40abfe0fb)                      | running | n/a | resource_haproxy | 10.0.16.4   |
+  | ha_proxy_z1/1 (0565f4a3-37f0-42cf-9ef0-5332f067027c)                      | running | n/a | resource_haproxy | 10.0.16.5   |
+  | loggregator_trafficcontroller_z1/0 (941ffc66-e681-4bec-b691-6d36371d4eba) | running | n/a | resource_z1      | 10.0.16.104 |
+  | nats_z1/0 (b288ef95-7e37-414b-ab58-5e9d5e05aa65)                          | running | n/a | resource_z1      | 10.0.16.13  |
+  | nfs_z1/0 (81733add-df1b-43cf-8274-62e4ab23ca42)                           | running | n/a | resource_z1      | 10.0.16.15  |
+  | postgres_z1/0 (b2bbd940-f42d-443b-b86a-75925e08747e)                      | running | n/a | resource_z1      | 10.0.16.11  |
+  | route_emitter_z1/0 (e00d21be-003a-4f8c-9bb1-9fb4e250e712)                 | running | n/a | resource_z1      | 10.0.16.111 |
+  | router_z1/0 (f6a72ce7-94bb-4272-a3e8-a0b4fdbbf959)                        | running | n/a | resource_z1      | 10.0.16.12  |
+  | router_z1/1 (897c5bc0-9e76-4c78-8696-012c29147221)                        | running | n/a | resource_z1      | 10.0.16.22  |
+  | uaa_z1/0 (c5a727c1-8611-4281-8f09-41c79362e263)                           | running | n/a | resource_z1      | 10.0.16.101 |
+  +---------------------------------------------------------------------------+---------+-----+------------------+-------------+
   ```
 
 ## Create Azure Load Balancer
@@ -46,71 +52,86 @@ Please update the value which starts with `REPLACE-ME` and run it after you [log
 2. Login to your BOSH director VM
 
   ```
-  bosh target 10.0.0.4 # Username: admin, Password: admin.
+  bosh target 10.0.0.4
   ```
 
-  _**Note:** If you have used `bosh logout`, you should use `bosh login admin admin` to log in._
+  >**Note:** The username and password can be found in your `bosh.yml`. If you deployed BOSH using ARM template, the default username is `admin`, and the password can be found in the file `~/BOSH_DIRECTOR_ADMIN_PASSWORD`.
 
-3. Update the cloud foundry manifest `~/example_manifests/multiple-vm-cf.yml` to set the router instance number to 2 and add a new static private IP.
+3. Update the cloud foundry manifest `~/example_manifests/multiple-vm-cf.yml`.
 
-  ```
-  - name: router_z1
-  instances: 2
-  resource_pool: resource_z1
-  templates:
-  - {name: gorouter, release: cf}
-  - {name: metron_agent, release: cf}
-  networks:
-  - name: cf_private
-    static_ips: [10.0.16.12, 10.0.16.22]
-  properties:
+  1. Update the job `router_z1`
+
+    1. Set the router instance number to 2
+
+    2. Add a new static private IP
+
+    Example:
+
+    ```
+    - name: router_z1
+    instances: 2
+    resource_pool: resource_z1
+    templates:
+    - {name: gorouter, release: cf}
+    - {name: metron_agent, release: cf}
+    networks:
+    - name: cf_private
+      static_ips: [10.0.16.12, 10.0.16.22]
+    properties:
+      ...
+    ```
+
+  2. Update the job `ha_proxy_z1`
+
+    1. Add a new resource pool for HAProxy. If you do not use `haproxylb`, you need use your Azure Load Balancer name.
+
+    2. Set the HAProxy instance number to 2
+
+    3. Use the resource pool `resource_haproxy`
+
+    4. Remove the `cf_public` network
+
+    5. Add a new static private IP for the second HAProxy instance
+
+    6. Add the IP address of the second router
+
+    Example:
+
+    ```
+    resource_pools:
     ...
-  ```
-
-4. Update the cloud foundry manifest `~/example_manifests/multiple-vm-cf.yml` to add a new resource pool for HAProxy. If you do not use `haproxylb`, you need use your Azure Load Balancer name.
-
-  ```
-  resource_pools:
-  ...
-  - name: resource_haproxy
-    network: cf_private
-    stemcell:
-      name: bosh-azure-hyperv-ubuntu-trusty-go_agent
-      version: latest
-    cloud_properties:
-      load_balancer: haproxylb
-      availability_set: haproxy
-      instance_type: Standard_D1
-      security_group: nsg-cf
-    env:
-      bosh:
-        password: $6$4gDD3aV0rdqlrKC$2axHCxGKIObs6tAmMTqYCspcdvQXh3JJcvWOY2WGb4SrdXtnCyNaWlrf3WEqvYR2MYizEGp3kMmbpwBC6jsHt0
-  ```
-
-5. Update the cloud foundry manifest `~/example_manifests/multiple-vm-cf.yml` to set the HAProxy instance number to 2, add a new static private IP for the second HAProxy instance, remove the `cf_public` network and add the IP address of the second router.
-
-  ```
-  - name: ha_proxy_z1
-  instances: 2
-  resource_pool: resource_haproxy
-  templates:
-  - {name: haproxy, release: cf}
-  - {name: metron_agent, release: cf}
-  - {name: consul_agent, release: cf}
-  networks:
-  - name: cf_private
-    default: [gateway, dns]
-    static_ips: [10.0.16.4, 10.0.16.5]
-  properties:
+    - name: resource_haproxy
+      network: cf_private
+      stemcell:
+        name: bosh-azure-hyperv-ubuntu-trusty-go_agent
+        version: latest
+      cloud_properties:
+        load_balancer: haproxylb
+        availability_set: haproxy
+        instance_type: Standard_D1
+        security_group: nsg-cf
     ...
-    router:
-      servers:
-      - 10.0.16.12
-      - 10.0.16.22
-    ...
-  ```
+    - name: ha_proxy_z1
+    instances: 2
+    resource_pool: resource_haproxy
+    templates:
+    - {name: haproxy, release: cf}
+    - {name: metron_agent, release: cf}
+    - {name: consul_agent, release: cf}
+    networks:
+    - name: cf_private
+      default: [gateway, dns]
+      static_ips: [10.0.16.4, 10.0.16.5]
+    properties:
+      ...
+      router:
+        servers:
+        - 10.0.16.12
+        - 10.0.16.22
+      ...
+    ```
 
-6. Deploy cloud foundry
+4. Deploy cloud foundry
 
   ```
   ./deploy_cloudfoundry.sh ~/example_manifests/multiple-vm-cf.yml

--- a/docs/advanced/deploy-multiple-haproxy/create-load-balancer.sh
+++ b/docs/advanced/deploy-multiple-haproxy/create-load-balancer.sh
@@ -2,12 +2,13 @@
 
 resourceGroupName="REPLACE-ME-WITH-YOUR-RESOURCE-GROUP-NAME" 
 location="REPLACE-ME-WITH-THE-LOCATION-OF-YOUR-RESOURCE-GROUP"
-virtualNetworkName="REPLACE-ME-WITH-VNET-NAME" # Default: boshvnet-crp
 publicIPName="REPLACE-ME-WITH-THE-PUBLIC-IP-NAME-OF-CLOUDFOUNDRY" # Default: <YOUR-DEVBOX-NAME>-cf
 loadBalancerName="haproxylb" # This will be used in your Cloud Foundry manifest
 frontendIPName="fip"
 backendPoolName="backendpool"
 idleTimeout=15 # Minutes. Match the default timeout in HAPROXY
+probeName="healthprobe"
+probePort=443 # You can change to 80 if 443 is disabled in your deployment
 
 azure config mode arm
 
@@ -17,17 +18,16 @@ azure network lb frontend-ip create --resource-group $resourceGroupName --lb-nam
 
 azure network lb address-pool create --resource-group $resourceGroupName --lb-name $loadBalancerName --name $backendPoolName
 
-azure network lb probe create --resource-group $resourceGroupName --lb-name $loadBalancerName --name healthprobe --protocol tcp --port 22 --interval 15 --count 4
+azure network lb probe create --resource-group $resourceGroupName --lb-name $loadBalancerName --name $probeName --protocol tcp --port $probePort --interval 15 --count 4
 
 tcpPorts="22 80 443 2222 4222 4443 6868 25250 25555 25777"
 for tcpPort in $tcpPorts
 do
-azure network lb rule create --resource-group $resourceGroupName --lb-name $loadBalancerName --name "lbruletcp$tcpPort" --protocol tcp --frontend-port $tcpPort --backend-port $tcpPort --frontend-ip-name $frontendIPName --backend-address-pool-name $backendPoolName --idle-timeout $idleTimeout
+  azure network lb rule create --resource-group $resourceGroupName --lb-name $loadBalancerName --name "lbruletcp$tcpPort" --protocol tcp --frontend-port $tcpPort --backend-port $tcpPort --frontend-ip-name $frontendIPName --backend-address-pool-name $backendPoolName --idle-timeout $idleTimeout --probe-name $probeName
 done
 
 udpPorts="53 68"
 for udpPort in $udpPorts
 do
-azure network lb rule create --resource-group $resourceGroupName --lb-name $loadBalancerName --name "lbruleudp$udpPort" --protocol udp --frontend-port $udpPort --backend-port $udpPort --frontend-ip-name $frontendIPName --backend-address-pool-name $backendPoolName --idle-timeout $idleTimeout
-
+  azure network lb rule create --resource-group $resourceGroupName --lb-name $loadBalancerName --name "lbruleudp$udpPort" --protocol udp --frontend-port $udpPort --backend-port $udpPort --frontend-ip-name $frontendIPName --backend-address-pool-name $backendPoolName --idle-timeout $idleTimeout --probe-name $probeName
 done


### PR DESCRIPTION
1. Change the health probe port to 443. Fix #191.
2. Specify the probe name for each load balancer rule.
3. Refine the docs.