### PR TITLE
Get os_type from cloud_properties of stemcells

### DIFF
--- a/src/bosh_azure_cpi/lib/cloud/azure/cloud.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/cloud.rb
@@ -113,7 +113,7 @@ module Bosh::AzureCloud
         vm_params = @vm_manager.create(
           agent_id,
           storage_account,
-          @stemcell_manager.get_stemcell_uri(storage_account[:name], stemcell_id),
+          @stemcell_manager.get_stemcell_info(storage_account[:name], stemcell_id),
           resource_pool,
           NetworkConfigurator.new(@azure_properties, networks),
           env)

--- a/src/bosh_azure_cpi/lib/cloud/azure/disk_manager.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/disk_manager.rb
@@ -97,7 +97,7 @@ module Bosh::AzureCloud
       "#{OS_DISK_PREFIX}-#{instance_id}-#{EPHEMERAL_DISK_POSTFIX}"
     end
 
-    def os_disk(instance_id)
+    def os_disk(instance_id, minimum_disk_size)
       disk_name = generate_os_disk_name(instance_id)
       disk_uri = get_disk_uri(disk_name)
 
@@ -105,9 +105,9 @@ module Bosh::AzureCloud
       root_disk = @resource_pool.fetch('root_disk', {})
       size = root_disk.fetch('size', nil)
       unless size.nil?
-        validate_disk_size(size)
-        disk_size = size/1024
-        cloud_error('root_disk.size must not be smaller than 3 GiB') if disk_size < 3
+        cloud_error("root_disk.size `#{size}' is smaller than the default OS disk size `#{minimum_disk_size}' MiB") if size < minimum_disk_size
+        disk_size = (size/1024.0).ceil
+        validate_disk_size(disk_size*1024)
       end
 
       disk_caching = @resource_pool.fetch('caching', 'ReadWrite')

--- a/src/bosh_azure_cpi/lib/cloud/azure/helpers.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/helpers.rb
@@ -305,6 +305,25 @@ module Bosh::AzureCloud
       end
     end
 
+    # Stemcell information, got from the stemcell blob file on Azure
+    # * +:uri+      - String. uri of the stemcell, e.g. "https://<storageaccount>.blob.core.windows.net/stemcell/bosh-stemcell-82817f34-ae10-4cfe-8ca8-b18d18ee5cdd.vhd"
+    # * +:os_type+  - String. os type of the stemcell, e.g. "linux"
+    # * +:name+     - String. name of the stemcell, e.g. "bosh-azure-hyperv-ubuntu-trusty-go_agent"
+    # * +:version   - String. version of the stemcell, e.g. "2972"
+    # * +:disk_size - Integer. disk size in MiB, e.g. 3072
+    class StemcellInfo
+      attr_reader :uri, :os_type, :name, :version, :disk_size
+
+      def initialize(uri, metadata)
+        @uri = uri
+        @metadata = metadata
+        @os_type = @metadata['os_type'].nil? ? 'linux': @metadata['os_type'].downcase
+        @name = @metadata['name']
+        @version = @metadata['version']
+        @disk_size = @metadata['disk'].nil? ? 3072 : @metadata['disk'].to_i
+      end
+    end
+
     private
 
     def validate_azure_stack_options(azure_properties)

--- a/src/bosh_azure_cpi/lib/cloud/azure/stemcell_manager.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/stemcell_manager.rb
@@ -46,7 +46,7 @@ module Bosh::AzureCloud
         run_command("tar -zxf #{image_path} -C #{tmp_dir}")
         @logger.info("Start to upload VHD")
         stemcell_name = "#{STEMCELL_PREFIX}-#{SecureRandom.uuid}"
-        @blob_manager.create_page_blob(@default_storage_account_name, STEMCELL_CONTAINER, "#{tmp_dir}/root.vhd", "#{stemcell_name}.vhd")
+        @blob_manager.create_page_blob(@default_storage_account_name, STEMCELL_CONTAINER, "#{tmp_dir}/root.vhd", "#{stemcell_name}.vhd", cloud_properties)
       end
       stemcell_name
     end
@@ -64,6 +64,14 @@ module Bosh::AzureCloud
     def get_stemcell_uri(storage_account_name, name)
       @logger.info("get_stemcell_uri(#{storage_account_name}, #{name})")
       @blob_manager.get_blob_uri(storage_account_name, STEMCELL_CONTAINER, "#{name}.vhd")
+    end
+
+    def get_stemcell_info(storage_account_name, name)
+      @logger.info("get_stemcell_info(#{storage_account_name}, #{name})")
+      uri = @blob_manager.get_blob_uri(storage_account_name, STEMCELL_CONTAINER, "#{name}.vhd")
+      metadata = @blob_manager.get_blob_metadata(storage_account_name, STEMCELL_CONTAINER, "#{name}.vhd")
+      cloud_error("The stemcell `#{name}' does not exist in the storage account `#{storage_account_name}'") if metadata.nil?
+      StemcellInfo.new(uri, metadata)
     end
 
     private

--- a/src/bosh_azure_cpi/spec/unit/azure_client2/create_virtual_machine_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client2/create_virtual_machine_spec.rb
@@ -33,7 +33,7 @@ describe Bosh::AzureCloud::AzureClient2 do
         :name           => vm_name,
         :location       => "b",
         :vm_size        => "c",
-        :username       => "d",
+        :ssh_username   => "d",
         :ssh_cert_data  => "e",
         :custom_data    => "f",
         :image_uri      => "g",
@@ -48,7 +48,8 @@ describe Bosh::AzureCloud::AzureClient2 do
           :disk_uri      => "m",
           :disk_caching  => "n",
           :disk_size     => "o",
-        }
+        },
+        :os_type        => "linux"
       }
     end
     let(:network_interfaces) {[
@@ -89,7 +90,7 @@ describe Bosh::AzureCloud::AzureClient2 do
             :name           => vm_name,
             :location       => "b",
             :vm_size        => "c",
-            :username       => "d",
+            :ssh_username   => "d",
             :ssh_cert_data  => "e",
             :custom_data    => "f",
             :image_uri      => "g",
@@ -98,7 +99,8 @@ describe Bosh::AzureCloud::AzureClient2 do
               :disk_uri      => "i",
               :disk_caching  => "j",
               :disk_size     => "k",
-            }
+            },
+            :os_type        => "linux"
           }
         end
 
@@ -133,7 +135,7 @@ describe Bosh::AzureCloud::AzureClient2 do
             :name           => vm_name,
             :location       => "b",
             :vm_size        => "c",
-            :username       => "d",
+            :ssh_username   => "d",
             :ssh_cert_data  => "e",
             :custom_data    => "f",
             :image_uri      => "g",
@@ -141,7 +143,8 @@ describe Bosh::AzureCloud::AzureClient2 do
               :disk_name     => "h",
               :disk_uri      => "i",
               :disk_caching  => "j"
-            }
+            },
+            :os_type        => "linux"
           }
         end
 

--- a/src/bosh_azure_cpi/spec/unit/cloud_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/cloud_spec.rb
@@ -114,9 +114,7 @@ describe Bosh::AzureCloud::Cloud do
 
   describe '#create_vm' do
     let(:storage_account_name) { azure_properties['storage_account_name'] }
-    let(:stemcell_uri) {
-      "https://#{storage_account_name}.blob.core.windows.net/fakecontainer/#{stemcell_id}.vhd"
-    }
+    let(:stemcell_info) { instance_double(Bosh::AzureCloud::Helpers::StemcellInfo) }
     let(:resource_pool) { {'instance_type' => 'fake-vm-size'} }
     let(:networks_spec) { {} }
     let(:disk_locality) { double("disk locality") }
@@ -143,9 +141,9 @@ describe Bosh::AzureCloud::Cloud do
       allow(stemcell_manager).to receive(:has_stemcell?).
         with(storage_account_name, stemcell_id).
         and_return(true)
-      allow(stemcell_manager).to receive(:get_stemcell_uri).
+      allow(stemcell_manager).to receive(:get_stemcell_info).
         with(storage_account_name, stemcell_id).
-        and_return(stemcell_uri)
+        and_return(stemcell_info)
       allow(vm_manager).to receive(:create).and_return(vm_params)
       allow(Bosh::AzureCloud::NetworkConfigurator).to receive(:new).
           with(azure_properties, networks_spec).
@@ -318,9 +316,9 @@ describe Bosh::AzureCloud::Cloud do
             allow(stemcell_manager).to receive(:has_stemcell?).
               with(storage_account_name, stemcell_id).
               and_return(true)
-            allow(stemcell_manager).to receive(:get_stemcell_uri).
+            allow(stemcell_manager).to receive(:get_stemcell_info).
               with(storage_account_name, stemcell_id).
-              and_return(stemcell_uri)
+              and_return(stemcell_info)
           end
 
           context 'when storage_account_location is specified' do
@@ -444,9 +442,9 @@ describe Bosh::AzureCloud::Cloud do
             allow(stemcell_manager).to receive(:has_stemcell?).
               with(storage_account_name, stemcell_id).
               and_return(true)
-            allow(stemcell_manager).to receive(:get_stemcell_uri).
+            allow(stemcell_manager).to receive(:get_stemcell_info).
               with(storage_account_name, stemcell_id).
-              and_return(stemcell_uri)
+              and_return(stemcell_info)
           end
 
           context 'when the storage account belongs to other resource group' do
@@ -536,9 +534,9 @@ describe Bosh::AzureCloud::Cloud do
             allow(stemcell_manager).to receive(:has_stemcell?).
               with(storage_account_name, stemcell_id).
               and_return(true)
-            allow(stemcell_manager).to receive(:get_stemcell_uri).
+            allow(stemcell_manager).to receive(:get_stemcell_info).
               with(storage_account_name, stemcell_id).
-              and_return(stemcell_uri)
+              and_return(stemcell_info)
           end
 
           it 'should not raise any error' do
@@ -690,9 +688,9 @@ describe Bosh::AzureCloud::Cloud do
                 allow(stemcell_manager).to receive(:has_stemcell?).
                   with(anything, stemcell_id).
                   and_return(true)
-                allow(stemcell_manager).to receive(:get_stemcell_uri).
+                allow(stemcell_manager).to receive(:get_stemcell_info).
                   with(anything, stemcell_id).
-                  and_return(stemcell_uri)
+                  and_return(stemcell_info)
             end
 
             context 'without storage_account_max_disk_number' do

--- a/src/bosh_azure_cpi/spec/unit/helpers_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/helpers_spec.rb
@@ -557,4 +557,46 @@ describe Bosh::AzureCloud::Helpers do
       end
     end
   end
+
+  describe "StemcellInfo" do
+    context "when metadata is not empty" do
+      let(:uri) { "fake-uri" }
+      let(:metadata) {
+        {
+          "name" => "fake-name",
+          "version" => "fake-version",
+          "infrastructure" => "azure",
+          "hypervisor" => "hyperv",
+          "disk" => "3072",
+          "disk_format" => "vhd",
+          "container_format" => "bare",
+          "os_type" => "linux",
+          "os_distro" => "ubuntu",
+          "architecture" => "x86_64",
+        }
+      }
+
+      it "should return correct values" do
+        stemcell_info = Bosh::AzureCloud::Helpers::StemcellInfo.new(uri, metadata)
+        expect(stemcell_info.uri).to eq("fake-uri")
+        expect(stemcell_info.os_type).to eq("linux")
+        expect(stemcell_info.name).to eq("fake-name")
+        expect(stemcell_info.version).to eq("fake-version")
+        expect(stemcell_info.disk_size).to eq(3072)
+      end
+    end
+
+    context "when metadata is empty" do
+      let(:uri) { "fake-uri" }
+      let(:metadata) { {} }
+      it "should return correct values" do
+        stemcell_info = Bosh::AzureCloud::Helpers::StemcellInfo.new(uri, metadata)
+        expect(stemcell_info.uri).to eq("fake-uri")
+        expect(stemcell_info.os_type).to eq('linux')
+        expect(stemcell_info.name).to be(nil)
+        expect(stemcell_info.version).to be(nil)
+        expect(stemcell_info.disk_size).to eq(3072)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Originally, `os_type` of a VM was hard coded as `linux`. From now on, we will get the value from `cloud_properties` of stemcells.

This PR has these changes:
1. when creating a stemcell, put `cloud_properties`(including `os_type`) of it to `metadata` of the blob. 
1. when creating a VM, get `os_type` from `metadata` of the stemcell blob, and use this value for parameter of the VM.
1. for existed stemcell which does not have metadata, `os_type`  has default value `linux`.