### PR TITLE
Auto retry when the connection to Azure AD or ARM is reset because of OpenSSL::SSL::SSLError or OpenSSL::X509::StoreError.

### DIFF
--- a/src/bosh_azure_cpi/lib/cloud/azure/azure_client2.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/azure_client2.rb
@@ -1269,25 +1269,17 @@ module Bosh::AzureCloud
           request.each_header { |k,v| @logger.debug("\t#{k} = #{v}") }
 
           response = http(uri).request(request)
-        rescue Net::OpenTimeout => e
+        rescue Net::OpenTimeout, Net::ReadTimeout, Errno::ECONNRESET => e
           if retry_count < AZURE_MAX_RETRY_COUNT
-            @logger.warn("get_token - Fail for an OpenTimeout. Will retry after #{retry_after} seconds.")
+            @logger.warn("get_token - Fail for an error #{e.class.name}. Will retry after #{retry_after} seconds.")
             retry_count += 1
             sleep(retry_after)
             retry
           end
           raise e
-        rescue Net::ReadTimeout => e
-          if retry_count < AZURE_MAX_RETRY_COUNT
-            @logger.warn("get_token - Fail for a ReadTimeout. Will retry after #{retry_after} seconds.")
-            retry_count += 1
-            sleep(retry_after)
-            retry
-          end
-          raise e
-        rescue Errno::ECONNRESET => e
-          if retry_count < AZURE_MAX_RETRY_COUNT
-            @logger.warn("get_token - Fail for an ECONNRESET. Will retry after #{retry_after} seconds.")
+        rescue OpenSSL::SSL::SSLError, OpenSSL::X509::StoreError => e
+          if retry_count < AZURE_MAX_RETRY_COUNT && e.inspect.include?(ERROR_OPENSSL_RESET)
+            @logger.warn("get_token - Fail for an error #{e.class.name}. Will retry after #{retry_after} seconds.")
             retry_count += 1
             sleep(retry_after)
             retry
@@ -1295,7 +1287,7 @@ module Bosh::AzureCloud
           raise e
         rescue => e
           # Below error message depends on require "resolv-replace.rb" in lib/cloud/azure.rb
-          if e.inspect.include?('SocketError: Hostname not known') && retry_count < AZURE_MAX_RETRY_COUNT
+          if e.inspect.include?(ERROR_SOCKET_UNKNOWN_HOSTNAME) && retry_count < AZURE_MAX_RETRY_COUNT
             @logger.warn("get_token - Fail for a DNS resolve error. Will retry after #{retry_after} seconds.")
             retry_count += 1
             sleep(retry_after)
@@ -1390,37 +1382,21 @@ module Bosh::AzureCloud
           retry
         end
         raise e
-      rescue AzureInternalError => e
-        if retry_count < AZURE_MAX_RETRY_COUNT
-          @logger.warn("http_get_response - Fail for an AzureInternalError. Will retry after #{retry_after} seconds.")
-          retry_count += 1
-          sleep(retry_after)
-          retry
-        end
-        raise e
       rescue AzureAsynInternalError => e
         @logger.warn("http_get_response - Fail for an AzureAsynInternalError. Will retry after #{retry_after} seconds.")
         sleep(retry_after)
         raise e
-      rescue Net::OpenTimeout => e
+      rescue AzureInternalError, Net::OpenTimeout, Net::ReadTimeout, Errno::ECONNRESET => e
         if retry_count < AZURE_MAX_RETRY_COUNT
-          @logger.warn("http_get_response - Fail for an OpenTimeout. Will retry after #{retry_after} seconds.")
+          @logger.warn("http_get_response - Fail for an error #{e.class.name}. Will retry after #{retry_after} seconds.")
           retry_count += 1
           sleep(retry_after)
           retry
         end
         raise e
-      rescue Net::ReadTimeout => e
-        if retry_count < AZURE_MAX_RETRY_COUNT
-          @logger.warn("http_get_response - Fail for a ReadTimeout. Will retry after #{retry_after} seconds.")
-          retry_count += 1
-          sleep(retry_after)
-          retry
-        end
-        raise e
-      rescue Errno::ECONNRESET => e
-        if retry_count < AZURE_MAX_RETRY_COUNT
-          @logger.warn("http_get_response - Fail for an ECONNRESET. Will retry after #{retry_after} seconds.")
+      rescue OpenSSL::SSL::SSLError, OpenSSL::X509::StoreError => e
+        if retry_count < AZURE_MAX_RETRY_COUNT && e.inspect.include?(ERROR_OPENSSL_RESET)
+          @logger.warn("http_get_response - Fail for an error #{e.class.name}. Will retry after #{retry_after} seconds.")
           retry_count += 1
           sleep(retry_after)
           retry
@@ -1428,7 +1404,7 @@ module Bosh::AzureCloud
         raise e
       rescue => e
         # Below error message depends on require "resolv-replace.rb" in lib/cloud/azure.rb
-        if e.inspect.include?('SocketError: Hostname not known') && retry_count < AZURE_MAX_RETRY_COUNT
+        if e.inspect.include?(ERROR_SOCKET_UNKNOWN_HOSTNAME) && retry_count < AZURE_MAX_RETRY_COUNT
           @logger.warn("http_get_response - Fail for a DNS resolve error. Will retry after #{retry_after} seconds.")
           retry_count += 1
           sleep(retry_after)

--- a/src/bosh_azure_cpi/lib/cloud/azure/helpers.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/helpers.rb
@@ -61,6 +61,10 @@ module Bosh::AzureCloud
     DISK_CONTAINER            = 'bosh'
     STEMCELL_CONTAINER        = 'stemcell'
 
+    # REST Connection Errors
+    ERROR_OPENSSL_RESET           = 'SSL_connect'
+    ERROR_SOCKET_UNKNOWN_HOSTNAME = 'SocketError: Hostname not known'
+
     ##
     # Raises CloudError exception
     #

--- a/src/bosh_azure_cpi/spec/spec_helper.rb
+++ b/src/bosh_azure_cpi/spec/spec_helper.rb
@@ -21,6 +21,8 @@ AZURE_STACK_API_VERSION = '2015-05-01-preview'
 AZURE_CHINA_API_VERSION = '2015-06-15'
 AZURE_USGOV_API_VERSION = '2015-06-15'
 
+ERROR_MSG_OPENSSL_RESET = 'Connection reset by peer - SSL_connect'
+
 def mock_cloud_options
   {
     'plugin' => 'azure',

--- a/src/bosh_azure_cpi/spec/unit/azure_client2/attach_disk_to_virtual_machine_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client2/attach_disk_to_virtual_machine_spec.rb
@@ -24,7 +24,7 @@ describe Bosh::AzureCloud::AzureClient2 do
   let(:tags) { {} }
 
   let(:valid_access_token) { "valid-access-token" }
-  let(:invalid_access_token) { "invalid-access-token" }
+
   let(:expires_on) { (Time.now+1800).to_i.to_s }
 
   describe "#attach_disk_to_virtual_machine" do

--- a/src/bosh_azure_cpi/spec/unit/azure_client2/create_load_balancer_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client2/create_load_balancer_spec.rb
@@ -21,7 +21,7 @@ describe Bosh::AzureCloud::AzureClient2 do
   let(:operation_status_link) { "https://management.azure.com/subscriptions/#{subscription_id}/operations/#{request_id}" }
 
   let(:valid_access_token) { "valid-access-token" }
-  let(:invalid_access_token) { "invalid-access-token" }
+
   let(:expires_on) { (Time.now+1800).to_i.to_s }
 
   let(:load_balancer_name) { "fake-load-balancer-name" }

--- a/src/bosh_azure_cpi/spec/unit/azure_client2/create_network_interface_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client2/create_network_interface_spec.rb
@@ -21,7 +21,7 @@ describe Bosh::AzureCloud::AzureClient2 do
   let(:operation_status_link) { "https://management.azure.com/subscriptions/#{subscription_id}/operations/#{request_id}" }
 
   let(:valid_access_token) { "valid-access-token" }
-  let(:invalid_access_token) { "invalid-access-token" }
+
   let(:expires_on) { (Time.now+1800).to_i.to_s }
 
   let(:nic_name) { "fake-nic-name" }

--- a/src/bosh_azure_cpi/spec/unit/azure_client2/create_public_ip_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client2/create_public_ip_spec.rb
@@ -22,7 +22,7 @@ describe Bosh::AzureCloud::AzureClient2 do
 
   let(:public_ip_name) { "fake-public-ip-name" }
   let(:valid_access_token) { "valid-access-token" }
-  let(:invalid_access_token) { "invalid-access-token" }
+
   let(:expires_on) { (Time.now+1800).to_i.to_s }
 
   describe "#create_public_ip" do

--- a/src/bosh_azure_cpi/spec/unit/azure_client2/create_virtual_machine_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client2/create_virtual_machine_spec.rb
@@ -22,7 +22,7 @@ describe Bosh::AzureCloud::AzureClient2 do
 
   let(:vm_name) { "fake-vm-name" }
   let(:valid_access_token) { "valid-access-token" }
-  let(:invalid_access_token) { "invalid-access-token" }
+
   let(:expires_on) { (Time.now+1800).to_i.to_s }
 
   describe "#create_virtual_machine" do

--- a/src/bosh_azure_cpi/spec/unit/azure_client2/delete_load_balancer_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client2/delete_load_balancer_spec.rb
@@ -21,7 +21,7 @@ describe Bosh::AzureCloud::AzureClient2 do
   let(:operation_status_link) { "https://management.azure.com/subscriptions/#{subscription_id}/operations/#{request_id}" }
 
   let(:valid_access_token) { "valid-access-token" }
-  let(:invalid_access_token) { "invalid-access-token" }
+
   let(:expires_on) { (Time.now+1800).to_i.to_s }
 
   let(:load_balancer_name) { "fake-load-balancer-name" }

--- a/src/bosh_azure_cpi/spec/unit/azure_client2/delete_network_interface_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client2/delete_network_interface_spec.rb
@@ -21,7 +21,7 @@ describe Bosh::AzureCloud::AzureClient2 do
   let(:operation_status_link) { "https://management.azure.com/subscriptions/#{subscription_id}/operations/#{request_id}" }
 
   let(:valid_access_token) { "valid-access-token" }
-  let(:invalid_access_token) { "invalid-access-token" }
+
   let(:expires_on) { (Time.now+1800).to_i.to_s }
 
   let(:nic_name) { "fake-nic-name" }

--- a/src/bosh_azure_cpi/spec/unit/azure_client2/delete_public_ip_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client2/delete_public_ip_spec.rb
@@ -20,7 +20,7 @@ describe Bosh::AzureCloud::AzureClient2 do
 
   let(:public_ip_name) { "fake-public-ip-name" }
   let(:valid_access_token) { "valid-access-token" }
-  let(:invalid_access_token) { "invalid-access-token" }
+
   let(:expires_on) { (Time.now+1800).to_i.to_s }
 
   describe "#delete_public_ip" do

--- a/src/bosh_azure_cpi/spec/unit/azure_client2/delete_virtual_machine_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client2/delete_virtual_machine_spec.rb
@@ -22,7 +22,7 @@ describe Bosh::AzureCloud::AzureClient2 do
 
   let(:vm_name) { "fake-vm-name" }
   let(:valid_access_token) { "valid-access-token" }
-  let(:invalid_access_token) { "invalid-access-token" }
+
   let(:expires_on) { (Time.now+1800).to_i.to_s }
 
   describe "#delete_virtual_machine" do

--- a/src/bosh_azure_cpi/spec/unit/azure_client2/detach_disk_from_virtual_machine_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client2/detach_disk_from_virtual_machine_spec.rb
@@ -24,7 +24,7 @@ describe Bosh::AzureCloud::AzureClient2 do
   let(:tags) { {} }
 
   let(:valid_access_token) { "valid-access-token" }
-  let(:invalid_access_token) { "invalid-access-token" }
+
   let(:expires_on) { (Time.now+1800).to_i.to_s }
 
   describe "#detach_disk_to_virtual_machine" do

--- a/src/bosh_azure_cpi/spec/unit/azure_client2/restart_virtual_machine_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client2/restart_virtual_machine_spec.rb
@@ -22,7 +22,7 @@ describe Bosh::AzureCloud::AzureClient2 do
 
   let(:vm_name) { "fake-vm-name" }
   let(:valid_access_token) { "valid-access-token" }
-  let(:invalid_access_token) { "invalid-access-token" }
+
   let(:expires_on) { (Time.now+1800).to_i.to_s }
 
   describe "#restart_virtual_machine" do

--- a/src/bosh_azure_cpi/spec/unit/azure_client2/update_tags_of_virtual_machine_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client2/update_tags_of_virtual_machine_spec.rb
@@ -21,7 +21,7 @@ describe Bosh::AzureCloud::AzureClient2 do
   let(:tags) { 'fake-tags' }
 
   let(:valid_access_token) { "valid-access-token" }
-  let(:invalid_access_token) { "invalid-access-token" }
+
   let(:expires_on) { (Time.now+1800).to_i.to_s }
 
   describe "#update_tags_of_virtual_machine" do


### PR DESCRIPTION
Auto retry when the connection to Azure AD or ARM is reset because of OpenSSL::SSL::SSLError or OpenSSL::X509::StoreError. #234 