### PR TITLE
Add the sku property only when using managed disk

### DIFF
--- a/src/bosh_azure_cpi/lib/cloud/azure/azure_client2.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/azure_client2.rb
@@ -533,16 +533,16 @@ module Bosh::AzureCloud
         'type'       => "#{REST_API_PROVIDER_COMPUTE}/#{REST_API_COMPUTE_AVAILABILITY_SETS}",
         'location'   => params[:location],
         'tags'       => params[:tags],
-        'sku'        => {
-          'name' => 'Classic'
-        },
         'properties' => {
           'platformUpdateDomainCount' => params[:platform_update_domain_count],
           'platformFaultDomainCount'  => params[:platform_fault_domain_count]
         }
       }
-      if !params[:managed].nil? && params[:managed] == true
-        availability_set['sku']['name'] = 'Aligned'
+
+      if params[:managed]
+        availability_set['sku'] = {
+          'name' => 'Aligned'
+        }
       end
 
       http_put(url, availability_set)
@@ -577,10 +577,9 @@ module Bosh::AzureCloud
         availability_set[:location] = result['location']
         availability_set[:tags]     = result['tags']
 
-        if result['sku']['name'] == 'Aligned'
-          availability_set[:managed] = true
-        else
-          availability_set[:managed] = false
+        availability_set[:managed] = false
+        unless result['sku'].nil?
+          availability_set[:managed] = true if result['sku']['name'] == 'Aligned'
         end
 
         properties = result['properties']


### PR DESCRIPTION
- [x] Please check this box once you have run the unit tests
  ```
  pushd src/bosh_azure_cpi
    bundle install
    bundle exec rspec spec/unit/*
  popd
  ```

### Changelog

* Add the sku property to the availability set only when using managed disk, since the sku property is not supported in `AzureChinaCloud` with the api-version `2015-06-15`.
