### PR TITLE
Fixes on the storage account and refinement of user images

### DIFF
--- a/src/bosh_azure_cpi/lib/cloud/azure/azure_client2.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/azure_client2.rb
@@ -1432,6 +1432,7 @@ module Bosh::AzureCloud
         storage_account[:id]        = result['id']
         storage_account[:name]      = result['name']
         storage_account[:location]  = result['location']
+        storage_account[:tags]      = result['tags']
 
         properties = result['properties']
         storage_account[:provisioning_state] = properties['provisioningState']

--- a/src/bosh_azure_cpi/lib/cloud/azure/blob_manager.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/blob_manager.rb
@@ -256,13 +256,13 @@ module Bosh::AzureCloud
       end
     end
 
-    def prepare(storage_account_name, containers: [DISK_CONTAINER, STEMCELL_CONTAINER])
+    def prepare(storage_account_name, containers: [DISK_CONTAINER, STEMCELL_CONTAINER], is_default_storage_account: false)
       @logger.info("prepare(#{storage_account_name}, #{containers})")
       containers.each do |container|
         @logger.debug("Creating the container `#{container}' in the storage account `#{storage_account_name}'")
         create_container(storage_account_name, container)
       end
-      set_stemcell_container_acl_to_public(storage_account_name)
+      set_stemcell_container_acl_to_public(storage_account_name) if is_default_storage_account
     end
 
     private

--- a/src/bosh_azure_cpi/lib/cloud/azure/cloud.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/cloud.rb
@@ -124,8 +124,12 @@ module Bosh::AzureCloud
           else
             location = @azure_client2.get_resource_group()[:location]
           end
-          # Treat user_image_info as stemcell_info
-          stemcell_info = @stemcell_manager2.get_user_image_info(stemcell_id, storage_account_type, location)
+          begin
+            # Treat user_image_info as stemcell_info
+            stemcell_info = @stemcell_manager2.get_user_image_info(stemcell_id, storage_account_type, location)
+          rescue => e
+            raise Bosh::Clouds::VMCreationFailed.new(false), "Failed to get the user image information for the stemcell `#{stemcell_id}': #{e.inspect}\n#{e.backtrace.join("\n")}"
+          end
         else
           storage_account = @storage_account_manager.get_storage_account_from_resource_pool(resource_pool)
           unless @stemcell_manager.has_stemcell?(storage_account[:name], stemcell_id)

--- a/src/bosh_azure_cpi/lib/cloud/azure/stemcell_manager2.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/stemcell_manager2.rb
@@ -88,8 +88,7 @@ module Bosh::AzureCloud
               @storage_account_manager.create_storage_account(storage_account_name, storage_account_type, location, STEMCELL_STORAGE_ACCOUNT_TAGS)
             end
           rescue => e
-            raise "Failed to finish the creation of the storage account `#{storage_account_name}', `#{storage_account_type}' in location `#{location}' in 60 seconds." if e.message == BOSH_LOCK_EXCEPTION_TIMEOUT
-            raise e.inspect
+            cloud_error("Failed to finish the creation of the storage account `#{storage_account_name}', `#{storage_account_type}' in location `#{location}' in 60 seconds.") if e.message == BOSH_LOCK_EXCEPTION_TIMEOUT
           end
         else
           storage_account_name = storage_account[:name]
@@ -107,8 +106,7 @@ module Bosh::AzureCloud
             end
           end
         rescue => e
-          raise "Failed to finish the copying process of the stemcell `#{stemcell_name}' from the default storage account `#{default_storage_account_name}' to the storage acccount `#{storage_account_name}' in `#{BOSH_LOCK_COPY_STEMCELL_TIMEOUT}' seconds." if e.message == BOSH_LOCK_EXCEPTION_TIMEOUT
-          raise e.inspect
+          cloud_error("Failed to finish the copying process of the stemcell `#{stemcell_name}' from the default storage account `#{default_storage_account_name}' to the storage acccount `#{storage_account_name}' in `#{BOSH_LOCK_COPY_STEMCELL_TIMEOUT}' seconds.") if e.message == BOSH_LOCK_EXCEPTION_TIMEOUT
         end
       end
 

--- a/src/bosh_azure_cpi/lib/cloud/azure/storage_account_manager.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/storage_account_manager.rb
@@ -13,7 +13,7 @@ module Bosh::AzureCloud
       @default_storage_account = nil
     end
 
-    def create_storage_account(storage_account_name, storage_account_type, storage_account_location = nil, tags = {})
+    def create_storage_account(storage_account_name, storage_account_type, storage_account_location = nil, tags = {}, is_default_storage_account = false)
       @logger.debug("create_storage_account(#{storage_account_name}, #{storage_account_type}, #{storage_account_location}, #{tags})")
 
       created = false
@@ -44,7 +44,7 @@ module Bosh::AzureCloud
           end
           created = @azure_client2.create_storage_account(storage_account_name, location, storage_account_type, tags)
         end
-        @blob_manager.prepare(storage_account_name)
+        @blob_manager.prepare(storage_account_name, is_default_storage_account: is_default_storage_account)
         true
       rescue => e
         error_msg = "create_storage_account - "
@@ -177,7 +177,7 @@ module Bosh::AzureCloud
       @logger.debug("Cannot find any valid storage account in the location `#{location}'")
       storage_account_name = "#{SecureRandom.hex(12)}"
       @logger.debug("Creating a storage account `#{storage_account_name}' with the tags `#{STEMCELL_STORAGE_ACCOUNT_TAGS}' in the location `#{location}'")
-      create_storage_account(storage_account_name, STORAGE_ACCOUNT_TYPE_STANDARD_LRS, location, STEMCELL_STORAGE_ACCOUNT_TAGS)
+      create_storage_account(storage_account_name, STORAGE_ACCOUNT_TYPE_STANDARD_LRS, location, STEMCELL_STORAGE_ACCOUNT_TAGS, true)
       @logger.debug("The default storage account is `#{storage_account_name}'")
       @default_storage_account = @azure_client2.get_storage_account_by_name(storage_account_name)
     end

--- a/src/bosh_azure_cpi/lib/cloud/azure/storage_account_manager.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/storage_account_manager.rb
@@ -7,6 +7,7 @@ module Bosh::AzureCloud
       @blob_manager  = blob_manager
       @disk_manager  = disk_manager
       @azure_client2 = azure_client2
+      @use_managed_disks = @azure_properties['use_managed_disks']
       @logger = Bosh::Clouds::Config.logger
 
       @default_storage_account_name = nil
@@ -136,6 +137,9 @@ module Bosh::AzureCloud
         storage_account_name = @azure_properties['storage_account_name']
         @logger.debug("The default storage account is `#{storage_account_name}'")
         @default_storage_account = @azure_client2.get_storage_account_by_name(storage_account_name)
+        if @use_managed_disks && !is_stemcell_storage_account?(@default_storage_account[:tags])
+          @azure_client2.update_tags_of_storage_account(storage_account_name, STEMCELL_STORAGE_ACCOUNT_TAGS)
+        end
         return @default_storage_account
       end
 

--- a/src/bosh_azure_cpi/spec/spec_helper.rb
+++ b/src/bosh_azure_cpi/spec/spec_helper.rb
@@ -28,6 +28,11 @@ AZURE_GERMAN_API_VERSION = '2015-06-15'
 
 ERROR_MSG_OPENSSL_RESET = 'Connection reset by peer - SSL_connect'
 
+STEMCELL_STORAGE_ACCOUNT_TAGS = {
+  'user-agent' => 'bosh',
+  'type' => 'stemcell'
+}
+
 def mock_cloud_options
   {
     'plugin' => 'azure',

--- a/src/bosh_azure_cpi/spec/unit/azure_client2/get_operation_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client2/get_operation_spec.rb
@@ -672,6 +672,9 @@ describe Bosh::AzureCloud::AzureClient2 do
               "id" => "fake-id",
               "name" => "fake-name",
               "location" => "fake-location",
+              "tags" => {
+                "foo" => "bar"
+              },
               "properties" => {
                 "provisioningState" => "fake-state",
                 "accountType" => "fake-type",
@@ -687,6 +690,9 @@ describe Bosh::AzureCloud::AzureClient2 do
               :id => "fake-id",
               :name => "fake-name",
               :location => "fake-location",
+              :tags => {
+                "foo" => "bar"
+              },
               :provisioning_state => "fake-state",
               :account_type => "fake-type",
               :storage_blob_host => "fake-blob-endpoint",
@@ -718,6 +724,9 @@ describe Bosh::AzureCloud::AzureClient2 do
               "id" => "fake-id",
               "name" => "fake-name",
               "location" => "fake-location",
+              "tags" => {
+                "foo" => "bar"
+              },
               "properties" => {
                 "provisioningState" => "fake-state",
                 "accountType" => "fake-type",
@@ -732,6 +741,9 @@ describe Bosh::AzureCloud::AzureClient2 do
               :id => "fake-id",
               :name => "fake-name",
               :location => "fake-location",
+              :tags => {
+                "foo" => "bar"
+              },
               :provisioning_state => "fake-state",
               :account_type => "fake-type",
               :storage_blob_host => "fake-blob-endpoint"

--- a/src/bosh_azure_cpi/spec/unit/blob_manager_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/blob_manager_spec.rb
@@ -605,59 +605,32 @@ describe Bosh::AzureCloud::BlobManager do
         :storage_table_host => "fake-table-endpoint"
       }
     }
+
     before do
       allow(azure_client2).to receive(:get_storage_account_by_name).
         with(another_storage_account_name).
         and_return(another_storage_account)
     end
 
-    context "when the container exists" do
-      before do
-        allow(blob_service).to receive(:create_container).
-          and_raise("ContainerAlreadyExists")
-      end
-
-      it "does not create the container" do
+    context "when the storage account is default storage account" do
+      it "creates the container, and set the acl" do
         expect(blob_service).to receive(:create_container).
           with(container_name, options).
           and_return(true)
-        expect(blob_service).to receive(:set_container_acl).
-          with(anything, 'blob', options)
+        expect(blob_service).to receive(:set_container_acl).with('stemcell', 'blob', options)
 
-        blob_manager.prepare(another_storage_account_name, containers: [container_name])
+        blob_manager.prepare(another_storage_account_name, containers: [container_name], is_default_storage_account: true)
       end
     end
 
-    context "when the container does not exist" do
-      before do
-        allow(blob_service).to receive(:get_container_properties).
-          and_raise("Error code: (404). This is a test!")
-      end
-
-      it "create the container" do
+    context "when the storage account is not default storage account" do
+      it "creates the container, and doesn't set the acl" do
         expect(blob_service).to receive(:create_container).
           with(container_name, options).
           and_return(true)
-        expect(blob_service).to receive(:set_container_acl).
-          with(anything, 'blob', options)
+        expect(blob_service).not_to receive(:set_container_acl)
 
         blob_manager.prepare(another_storage_account_name, containers: [container_name])
-      end
-    end
-
-    context "when the blob service throws an error" do
-      before do
-        allow(blob_service).to receive(:get_container_properties).
-          and_raise("Error code: (404). This is a test!")
-        allow(blob_service).to receive(:create_container).
-          with(container_name, options)
-        allow(blob_service).to receive(:set_container_acl).and_raise(StandardError)
-      end
-
-      it "should fail to set the ACL of the stemcell container to public" do
-        expect {
-          blob_manager.prepare(another_storage_account_name, containers: [container_name])
-        }.to raise_error /Failed to set the public access level/
       end
     end
   end

--- a/src/bosh_azure_cpi/spec/unit/cloud_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/cloud_spec.rb
@@ -165,6 +165,27 @@ describe Bosh::AzureCloud::Cloud do
         end
       end
 
+      context 'when it failed to get the user image info' do
+        let(:cloud) { mock_cloud(mock_cloud_properties_merge({'azure' => {'use_managed_disks' => true}})) }
+        before do
+          allow(client2).to receive(:get_resource_group).and_return({:location => 'fake-location'})
+          allow(stemcell_manager2).to receive(:get_user_image_info).and_raise(StandardError)
+        end
+
+        it 'should raise an error' do
+          expect {
+            cloud.create_vm(
+              agent_id,
+              stemcell_id,
+              resource_pool,
+              networks_spec,
+              disk_locality,
+              environment
+            )
+          }.to raise_error(/Failed to get the user image information for the stemcell `#{stemcell_id}'/)
+        end
+      end
+
       context 'when stemcell_id is invalid' do
         before do
           allow(stemcell_manager).to receive(:has_stemcell?).

--- a/src/bosh_azure_cpi/spec/unit/stemcell_manager2_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/stemcell_manager2_spec.rb
@@ -120,6 +120,7 @@ describe Bosh::AzureCloud::StemcellManager2 do
       end
 
       it "should return the user image information" do
+        expect(storage_account_manager).not_to receive(:default_storage_account)
         stemcell_info = stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location)
         expect(stemcell_info.uri).to eq(user_image_id)
         expect(stemcell_info.metadata).to eq(tags)
@@ -127,12 +128,6 @@ describe Bosh::AzureCloud::StemcellManager2 do
     end
 
     context "when the user image doesn't exist" do
-      before do
-        allow(client2).to receive(:get_user_image_by_name).
-          with(user_image_name).
-          and_return(nil)
-      end
-
       context "when the stemcell doesn't exist in the default storage account" do
         let(:default_storage_account) {
           {
@@ -141,6 +136,9 @@ describe Bosh::AzureCloud::StemcellManager2 do
         }
 
         before do
+          allow(client2).to receive(:get_user_image_by_name).
+            with(user_image_name).
+            and_return(nil)
           allow(storage_account_manager).to receive(:default_storage_account).
             and_return(default_storage_account)
           allow(blob_manager).to receive(:get_blob_properties).
@@ -155,43 +153,48 @@ describe Bosh::AzureCloud::StemcellManager2 do
       end
 
       context "when the stemcell exists in the default storage account" do
-        before do
-          allow(blob_manager).to receive(:get_blob_properties).
-            and_return({"foo" => "bar"}) # The blob properties are not nil, which means the stemcell exists
-        end
-
         let(:stemcell_container) { 'stemcell' }
         let(:stemcell_blob_uri) { 'fake-blob-url' }
         let(:stemcell_blob_metadata) { { "foo" => "bar" } }
+        let(:user_image) {
+          {
+            :id => user_image_id,
+            :tags => tags,
+            :provisioning_state => "Succeeded"
+          }
+        }
 
         before do
-          allow(blob_manager).to receive(:get_blob_uri).
-            with(MOCK_DEFAULT_STORAGE_ACCOUNT_NAME, stemcell_container, "#{stemcell_name}.vhd").
-            and_return(stemcell_blob_uri)
-          allow(blob_manager).to receive(:get_blob_metadata).
-            with(MOCK_DEFAULT_STORAGE_ACCOUNT_NAME, stemcell_container, "#{stemcell_name}.vhd").
-            and_return(stemcell_blob_metadata)
-          allow(client2).to receive(:create_user_image)
           allow(client2).to receive(:get_user_image_by_name).
             with(user_image_name).
-            and_return(user_image)
+            and_return(nil, user_image) # The first return value nil means the user image doesn't exist, the second one user_image is returned after the image is created.
+          allow(blob_manager).to receive(:get_blob_properties).
+            with(MOCK_DEFAULT_STORAGE_ACCOUNT_NAME, stemcell_container, "#{stemcell_name}.vhd").
+            and_return({"foo" => "bar"}) # The stemcell exists in the default storage account
+          allow(client2).to receive(:create_user_image)
         end
 
         context "when the location of the default storage account is the targeted location" do
           let(:default_storage_account) {
             {
               :name => MOCK_DEFAULT_STORAGE_ACCOUNT_NAME,
-              :location => "SoutheastAsia"
+              :location => location
             }
           }
 
           before do
             allow(storage_account_manager).to receive(:default_storage_account).
               and_return(default_storage_account)
+            allow(blob_manager).to receive(:get_blob_uri).
+              with(MOCK_DEFAULT_STORAGE_ACCOUNT_NAME, stemcell_container, "#{stemcell_name}.vhd").
+              and_return(stemcell_blob_uri)
+            allow(blob_manager).to receive(:get_blob_metadata).
+              with(MOCK_DEFAULT_STORAGE_ACCOUNT_NAME, stemcell_container, "#{stemcell_name}.vhd").
+              and_return(stemcell_blob_metadata)
           end
 
-
           it "should get the stemcell from the default storage account, create a new user image and return the user image information" do
+            expect(client2).not_to receive(:list_storage_accounts)
             stemcell_info = stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location)
             expect(stemcell_info.uri).to eq(user_image_id)
             expect(stemcell_info.metadata).to eq(tags)
@@ -202,35 +205,241 @@ describe Bosh::AzureCloud::StemcellManager2 do
           let(:default_storage_account) {
             {
               :name => MOCK_DEFAULT_STORAGE_ACCOUNT_NAME,
-              :location => "SoutheastAsia-different"
+              :location => "#{location}-different"
             }
-          }
-          let(:storage_accounts) {
-            [
-              {
-                :name => "foo",
-                :location => "SoutheastAsia",
-                :tags => {
-                  "user-agent" => "bosh",
-                  "type" => "stemcell"
-                }
-              }
-            ]
           }
 
           before do
             allow(storage_account_manager).to receive(:default_storage_account).
               and_return(default_storage_account)
-            allow(client2).to receive(:list_storage_accounts).
-              and_return(storage_accounts)
           end
 
-          it "should get the stemcell from another storage account, create a new user image and return the user image information" do
-            # TODO: Mock the file mutex
+          context "when the storage account with tags exists in the specified location" do
+            let(:existing_storage_account_name) { "existing-storage-account-name-other-than-default-storage-account" }
+            let(:storage_accounts) {
+              [
+                {
+                  :name => existing_storage_account_name,
+                  :location => location,
+                  :tags => STEMCELL_STORAGE_ACCOUNT_TAGS
+                }
+              ]
+            }
+            before do
+              allow(client2).to receive(:list_storage_accounts).and_return(storage_accounts)
+              # The following two allows are for get_stemcell_info of stemcell_manager.rb
+              allow(blob_manager).to receive(:get_blob_uri).
+                with(existing_storage_account_name, stemcell_container, "#{stemcell_name}.vhd").
+                and_return(stemcell_blob_uri)
+              allow(blob_manager).to receive(:get_blob_metadata).
+                with(existing_storage_account_name, stemcell_container, "#{stemcell_name}.vhd").
+                and_return(stemcell_blob_metadata)
+            end
 
-            stemcell_info = stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location)
-            expect(stemcell_info.uri).to eq(user_image_id)
-            expect(stemcell_info.metadata).to eq(tags)
+            context "when the stemcell exists in the exising storage account" do
+              before do
+                allow(blob_manager).to receive(:get_blob_properties).
+                  with(existing_storage_account_name, stemcell_container, "#{stemcell_name}.vhd").
+                  and_return({"foo"=>"bar"}) # The stemcell exists in the existing storage account
+              end
+
+              it "should create a new user image and return the user image information" do
+                expect(blob_manager).not_to receive(:get_blob_uri).
+                  with(MOCK_DEFAULT_STORAGE_ACCOUNT_NAME, stemcell_container, "#{stemcell_name}.vhd")
+                expect(blob_manager).not_to receive(:copy_blob)
+                stemcell_info = stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location)
+                expect(stemcell_info.uri).to eq(user_image_id)
+                expect(stemcell_info.metadata).to eq(tags)
+              end
+            end
+
+            context "when the stemcell doesn't exist in the exising storage account" do
+              before do
+                allow(blob_manager).to receive(:get_blob_properties).
+                  with(existing_storage_account_name, stemcell_container, "#{stemcell_name}.vhd").
+                  and_return(nil) # The stemcell doesn't exist in the existing storage account
+              end
+
+              after do
+                File.delete('/tmp/bosh-lock-copy-stemcell') if File.exists?('/tmp/bosh-lock-copy-stemcell')
+              end
+
+              it "should copy the stemcell from default storage account to an existing storage account, create a new user image and return the user image information" do
+                expect(blob_manager).to receive(:get_blob_uri).
+                  with(MOCK_DEFAULT_STORAGE_ACCOUNT_NAME, stemcell_container, "#{stemcell_name}.vhd").
+                  and_return(stemcell_blob_uri)
+                expect(blob_manager).to receive(:copy_blob).
+                  with(existing_storage_account_name, stemcell_container, "#{stemcell_name}.vhd", stemcell_blob_uri)
+                stemcell_info = stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location)
+                expect(stemcell_info.uri).to eq(user_image_id)
+                expect(stemcell_info.metadata).to eq(tags)
+              end
+            end
+          end
+
+          context "when the storage account with doesn't exist in the specified location" do
+            let(:new_storage_account_name) { "new-storage-account-name" }
+            let(:storage_accounts) {
+              [
+                {
+                  :name => new_storage_account_name,
+                  :location => location,
+                  :tags => STEMCELL_STORAGE_ACCOUNT_TAGS
+                }
+              ]
+            }
+            before do
+              allow(client2).to receive(:list_storage_accounts).and_return(storage_accounts)
+              # The following two allows are for get_stemcell_info of stemcell_manager.rb
+              allow(blob_manager).to receive(:get_blob_uri).
+                with(new_storage_account_name, stemcell_container, "#{stemcell_name}.vhd").
+                and_return(stemcell_blob_uri)
+              allow(blob_manager).to receive(:get_blob_metadata).
+                with(new_storage_account_name, stemcell_container, "#{stemcell_name}.vhd").
+                and_return(stemcell_blob_metadata)
+              allow(blob_manager).to receive(:get_blob_properties).
+                with(new_storage_account_name, stemcell_container, "#{stemcell_name}.vhd").
+                and_return(nil) # The stemcell doesn't exist in the new storage account
+            end
+
+            after do
+              File.delete('/tmp/bosh-lock-copy-stemcell') if File.exists?('/tmp/bosh-lock-copy-stemcell')
+            end
+
+            it "should copy the stemcell from default storage account to the new storage account, create a new user image and return the user image information" do
+              expect(blob_manager).to receive(:get_blob_uri).
+                with(MOCK_DEFAULT_STORAGE_ACCOUNT_NAME, stemcell_container, "#{stemcell_name}.vhd").
+                and_return(stemcell_blob_uri)
+              expect(blob_manager).to receive(:copy_blob).
+                with(new_storage_account_name, stemcell_container, "#{stemcell_name}.vhd", stemcell_blob_uri)
+              stemcell_info = stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location)
+              expect(stemcell_info.uri).to eq(user_image_id)
+              expect(stemcell_info.metadata).to eq(tags)
+            end
+          end
+        end
+
+        context "Check whether user image is created" do
+          let(:default_storage_account) {
+            {
+              :name => MOCK_DEFAULT_STORAGE_ACCOUNT_NAME,
+              :location => location
+            }
+          }
+          before do
+            allow(client2).to receive(:create_user_image)
+            allow(storage_account_manager).to receive(:default_storage_account).
+              and_return(default_storage_account)
+            allow(blob_manager).to receive(:get_blob_properties).
+              with(MOCK_DEFAULT_STORAGE_ACCOUNT_NAME, stemcell_container, "#{stemcell_name}.vhd").
+              and_return({"foo" => "bar"}) # The stemcell exists in the default storage account
+            allow(blob_manager).to receive(:get_blob_uri).
+              with(MOCK_DEFAULT_STORAGE_ACCOUNT_NAME, stemcell_container, "#{stemcell_name}.vhd").
+              and_return(stemcell_blob_uri)
+            allow(blob_manager).to receive(:get_blob_metadata).
+              with(MOCK_DEFAULT_STORAGE_ACCOUNT_NAME, stemcell_container, "#{stemcell_name}.vhd").
+              and_return(stemcell_blob_metadata)
+          end
+
+          context "when user image can't be found" do
+            before do
+              allow(client2).to receive(:get_user_image_by_name).
+                with(user_image_name).
+                and_return(nil, nil) # The first return value nil means the user image doesn't exist, the others are returned after the image is created.
+            end
+
+            it "should raise an error" do
+              expect {
+                stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location)
+              }.to raise_error(/get_user_image: Can not find a user image with the name `#{user_image_name}'/)
+            end
+          end
+
+          context "when the provisioning state of user image is Succeeded finally" do
+            let(:user_image_in_progress) {
+              {
+                :id => user_image_id,
+                :tags => tags,
+                :provisioning_state => "InProgress"
+              }
+            }
+            let(:user_image_succeeded) {
+              {
+                :id => user_image_id,
+                :tags => tags,
+                :provisioning_state => "Succeeded"
+              }
+            }
+
+            before do
+              allow(client2).to receive(:get_user_image_by_name).
+                with(user_image_name).
+                and_return(nil, user_image_in_progress, user_image_in_progress, user_image_succeeded) # The first return value nil means the user image doesn't exist, the others are returned after the image is created.
+            end
+
+            it "should create a new user image and check the provisionging state" do
+              stemcell_info = stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location)
+              expect(stemcell_info.uri).to eq(user_image_id)
+              expect(stemcell_info.metadata).to eq(tags)
+            end
+          end
+
+          context "when the provisioning state of user image is Failed finally" do
+            let(:user_image_in_progress) {
+              {
+                :id => user_image_id,
+                :tags => tags,
+                :provisioning_state => "InProgress"
+              }
+            }
+            let(:user_image_failed) {
+              {
+                :id => user_image_id,
+                :tags => tags,
+                :provisioning_state => "Failed"
+              }
+            }
+
+            before do
+              allow(client2).to receive(:get_user_image_by_name).
+                with(user_image_name).
+                and_return(nil, user_image_in_progress, user_image_in_progress, user_image_failed) # The first return value nil means the user image doesn't exist, the others are returned after the image is created.
+            end
+
+            it "should raise an error" do
+              expect {
+                stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location)
+              }.to raise_error(/get_user_image: Failed to create a user image `#{user_image_name}' whose provisioning state is `Failed'/)
+            end
+          end
+
+          context "when the provisioning state of user image is Canceled finally" do
+            let(:user_image_in_progress) {
+              {
+                :id => user_image_id,
+                :tags => tags,
+                :provisioning_state => "InProgress"
+              }
+            }
+            let(:user_image_canceled) {
+              {
+                :id => user_image_id,
+                :tags => tags,
+                :provisioning_state => "Canceled"
+              }
+            }
+
+            before do
+              allow(client2).to receive(:get_user_image_by_name).
+                with(user_image_name).
+                and_return(nil, user_image_in_progress, user_image_in_progress, user_image_canceled) # The first return value nil means the user image doesn't exist, the others are returned after the image is created.
+            end
+
+            it "should raise an error" do
+              expect {
+                stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location)
+              }.to raise_error(/get_user_image: Failed to create a user image `#{user_image_name}' whose provisioning state is `Canceled'/)
+            end
           end
         end
       end

--- a/src/bosh_azure_cpi/spec/unit/storage_account_manager_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/storage_account_manager_spec.rb
@@ -46,8 +46,50 @@ describe Bosh::AzureCloud::StorageAccountManager do
       end
 
       it 'should create the storage account' do
-        allow(client2).to receive(:create_storage_account).with(storage_account_name, storage_account_location, storage_account_type, tags)
-        expect(blob_manager).to receive(:prepare).with(storage_account_name)
+        expect(client2).to receive(:create_storage_account).with(storage_account_name, storage_account_location, storage_account_type, tags)
+        expect(blob_manager).to receive(:prepare).with(storage_account_name, {:is_default_storage_account=>false})
+
+        expect(
+          storage_account_manager.create_storage_account(storage_account_name, storage_account_type, storage_account_location, tags)
+        ).to be(true)
+      end
+    end
+
+    context 'when the storage account is default storage account' do
+      let(:result) {
+        {
+          :available => true
+        }
+      }
+
+      before do
+        allow(client2).to receive(:check_storage_account_name_availability).with(storage_account_name).and_return(result)
+      end
+
+      it 'should create the storage account, and set the acl of the stemcell container to public' do
+        expect(client2).to receive(:create_storage_account).with(storage_account_name, storage_account_location, storage_account_type, tags)
+        expect(blob_manager).to receive(:prepare).with(storage_account_name, {:is_default_storage_account=>true})
+
+        expect(
+          storage_account_manager.create_storage_account(storage_account_name, storage_account_type, storage_account_location, tags, true)
+        ).to be(true)
+      end
+    end
+
+    context 'when the storage account is not default storage account' do
+      let(:result) {
+        {
+          :available => true
+        }
+      }
+
+      before do
+        allow(client2).to receive(:check_storage_account_name_availability).with(storage_account_name).and_return(result)
+      end
+
+      it 'should create the storage account, and do not set the acl' do
+        expect(client2).to receive(:create_storage_account).with(storage_account_name, storage_account_location, storage_account_type, tags)
+        expect(blob_manager).to receive(:prepare).with(storage_account_name, {:is_default_storage_account=>false})
 
         expect(
           storage_account_manager.create_storage_account(storage_account_name, storage_account_type, storage_account_location, tags)
@@ -76,8 +118,8 @@ describe Bosh::AzureCloud::StorageAccountManager do
       end
 
       it 'should create the storage account in the location of the resource group' do
-        allow(client2).to receive(:create_storage_account).with(storage_account_name, resource_group_location, storage_account_type, tags)
-        expect(blob_manager).to receive(:prepare).with(storage_account_name)
+        expect(client2).to receive(:create_storage_account).with(storage_account_name, resource_group_location, storage_account_type, tags)
+        expect(blob_manager).to receive(:prepare).with(storage_account_name, {:is_default_storage_account=>false})
 
         expect(
           storage_account_manager.create_storage_account(storage_account_name, storage_account_type, storage_account_location, tags)
@@ -111,7 +153,7 @@ describe Bosh::AzureCloud::StorageAccountManager do
       end
 
       it 'should create the storage account' do
-        expect(blob_manager).to receive(:prepare).with(storage_account_name)
+        expect(blob_manager).to receive(:prepare).with(storage_account_name, {:is_default_storage_account=>false})
 
         expect(
           storage_account_manager.create_storage_account(storage_account_name, storage_account_type, storage_account_location, tags)
@@ -722,8 +764,7 @@ describe Bosh::AzureCloud::StorageAccountManager do
           before do
             allow(SecureRandom).to receive(:hex).and_return(random_postfix)
             allow(client2).to receive(:check_storage_account_name_availability).with(new_storage_account_name).and_return(result)
-            allow(blob_manager).to receive(:prepare).with(new_storage_account_name)
-            allow(blob_manager).to receive(:set_stemcell_container_acl_to_public)
+            allow(blob_manager).to receive(:prepare).with(new_storage_account_name, {:is_default_storage_account=>true})
           end
 
           it 'should create a new storage account' do
@@ -782,8 +823,7 @@ describe Bosh::AzureCloud::StorageAccountManager do
           before do
             allow(SecureRandom).to receive(:hex).and_return(random_postfix)
             allow(client2).to receive(:check_storage_account_name_availability).with(new_storage_account_name).and_return(result)
-            allow(blob_manager).to receive(:prepare).with(new_storage_account_name)
-            allow(blob_manager).to receive(:set_stemcell_container_acl_to_public)
+            allow(blob_manager).to receive(:prepare).with(new_storage_account_name, {:is_default_storage_account=>true})
           end
 
           it 'should create a new storage account' do
@@ -811,9 +851,7 @@ describe Bosh::AzureCloud::StorageAccountManager do
           allow(client2).to receive(:get_resource_group).and_return(resource_group)
           allow(SecureRandom).to receive(:hex).and_return(random_postfix)
           allow(client2).to receive(:check_storage_account_name_availability).with(new_storage_account_name).and_return(result)
-          allow(blob_manager).to receive(:prepare).with(new_storage_account_name)
-          allow(blob_manager).to receive(:has_container?).and_return(true)
-          allow(blob_manager).to receive(:set_stemcell_container_acl_to_public)
+          allow(blob_manager).to receive(:prepare).with(new_storage_account_name, {:is_default_storage_account=>true})
         end
 
         it 'should create a new storage account' do


### PR DESCRIPTION
- [x] Please check this box once you have run the unit tests
  ```
  pushd src/bosh_azure_cpi
    bundle install
    bundle exec rspec spec/unit/*
  popd
  ```

### Changelog

* Set the acl of the stemcell container to public only when the storage account is the default storage account
* Add tags to the default storage account only when use_managed_disks is true
* Refine the error handling of getting user image and add more test cases
