### PR TITLE
Fix the error when rendering CPI job template

### DIFF
--- a/jobs/azure_cpi/templates/cpi.json.erb
+++ b/jobs/azure_cpi/templates/cpi.json.erb
@@ -53,20 +53,14 @@
     raise 'ssh_certificate has been replaced by ssh_public_key. Please read https://bosh.io/docs/azure-cpi.html.'
   end
 
-  if_p('azure.windows') do
+  windows = p('azure.windows')
+  username = windows['username']
+  password = windows['password']
+  unless username.nil? && password.nil?
+    raise 'Both "username" and "password" must be set for Windows' if username.nil? || username.empty? || password.nil? || password.empty?
     params['cloud']['properties']['azure']['windows'] = {}
-    if_p('azure.windows.username') do |username|
-      raise 'The username of Windows can not be empty' if username.empty?
-      params['cloud']['properties']['azure']['windows']['username'] = username
-    end.else do
-      raise 'You must provide a username for Windows'
-    end
-    if_p('azure.windows.password') do |password|
-      raise 'The password of Windows can not be empty' if password.empty?
-      params['cloud']['properties']['azure']['windows']['password'] = password
-    end.else do
-      raise 'You must provide a password for Windows'
-    end
+    params['cloud']['properties']['azure']['windows']['username'] = username
+    params['cloud']['properties']['azure']['windows']['password'] = password
   end
 
   if p('azure.environment') == 'AzureStack'


### PR DESCRIPTION

### Changelog

* Fix the error on rendering CPI job template when azure.windows is not specified.

