### PR TITLE
Disable automatic Windows updates

### DIFF
--- a/src/bosh_azure_cpi/lib/cloud/azure/azure_client2.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/azure_client2.rb
@@ -203,6 +203,9 @@ module Bosh::AzureCloud
         when 'windows'
           os_profile['adminUsername'] = vm_params[:windows_username]
           os_profile['adminPassword'] = vm_params[:windows_password]
+          os_profile['windowsConfiguration'] = {
+            'enableAutomaticUpdates' => false
+          }
         else
           raise ArgumentError, "Unsupported os type: #{vm_params[:os_type]}"
       end

--- a/src/bosh_azure_cpi/spec/unit/azure_client2/create_virtual_machine_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client2/create_virtual_machine_spec.rb
@@ -724,7 +724,10 @@ describe Bosh::AzureCloud::AzureClient2 do
                 :customData => "f",
                 :computerName => vm_name,
                 :adminUsername => "d",
-                :adminPassword => "e"
+                :adminPassword => "e",
+                :windowsConfiguration => {
+                  :enableAutomaticUpdates => false
+                }
               },
               :networkProfile => {
                 :networkInterfaces => [


### PR DESCRIPTION
BOSH Windows does not support restarts.  Windows updates may trigger
a restart.  This change modifies the 'osProfile' of the ARM template
of Windows VMs to explicitly disable automatic updates.

[#138665845]

Signed-off-by: Charlie Vieth <cviethjr@pivotal.io>

Thanks for submitting a pull request!

All pull request submitters and commit authors must have a Contributor License Agreement (CLA) on-file with us. Please sign the appropriate CLA ([individual](http://cloudfoundry.org/pdfs/CFF_Individual_CLA.pdf) or [corporate](http://cloudfoundry.org/pdfs/CFF_Corporate_CLA.pdf)).

When sending signed CLA please provide your github username in case of individual CLA or the list of github usernames that can make pull requests on behalf of your organization.

If you are confident that you're covered under a Corporate CLA, please make sure you've publicized your membership in the appropriate Github Org, per [these instructions](https://help.github.com/articles/publicizing-or-concealing-organization-membership/).

- [x] Please check this box once you have run the unit tests
  ```
  pushd src/bosh_azure_cpi
    bundle install
    bundle exec rspec spec/unit/*
  popd
  ```

### Changelog

* Disable automatic Windows updates when creating Windows virtual machines as BOSH Windows does not support restarts.
