### PR TITLE
add "plan" to create_virtual_machine Azure request

### DIFF
--- a/src/bosh_azure_cpi/lib/cloud/azure/azure_client2.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/azure_client2.rb
@@ -281,6 +281,12 @@ module Bosh::AzureCloud
           'imageReference' => vm_params[:image_reference],
           'osDisk'         => os_disk
         }
+
+        vm['plan'] = {
+          'name' => vm_params[:image_reference]['sku'],
+          'publisher' => vm_params[:image_reference]['publisher'],
+          'product' => vm_params[:image_reference]['offer']
+        }
       end
 
       unless vm_params[:ephemeral_disk].nil?


### PR DESCRIPTION
- When deploying a vm from a light stemcell, the request to Azure
must include a "plan" that references the vm marketplace image

[#138665845]

Signed-off-by: Paul Nikonowicz <pnikonowicz@pivotal.io>

Thanks for submitting a pull request!

All pull request submitters and commit authors must have a Contributor License Agreement (CLA) on-file with us. Please sign the appropriate CLA ([individual](http://cloudfoundry.org/pdfs/CFF_Individual_CLA.pdf) or [corporate](http://cloudfoundry.org/pdfs/CFF_Corporate_CLA.pdf)).

When sending signed CLA please provide your github username in case of individual CLA or the list of github usernames that can make pull requests on behalf of your organization.

If you are confident that you're covered under a Corporate CLA, please make sure you've publicized your membership in the appropriate Github Org, per [these instructions](https://help.github.com/articles/publicizing-or-concealing-organization-membership/).

- [x] Please check this box once you have run the unit tests
  ```
  pushd src/bosh_azure_cpi
    bundle install
    bundle exec rspec spec/unit/*
  popd
  ```