### PR TITLE
Raise error if it's not a timeout error when creating storage account and copying blobs

### DIFF
--- a/src/bosh_azure_cpi/lib/cloud/azure/stemcell_manager2.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/stemcell_manager2.rb
@@ -88,7 +88,10 @@ module Bosh::AzureCloud
               @storage_account_manager.create_storage_account(storage_account_name, storage_account_type, location, STEMCELL_STORAGE_ACCOUNT_TAGS)
             end
           rescue => e
-            cloud_error("Failed to finish the creation of the storage account `#{storage_account_name}', `#{storage_account_type}' in location `#{location}' in 60 seconds.") if e.message == BOSH_LOCK_EXCEPTION_TIMEOUT
+            if e.message == BOSH_LOCK_EXCEPTION_TIMEOUT
+              cloud_error("Failed to finish the creation of the storage account `#{storage_account_name}', `#{storage_account_type}' in location `#{location}' in 60 seconds.")
+            end
+            raise e
           end
         else
           storage_account_name = storage_account[:name]
@@ -106,7 +109,10 @@ module Bosh::AzureCloud
             end
           end
         rescue => e
-          cloud_error("Failed to finish the copying process of the stemcell `#{stemcell_name}' from the default storage account `#{default_storage_account_name}' to the storage acccount `#{storage_account_name}' in `#{BOSH_LOCK_COPY_STEMCELL_TIMEOUT}' seconds.") if e.message == BOSH_LOCK_EXCEPTION_TIMEOUT
+          if e.message == BOSH_LOCK_EXCEPTION_TIMEOUT
+            cloud_error("Failed to finish the copying process of the stemcell `#{stemcell_name}' from the default storage account `#{default_storage_account_name}' to the storage acccount `#{storage_account_name}' in `#{BOSH_LOCK_COPY_STEMCELL_TIMEOUT}' seconds.")
+          end
+          raise e
         end
       end
 

--- a/src/bosh_azure_cpi/spec/unit/stemcell_manager2_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/stemcell_manager2_spec.rb
@@ -254,14 +254,12 @@ describe Bosh::AzureCloud::StemcellManager2 do
             end
 
             context "when the stemcell doesn't exist in the exising storage account" do
+              let(:lock_copy_blob) { instance_double(Bosh::AzureCloud::Helpers::FileMutex) }
               before do
                 allow(blob_manager).to receive(:get_blob_properties).
                   with(existing_storage_account_name, stemcell_container, "#{stemcell_name}.vhd").
                   and_return(nil) # The stemcell doesn't exist in the existing storage account
-              end
-
-              after do
-                File.delete('/tmp/bosh-lock-copy-stemcell') if File.exists?('/tmp/bosh-lock-copy-stemcell')
+                allow(lock_copy_blob).to receive(:synchronize)
               end
 
               it "should copy the stemcell from default storage account to an existing storage account, create a new user image and return the user image information" do
@@ -277,44 +275,129 @@ describe Bosh::AzureCloud::StemcellManager2 do
             end
           end
 
-          context "when the storage account with doesn't exist in the specified location" do
-            let(:new_storage_account_name) { "new-storage-account-name" }
-            let(:storage_accounts) {
+          context "when the storage account with tags doesn't exist in the specified location" do
+            let(:new_storage_account_name) { "54657da5936725e199fd616e" }
+            let(:storage_account) {
               [
                 {
                   :name => new_storage_account_name,
-                  :location => location,
-                  :tags => STEMCELL_STORAGE_ACCOUNT_TAGS
+                  :location => location
                 }
               ]
             }
+
             before do
-              allow(client2).to receive(:list_storage_accounts).and_return(storage_accounts)
-              # The following two allows are for get_stemcell_info of stemcell_manager.rb
-              allow(blob_manager).to receive(:get_blob_uri).
-                with(new_storage_account_name, stemcell_container, "#{stemcell_name}.vhd").
-                and_return(stemcell_blob_uri)
-              allow(blob_manager).to receive(:get_blob_metadata).
-                with(new_storage_account_name, stemcell_container, "#{stemcell_name}.vhd").
-                and_return(stemcell_blob_metadata)
-              allow(blob_manager).to receive(:get_blob_properties).
-                with(new_storage_account_name, stemcell_container, "#{stemcell_name}.vhd").
-                and_return(nil) # The stemcell doesn't exist in the new storage account
+              allow(client2).to receive(:list_storage_accounts).and_return([])
+              allow(SecureRandom).to receive(:hex).and_return(new_storage_account_name)
             end
 
-            after do
-              File.delete('/tmp/bosh-lock-copy-stemcell') if File.exists?('/tmp/bosh-lock-copy-stemcell')
+            context "when it fails to create the new storage account" do
+              let(:lock_creating_storage_account) { instance_double(Bosh::AzureCloud::Helpers::FileMutex) }
+              before do
+                allow(Bosh::AzureCloud::Helpers::FileMutex).to receive(:new).with('/tmp/bosh-lock-create-storage-account', anything).
+                  and_return(lock_creating_storage_account)
+              end
+
+              context "when an error is thrown when creating the new storage account" do
+                before do
+                  # The error should be raised by @storage_account_manager.create_storage_account. But it will be filtered by mutex.synchronize and not catched.
+                  # So, to make the case passed, we just raise the error from mutex.synchronize
+                  allow(lock_creating_storage_account).to receive(:synchronize).
+                    and_raise("Error when creating storage account")
+                end
+
+                it "raise an error" do
+                  expect {
+                    stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location)
+                  }.to raise_error /Error when creating storage account/
+                end
+              end
+
+              context "when it timeouts to create the new storage account" do
+                before do
+                  allow(lock_creating_storage_account).to receive(:synchronize).
+                    and_raise('timeout')
+                end
+
+                it "raise an error" do
+                  expect {
+                    stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location)
+                  }.to raise_error /Failed to finish the creation of the storage account/
+                end
+              end
             end
 
-            it "should copy the stemcell from default storage account to the new storage account, create a new user image and return the user image information" do
-              expect(blob_manager).to receive(:get_blob_uri).
-                with(MOCK_DEFAULT_STORAGE_ACCOUNT_NAME, stemcell_container, "#{stemcell_name}.vhd").
-                and_return(stemcell_blob_uri)
-              expect(blob_manager).to receive(:copy_blob).
-                with(new_storage_account_name, stemcell_container, "#{stemcell_name}.vhd", stemcell_blob_uri)
-              stemcell_info = stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location)
-              expect(stemcell_info.uri).to eq(user_image_id)
-              expect(stemcell_info.metadata).to eq(tags)
+            context "when it creates the new storage account successfully" do
+              let(:lock_creating_storage_account) { instance_double(Bosh::AzureCloud::Helpers::FileMutex) }
+              let(:lock_copy_blob) { instance_double(Bosh::AzureCloud::Helpers::FileMutex) }
+
+              before do
+                allow(storage_account_manager).to receive(:create_storage_account).
+                  with(new_storage_account_name, storage_account_type, location, STEMCELL_STORAGE_ACCOUNT_TAGS)
+                # The following two allows are for get_stemcell_info of stemcell_manager.rb
+                allow(blob_manager).to receive(:get_blob_uri).
+                  with(new_storage_account_name, stemcell_container, "#{stemcell_name}.vhd").
+                  and_return(stemcell_blob_uri)
+                allow(blob_manager).to receive(:get_blob_metadata).
+                  with(new_storage_account_name, stemcell_container, "#{stemcell_name}.vhd").
+                  and_return(stemcell_blob_metadata)
+                allow(blob_manager).to receive(:get_blob_properties).
+                  with(new_storage_account_name, stemcell_container, "#{stemcell_name}.vhd").
+                  and_return(nil) # The stemcell doesn't exist in the new storage account
+                allow(Bosh::AzureCloud::Helpers::FileMutex).to receive(:new).and_return(lock_creating_storage_account, lock_copy_blob)
+                allow(lock_creating_storage_account).to receive(:synchronize)
+              end
+
+              context "when an error is thrown when copying the stemcell from default storage account to the new storage account" do
+                before do
+                  allow(blob_manager).to receive(:get_blob_uri).
+                    with(MOCK_DEFAULT_STORAGE_ACCOUNT_NAME, stemcell_container, "#{stemcell_name}.vhd").
+                    and_return(stemcell_blob_uri)
+                  # The error should be raised by @blob_manager.copy_blob. But it will be filtered by mutex.synchronize and not catched.
+                  # So, to make the case passed, we just raise the error from mutex.synchronize
+                  allow(lock_copy_blob).to receive(:synchronize).
+                    and_raise("Error when copying blobs")
+                end
+
+                it "raise an error" do
+                  expect {
+                    stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location)
+                  }.to raise_error /Error when copying blobs/
+                end
+              end
+
+              context "when it timeouts to copy the stemcell from default storage account to the new storage account" do
+                before do
+                  allow(blob_manager).to receive(:get_blob_uri).
+                    with(MOCK_DEFAULT_STORAGE_ACCOUNT_NAME, stemcell_container, "#{stemcell_name}.vhd").
+                    and_return(stemcell_blob_uri)
+                  allow(lock_copy_blob).to receive(:synchronize).
+                    and_raise("timeout")
+                end
+
+                it "raise an error" do
+                  expect {
+                    stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location)
+                  }.to raise_error /Failed to finish the copying process of the stemcell/
+                end
+              end
+
+              context "when it copies the stemcell from default storage account to the new storage account" do
+                before do
+                  allow(blob_manager).to receive(:get_blob_uri).
+                    with(MOCK_DEFAULT_STORAGE_ACCOUNT_NAME, stemcell_container, "#{stemcell_name}.vhd").
+                    and_return(stemcell_blob_uri)
+                  allow(blob_manager).to receive(:copy_blob).
+                    with(new_storage_account_name, stemcell_container, "#{stemcell_name}.vhd", stemcell_blob_uri)
+                  allow(lock_copy_blob).to receive(:synchronize)
+                end
+
+                it "should create a new user image and return the user image information" do
+                  stemcell_info = stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location)
+                  expect(stemcell_info.uri).to eq(user_image_id)
+                  expect(stemcell_info.metadata).to eq(tags)
+                end
+              end
             end
           end
         end


### PR DESCRIPTION
- [x] Please check this box once you have run the unit tests
  ```
  pushd src/bosh_azure_cpi
    bundle install
    bundle exec rspec spec/unit/*
  popd
  ```

### Changelog

* Raise error if it's not a timeout error when creating storage account and copying blobs
