### PR TITLE
Keep failed VM in provosioning

### DIFF
--- a/src/bosh_azure_cpi/spec/unit/azure_client2/create_virtual_machine_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client2/create_virtual_machine_spec.rb
@@ -1308,7 +1308,7 @@ describe Bosh::AzureCloud::AzureClient2 do
 
         expect {
           azure_client2.create_virtual_machine(vm_params, network_interfaces)
-        }.to raise_error /check_completion - http code: 404/
+        }.to raise_error { |error| expect(error.error).to match(/check_completion - http code: 404/) }
       end
 
       it "should raise an error if create operation failed" do
@@ -1332,7 +1332,7 @@ describe Bosh::AzureCloud::AzureClient2 do
 
         expect {
           azure_client2.create_virtual_machine(vm_params, network_interfaces)
-        }.to raise_error /status: Cancelled/
+        }.to raise_error { |error| expect(error.status).to eq('Cancelled') }
       end
     end
 

--- a/src/bosh_azure_cpi/spec/unit/azure_client2/restart_virtual_machine_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client2/restart_virtual_machine_spec.rb
@@ -171,7 +171,7 @@ describe Bosh::AzureCloud::AzureClient2 do
 
         expect {
           azure_client2.restart_virtual_machine(vm_name)
-        }.to raise_error /check_completion - http code: 404/
+        }.to raise_error { |error| expect(error.error).to match(/check_completion - http code: 404/) }
       end
 
       it "should raise an error if restart operation failed" do
@@ -195,7 +195,7 @@ describe Bosh::AzureCloud::AzureClient2 do
 
         expect {
           azure_client2.restart_virtual_machine(vm_name)
-        }.to raise_error /status: Cancelled/
+        }.to raise_error { |error| expect(error.status).to eq('Cancelled') }
       end
 
       # TODO


### PR DESCRIPTION
- [x] Please check this box once you have run the unit tests
  ```
  pushd src/bosh_azure_cpi
    bundle install
    bundle exec rspec spec/unit/*
  popd
  ```
  513 examples, 0 failures. 2474 / 2715 LOC (91.12%) covered.

### Changelog

* Keep the VM which fails in provisioning for platform issues or stemcell issues so users can use the VM for debugging.

