### PR TITLE
VM should be in same location with VNET

### DIFF
--- a/docs/advanced/deploy-cloudfoundry-for-enterprise/README.md
+++ b/docs/advanced/deploy-cloudfoundry-for-enterprise/README.md
@@ -93,8 +93,6 @@ By default there is one Standard Tier storage account created for each resource 
 
   If the new storage account does not exist and you expect Azure CPI to create it automatically, you need to specify storage_account_type. It can be either `Standard_LRS`, `Standard_ZRS`, `Standard_GRS`, `Standard_RAGRS` or `Premium_LRS`. You can click [**HERE**](http://azure.microsoft.com/en-us/pricing/details/storage/) to learn more about the type of Azure storage account.
 
-  You also can specify the location for the new storage account. If it is not set, the location of the default resource group will be used. For more information, see [List all of the available geo-locations](http://azure.microsoft.com/en-us/regions/). For `AzureChinaCloud`, you should only use the regions in China, `chinanorth` or `chinaeast`.
-
 1. For best disk performance, you should use DS-series, DSv2-series, Fs-series and GS-series VMs which can use premium storage. For more information, see [Sizes for virtual machines in Azure](https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-linux-sizes/).
 
   ```
@@ -115,11 +113,12 @@ By default there is one Standard Tier storage account created for each resource 
       instance_type: Standard_DS1_v2
       storage_account_name: <new-storage-account>
       storage_account_type: Premium_LRS
-      storage_account_location: eastus2
   ```
 
 1. Please use Azure CPI v7 or later version. The new storage accounts which are specified in the `resource_pools` section will be created by Azure CPI automatically if they do not exist.
 
 1. Deploy your Cloud Foundry with the updated manifest. You can configure multiple storage accounts for the first deployment, or for on going deployments.
+
+>**NOTE:** If you manually create storage accounts for VMs, you must create storage accounts in the same location as VMs' VNET. If you specify a storage account which does not exist for VMs, CPI (v25+) will create it automatically in the same location as VMs' VNET.
 
 Click [**HERE**](https://github.com/cloudfoundry-incubator/bosh-azure-cpi-release/blob/master/src/bosh_azure_cpi/README.md) to learn more about the configuration of availability sets and multiple storage accounts.

--- a/src/bosh_azure_cpi/lib/cloud/azure/cloud.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/cloud.rb
@@ -123,15 +123,17 @@ module Bosh::AzureCloud
       # env may contain credentials so we must not log it
       @logger.info("create_vm(#{agent_id}, #{stemcell_id}, #{resource_pool}, #{networks}, #{disk_locality}, ...)")
       with_thread_name("create_vm(#{agent_id}, ...)") do
+        # These resources should be in the same location for a VM: VM, NIC, disk(storage account or managed disk).
+        # And NIC must be in the same location with VNET, so CPI will use VNET's location as default location for the resources related to the VM.
+        network_configurator = NetworkConfigurator.new(azure_properties, networks)
+        network = network_configurator.networks[0]
+        vnet = @azure_client2.get_virtual_network_by_name(network.resource_group_name, network.virtual_network_name)
+        cloud_error("Cannot find the virtual network `#{network.virtual_network_name}' under resource group `#{network.resource_group_name}'") if vnet.nil?
+        location = vnet[:location]
         if @use_managed_disks
           instance_id = agent_id
           storage_account_type = resource_pool['storage_account_type']
           storage_account_type = get_storage_account_type_by_instance_type(resource_pool['instance_type']) if storage_account_type.nil?
-          if !resource_pool['storage_account_location'].nil?
-            location = resource_pool['storage_account_location'] 
-          else
-            location = @azure_client2.get_resource_group()[:location]
-          end
 
           if is_light_stemcell_id?(stemcell_id)
             raise Bosh::Clouds::VMCreationFailed.new(false), "Given stemcell `#{stemcell_id}' does not exist" unless @light_stemcell_manager.has_stemcell?(location, stemcell_id)
@@ -145,8 +147,7 @@ module Bosh::AzureCloud
             end
           end
         else
-          storage_account = @storage_account_manager.get_storage_account_from_resource_pool(resource_pool)
-          location = storage_account[:location]
+          storage_account = @storage_account_manager.get_storage_account_from_resource_pool(resource_pool, location)
 
           if is_light_stemcell_id?(stemcell_id)
             raise Bosh::Clouds::VMCreationFailed.new(false), "Given stemcell `#{stemcell_id}' does not exist" unless @light_stemcell_manager.has_stemcell?(location, stemcell_id)
@@ -166,7 +167,7 @@ module Bosh::AzureCloud
           location,
           stemcell_info,
           resource_pool,
-          NetworkConfigurator.new(azure_properties, networks),
+          network_configurator,
           env)
 
         @logger.info("Created new vm `#{instance_id}'")

--- a/src/bosh_azure_cpi/spec/unit/azure_client2/get_operation_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client2/get_operation_spec.rb
@@ -181,6 +181,48 @@ describe Bosh::AzureCloud::AzureClient2 do
     }
   }
 
+  # Virtual Network
+  let(:vnet_name) { "fake-vnet-name" }
+  let(:vnet_uri) { "https://management.azure.com//subscriptions/#{subscription_id}/resourceGroups/#{resource_group_name}/providers/Microsoft.Network/virtualNetworks/#{vnet_name}?api-version=#{api_version}" }
+  let(:vnet_response_body) {
+    {
+      "id" => "fake-vnet-id",
+      "name" => "fake-vnet-name",
+      "location" => "fake-location",
+      "properties" => {
+        "provisioningState" => "fake-vnet-state",
+        "addressSpace" => "fake-address-space",
+        "subnets" => [
+          {
+            "name" => "fake-subnet-name",
+            "id" => "fake-subnet-id",
+            "properties" => {
+              "provisioningState" => "fake-subnet-state",
+              "addressPrefix" => "fake-address-prefix"
+            }
+          }
+        ]
+      }
+    }.to_json
+  }
+  let(:fake_vnet) {
+    {
+      :id => "fake-vnet-id",
+      :name => "fake-vnet-name",
+      :location => "fake-location",
+      :provisioning_state => "fake-vnet-state",
+      :address_space => "fake-address-space",
+      :subnets => [
+        {
+          :id => "fake-subnet-id",
+          :name => "fake-subnet-name",
+          :provisioning_state => "fake-subnet-state",
+          :address_prefix => "fake-address-prefix"
+        }
+      ]
+    }
+  }
+
   # Subnet
   let(:vnet_name) { "fake-name" }
   let(:subnet_name) { "bar" }
@@ -395,6 +437,31 @@ describe Bosh::AzureCloud::AzureClient2 do
         expect(
           azure_client2.get_network_interface_by_name(nic_name)
         ).to eq(fake_nic)
+      end
+    end
+  end
+
+  describe "#get_virtual_network_by_name" do
+    context "when token is valid, getting response succeeds" do
+      it "should return null if response body is null" do
+        stub_request(:get, vnet_uri).to_return(
+          :status => 200,
+          :body => '',
+          :headers => {})
+        expect(
+          azure_client2.get_virtual_network_by_name(resource_group_name, vnet_name)
+        ).to be_nil
+      end
+
+      it "should return the resource if response body is not null" do
+        stub_request(:get, vnet_uri).to_return(
+          :status => 200,
+          :body => vnet_response_body,
+          :headers => {})
+        expect(
+          azure_client2.get_virtual_network_by_name(resource_group_name, vnet_name)
+        ).to eq(fake_vnet)
+
       end
     end
   end


### PR DESCRIPTION
- [x] Please check this box once you have run the unit tests
  ```
  pushd src/bosh_azure_cpi
    bundle install
    bundle exec rspec spec/unit/*
  popd
  ```
523 examples, 0 failures. 2509 / 2749 LOC (91.27%) covered.

### Changelog

* Use VNET's location as the location for VM related resources.
In Azure, these VM related resources must be in the same location:
    1. VM
    1. VNET/NIC
    1. Disks
    1. ...

For managed disk, Azure will not explicitly use a storage account, so it is reasonable to deprecate `storage_account_location` and use VNET's location as the location to create these VM related resources.
