### PR TITLE
Specify disk size when attaching unmanaged disks

### DIFF
--- a/src/bosh_azure_cpi/lib/cloud/azure/azure_client2.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/azure_client2.rb
@@ -384,7 +384,7 @@ module Bosh::AzureCloud
     # * +:disk_uri+               - String.  URI of an unmanaged disk.
     # * +:disk_size+              - Integer. Size of disk. Needs to be specified when attaching an unmanaged disk.
     #
-    # @return [Hash]
+    # @return [Integer]
     #
     # @See https://docs.microsoft.com/en-us/rest/api/compute/virtualmachines/virtualmachines-create-or-update
     #
@@ -436,19 +436,7 @@ module Bosh::AzureCloud
       @logger.info("attach_disk_to_virtual_machine - attach disk `#{disk_name}' to lun `#{lun}' of the virtual machine `#{vm_name}', managed: `#{managed}'")
       http_put(url, vm)
 
-      disk = {
-        :name          => disk_name,
-        :lun           => lun,
-        :create_option => 'Attach',
-        :caching       => caching
-      }
-      if managed
-        disk[:managed_disk] = { :id => disk_id }
-      else
-        disk[:vhd] = { :uri => disk_uri }
-        disk[:disk_size_gb] = disk_size
-      end
-      disk
+      lun
     end
 
     # Detach a specified disk from a virtual machine

--- a/src/bosh_azure_cpi/lib/cloud/azure/blob_manager.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/blob_manager.rb
@@ -36,6 +36,13 @@ module Bosh::AzureCloud
       end
     end
 
+    def get_blob_size_in_bytes(storage_account_name, container_name, blob_name)
+      @logger.info("get_blob_size_in_bytes(#{storage_account_name}, #{container_name}, #{blob_name})")
+      initialize_blob_client(storage_account_name) do
+        @blob_service_client.get_blob_properties(container_name, blob_name).properties[:content_length]
+      end
+    end
+
     def delete_blob_snapshot(storage_account_name, container_name, blob_name, snapshot_time)
       @logger.info("delete_blob_snapshot(#{storage_account_name}, #{container_name}, #{blob_name}, #{snapshot_time})")
       initialize_blob_client(storage_account_name) do

--- a/src/bosh_azure_cpi/lib/cloud/azure/disk_manager.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/disk_manager.rb
@@ -87,6 +87,12 @@ module Bosh::AzureCloud
       caching
     end
 
+    def get_disk_size_in_gb(disk_name)
+      @logger.info("get_disk_size_in_gb(#{disk_name})")
+      storage_account_name = get_storage_account_name(disk_name)
+      @blob_manager.get_blob_size_in_bytes(storage_account_name, DISK_CONTAINER, "#{disk_name}.vhd") / 1024 / 1024 / 1024
+    end
+
     # bosh-os-STORAGEACCOUNTNAME-AGENTID
     def generate_os_disk_name(instance_id)
       "#{OS_DISK_PREFIX}-#{instance_id}"

--- a/src/bosh_azure_cpi/lib/cloud/azure/vm_manager.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/vm_manager.rb
@@ -196,13 +196,22 @@ module Bosh::AzureCloud
     def attach_disk(instance_id, disk_name)
       @logger.info("attach_disk(#{instance_id}, #{disk_name})")
       if @use_managed_disks && is_managed_vm?(instance_id)
-        managed_disk = @azure_client2.get_managed_disk_by_name(disk_name)
-        caching = @disk_manager2.get_data_disk_caching(disk_name)
-        disk = @azure_client2.attach_disk_to_virtual_machine(instance_id, disk_name, managed_disk[:id], caching, true)
+        disk_params = {
+          :disk_name => disk_name,
+          :caching   => @disk_manager2.get_data_disk_caching(disk_name),
+          :disk_id   => @azure_client2.get_managed_disk_by_name(disk_name)[:id],
+          :managed   => true
+        }
+        disk = @azure_client2.attach_disk_to_virtual_machine(instance_id, disk_params)
       else
-        disk_uri = @disk_manager.get_disk_uri(disk_name)
-        caching = @disk_manager.get_data_disk_caching(disk_name)
-        disk = @azure_client2.attach_disk_to_virtual_machine(instance_id, disk_name, disk_uri, caching)
+        disk_params = {
+          :disk_name => disk_name,
+          :caching   => @disk_manager.get_data_disk_caching(disk_name),
+          :disk_uri  => @disk_manager.get_disk_uri(disk_name),
+          :disk_size => @disk_manager.get_disk_size_in_gb(disk_name),
+          :managed   => false
+        }
+        disk = @azure_client2.attach_disk_to_virtual_machine(instance_id, disk_params)
       end
       "#{disk[:lun]}"
     end

--- a/src/bosh_azure_cpi/lib/cloud/azure/vm_manager.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/vm_manager.rb
@@ -202,7 +202,6 @@ module Bosh::AzureCloud
           :disk_id   => @azure_client2.get_managed_disk_by_name(disk_name)[:id],
           :managed   => true
         }
-        disk = @azure_client2.attach_disk_to_virtual_machine(instance_id, disk_params)
       else
         disk_params = {
           :disk_name => disk_name,
@@ -211,9 +210,9 @@ module Bosh::AzureCloud
           :disk_size => @disk_manager.get_disk_size_in_gb(disk_name),
           :managed   => false
         }
-        disk = @azure_client2.attach_disk_to_virtual_machine(instance_id, disk_params)
       end
-      "#{disk[:lun]}"
+      lun = @azure_client2.attach_disk_to_virtual_machine(instance_id, disk_params)
+      "#{lun}"
     end
 
     def detach_disk(instance_id, disk_name)

--- a/src/bosh_azure_cpi/spec/unit/azure_client2/attach_disk_to_virtual_machine_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client2/attach_disk_to_virtual_machine_spec.rb
@@ -30,50 +30,28 @@ describe Bosh::AzureCloud::AzureClient2 do
 
   describe "#attach_disk_to_virtual_machine" do
     let(:disk_name) { "fake-disk-name" }
-    let(:disk_uri) { "fake-disk-uri" }
     let(:caching) { "ReadWrite" }
     let(:vm_uri) { "https://management.azure.com//subscriptions/#{subscription_id}/resourceGroups/#{resource_group}/providers/Microsoft.Compute/virtualMachines/#{vm_name}?api-version=#{api_version_compute}" }
-    let(:disk) {
-      {
-        :name          => disk_name,
-        :lun           => 2,
-        :create_option => 'Attach',
-        :caching       => 'ReadWrite',
-        :vhd           => { :uri => disk_uri }
-      }
-    }
 
     context "when attaching a managed disk" do
-      let(:managed) { true }
       let(:disk_id) { "fake-disk-id" }
-      let(:request_body) {
+      let(:disk_params) {
         {
-          "id" => "fake-id",
-          "name" => "fake-name",
-          "location" => "fake-location",
-          "tags" => "fake-tags",
-          "properties" => {
-            "provisioningState" => "fake-state",
-            "storageProfile" => {
-              "dataDisks" => [
-                { "lun" => 0 },
-                { "lun" => 1 },
-                {
-                  "name" => disk_name,
-                  "lun"  => 2,
-                  "createOption" => "Attach",
-                  "caching"      => 'ReadWrite',
-                  "managedDisk"  => { "id" => disk_id }
-                }
-              ]
-            },
-            "hardwareProfile" => {
-              "vmSize" => "Standard_A5"
-            }
-          }
-        }
+          :disk_name => disk_name,
+          :caching   => caching,
+          :disk_id   => disk_id,
+          :managed   => true
+         }
       }
-
+      let(:disk) {
+        {
+          :name          => disk_name,
+          :lun           => 2,
+          :create_option => 'Attach',
+          :caching       => caching,
+          :managed_disk  => { :id => disk_id }
+         }
+      }
       let(:response_body) {
         {
           "id" => "fake-id",
@@ -94,14 +72,31 @@ describe Bosh::AzureCloud::AzureClient2 do
           }
         }.to_json
       }
-
-      let(:disk) {
+      let(:request_body) {
         {
-          :name          => disk_name,
-          :lun           => 2,
-          :create_option => 'Attach',
-          :caching       => 'ReadWrite',
-          :managed_disk  => { :id => disk_id }
+          "id" => "fake-id",
+          "name" => "fake-name",
+          "location" => "fake-location",
+          "tags" => "fake-tags",
+          "properties" => {
+            "provisioningState" => "fake-state",
+            "storageProfile" => {
+              "dataDisks" => [
+                { "lun" => 0 },
+                { "lun" => 1 },
+                {
+                  "name" => disk_name,
+                  "lun"  => 2,
+                  "createOption" => "Attach",
+                  "caching"      => caching,
+                  "managedDisk"  => { "id" => disk_id }
+                }
+              ]
+            },
+            "hardwareProfile" => {
+              "vmSize" => "Standard_A5"
+            }
+          }
         }
       }
 
@@ -129,12 +124,33 @@ describe Bosh::AzureCloud::AzureClient2 do
           :headers => {})
 
         expect(
-          azure_client2.attach_disk_to_virtual_machine(vm_name, disk_name, disk_id, caching, managed)
+          azure_client2.attach_disk_to_virtual_machine(vm_name, disk_params)
         ).to eq(disk)
       end
     end
 
-    context "when token is valid, create operation is accepted and completed" do
+    context "when attaching an unmanaged disk" do
+      let(:disk_uri) { "fake-disk-uri" }
+      let(:disk_size) { 42 }
+      let(:disk_params) {
+        {
+          :disk_name => disk_name,
+          :caching   => caching,
+          :disk_uri  => disk_uri,
+          :disk_size => disk_size,
+          :managed   => false
+         }
+      }
+      let(:disk) {
+        {
+          :name          => disk_name,
+          :lun           => 2,
+          :create_option => 'Attach',
+          :caching       => caching,
+          :disk_size_gb  => disk_size,
+          :vhd           => { :uri => disk_uri }
+        }
+      }
       let(:request_body) {
         {
           "id" => "fake-id",
@@ -151,8 +167,9 @@ describe Bosh::AzureCloud::AzureClient2 do
                   "name" => disk_name,
                   "lun"  => 2,
                   "createOption" => "Attach",
-                  "caching"       => 'ReadWrite',
-                  "vhd"           => { "uri" => disk_uri }
+                  "caching"      => caching,
+                  "diskSizeGb"   => disk_size,
+                  "vhd"          => { "uri" => disk_uri }
                 }
               ]
             },
@@ -209,7 +226,7 @@ describe Bosh::AzureCloud::AzureClient2 do
             :headers => {})
 
           expect(
-            azure_client2.attach_disk_to_virtual_machine(vm_name, disk_name, disk_uri, caching)
+            azure_client2.attach_disk_to_virtual_machine(vm_name, disk_params)
           ).to eq(disk)
         end
       end
@@ -269,156 +286,156 @@ describe Bosh::AzureCloud::AzureClient2 do
             :headers => {})
 
           expect(
-            azure_client2.attach_disk_to_virtual_machine(vm_name, disk_name, disk_uri, caching)
+            azure_client2.attach_disk_to_virtual_machine(vm_name, disk_params)
           ).to eq(disk)
         end
       end
-    end
 
-    context "when the virtual machine is not found" do
-      it "should raise an error" do
-        stub_request(:post, token_uri).to_return(
-          :status => 200,
-          :body => {
-            "access_token" => valid_access_token,
-            "expires_on" => expires_on
-          }.to_json,
-          :headers => {})
-        stub_request(:get, vm_uri).to_return(
-          :status => 200,
-          :body => '',
-          :headers => {})
-
-        expect {
-          azure_client2.attach_disk_to_virtual_machine(vm_name, disk_name, disk_uri, caching)
-        }.to raise_error /attach_disk_to_virtual_machine - cannot find the virtual machine by name/
-      end
-    end
-
-    context "when no avaiable lun can be found" do
-      let(:response_body) {
-        {
-          "id" => "fake-id",
-          "name" => "fake-name",
-          "location" => "fake-location",
-          "tags" => "fake-tags",
-          "properties" => {
-            "provisioningState" => "fake-state",
-            "storageProfile" => {
-              "dataDisks" => [
-                { "lun" => 0 },
-                { "lun" => 1 }
-              ]
-            },
-            "hardwareProfile" => {
-              "vmSize" => "Standard_A1"
-            }
-          }
-        }.to_json
-      }
-
-      it "should raise an error" do
-        stub_request(:post, token_uri).to_return(
-          :status => 200,
-          :body => {
-            "access_token" => valid_access_token,
-            "expires_on" => expires_on
-          }.to_json,
-          :headers => {})
-        stub_request(:get, vm_uri).to_return(
-          :status => 200,
-          :body => response_body,
-          :headers => {})
-
-        expect {
-          azure_client2.attach_disk_to_virtual_machine(vm_name, disk_name, disk_uri, caching)
-        }.to raise_error /attach_disk_to_virtual_machine - cannot find an available lun in the virtual machine/
-      end
-    end
-
-    context "if put operation returns retryable error code (returns 429)" do
-      let(:response_body) {
-        {
-          "id" => "fake-id",
-          "name" => "fake-name",
-          "location" => "fake-location",
-          "tags" => "fake-tags",
-          "properties" => {
-            "provisioningState" => "fake-state",
-            "storageProfile" => {
-              "dataDisks" => [
-                { "lun" => 0 },
-                { "lun" => 1 }
-              ]
-            },
-            "hardwareProfile" => {
-              "vmSize" => "Standard_A5"
-            }
-          }
-        }.to_json
-      }
-
-      it "should raise error if it always returns 429" do
-        stub_request(:post, token_uri).to_return(
-          :status => 200,
-          :body => {
-            "access_token" => valid_access_token,
-            "expires_on" => expires_on
-          }.to_json,
-          :headers => {})
-        stub_request(:get, vm_uri).to_return(
-          :status => 200,
-          :body => response_body,
-          :headers => {})
-        stub_request(:put, vm_uri).to_return(
-          {
-            :status => 429,
-            :body => '',
-            :headers => {
-            }
-          }
-        )
-
-        expect {
-          azure_client2.attach_disk_to_virtual_machine(vm_name, disk_name, disk_uri, caching)
-        }.to raise_error Bosh::AzureCloud::AzureInternalError
-      end
-
-      it "should not raise error if it returns 429 at the first time but returns 200 at the second time" do
-        stub_request(:post, token_uri).to_return(
-          :status => 200,
-          :body => {
-            "access_token" => valid_access_token,
-            "expires_on" => expires_on
-          }.to_json,
-          :headers => {})
-        stub_request(:get, vm_uri).to_return(
-          :status => 200,
-          :body => response_body,
-          :headers => {})
-        stub_request(:put, vm_uri).to_return(
-          {
-            :status => 429,
-            :body => '',
-            :headers => {
-            }
-          },
-          {
+      context "when the virtual machine is not found" do
+        it "should raise an error" do
+          stub_request(:post, token_uri).to_return(
+            :status => 200,
+            :body => {
+              "access_token" => valid_access_token,
+              "expires_on" => expires_on
+            }.to_json,
+            :headers => {})
+          stub_request(:get, vm_uri).to_return(
             :status => 200,
             :body => '',
-            :headers => {
-              "azure-asyncoperation" => operation_status_link
-            }
-          }
-        )
-        stub_request(:get, operation_status_link).to_return(
-          :status => 200,
-          :body => '{"status":"Succeeded"}',
-          :headers => {})
+            :headers => {})
 
-        expect {
-          azure_client2.attach_disk_to_virtual_machine(vm_name, disk_name, disk_uri, caching)
-        }.not_to raise_error
+          expect {
+            azure_client2.attach_disk_to_virtual_machine(vm_name, disk_params)
+          }.to raise_error /attach_disk_to_virtual_machine - cannot find the virtual machine by name/
+        end
+      end
+
+      context "when no avaiable lun can be found" do
+        let(:response_body) {
+          {
+            "id" => "fake-id",
+            "name" => "fake-name",
+            "location" => "fake-location",
+            "tags" => "fake-tags",
+            "properties" => {
+              "provisioningState" => "fake-state",
+              "storageProfile" => {
+                "dataDisks" => [
+                  { "lun" => 0 },
+                  { "lun" => 1 }
+                ]
+              },
+              "hardwareProfile" => {
+                "vmSize" => "Standard_A1" # Standard_A1 only has 2 available luns
+              }
+            }
+          }.to_json
+        }
+
+        it "should raise an error" do
+          stub_request(:post, token_uri).to_return(
+            :status => 200,
+            :body => {
+              "access_token" => valid_access_token,
+              "expires_on" => expires_on
+            }.to_json,
+            :headers => {})
+          stub_request(:get, vm_uri).to_return(
+            :status => 200,
+            :body => response_body,
+            :headers => {})
+
+          expect {
+            azure_client2.attach_disk_to_virtual_machine(vm_name, disk_params)
+          }.to raise_error /attach_disk_to_virtual_machine - cannot find an available lun in the virtual machine/
+        end
+      end
+
+      context "if put operation returns retryable error code (returns 429)" do
+        let(:response_body) {
+          {
+            "id" => "fake-id",
+            "name" => "fake-name",
+            "location" => "fake-location",
+            "tags" => "fake-tags",
+            "properties" => {
+              "provisioningState" => "fake-state",
+              "storageProfile" => {
+                "dataDisks" => [
+                  { "lun" => 0 },
+                  { "lun" => 1 }
+                ]
+              },
+              "hardwareProfile" => {
+                "vmSize" => "Standard_A5"
+              }
+            }
+          }.to_json
+        }
+
+        it "should raise error if it always returns 429" do
+          stub_request(:post, token_uri).to_return(
+            :status => 200,
+            :body => {
+              "access_token" => valid_access_token,
+              "expires_on" => expires_on
+            }.to_json,
+            :headers => {})
+          stub_request(:get, vm_uri).to_return(
+            :status => 200,
+            :body => response_body,
+            :headers => {})
+          stub_request(:put, vm_uri).to_return(
+            {
+              :status => 429,
+              :body => '',
+              :headers => {
+              }
+            }
+          )
+
+          expect {
+            azure_client2.attach_disk_to_virtual_machine(vm_name, disk_params)
+          }.to raise_error Bosh::AzureCloud::AzureInternalError
+        end
+
+        it "should not raise error if it returns 429 at the first time but returns 200 at the second time" do
+          stub_request(:post, token_uri).to_return(
+            :status => 200,
+            :body => {
+              "access_token" => valid_access_token,
+              "expires_on" => expires_on
+            }.to_json,
+            :headers => {})
+          stub_request(:get, vm_uri).to_return(
+            :status => 200,
+            :body => response_body,
+            :headers => {})
+          stub_request(:put, vm_uri).to_return(
+            {
+              :status => 429,
+              :body => '',
+              :headers => {
+              }
+            },
+            {
+              :status => 200,
+              :body => '',
+              :headers => {
+                "azure-asyncoperation" => operation_status_link
+              }
+            }
+          )
+          stub_request(:get, operation_status_link).to_return(
+            :status => 200,
+            :body => '{"status":"Succeeded"}',
+            :headers => {})
+
+          expect {
+            azure_client2.attach_disk_to_virtual_machine(vm_name, disk_params)
+          }.not_to raise_error
+        end
       end
     end
   end

--- a/src/bosh_azure_cpi/spec/unit/azure_client2/attach_disk_to_virtual_machine_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client2/attach_disk_to_virtual_machine_spec.rb
@@ -43,15 +43,6 @@ describe Bosh::AzureCloud::AzureClient2 do
           :managed   => true
          }
       }
-      let(:disk) {
-        {
-          :name          => disk_name,
-          :lun           => 2,
-          :create_option => 'Attach',
-          :caching       => caching,
-          :managed_disk  => { :id => disk_id }
-         }
-      }
       let(:response_body) {
         {
           "id" => "fake-id",
@@ -72,6 +63,7 @@ describe Bosh::AzureCloud::AzureClient2 do
           }
         }.to_json
       }
+      let(:lun) { 2 }
       let(:request_body) {
         {
           "id" => "fake-id",
@@ -86,7 +78,7 @@ describe Bosh::AzureCloud::AzureClient2 do
                 { "lun" => 1 },
                 {
                   "name" => disk_name,
-                  "lun"  => 2,
+                  "lun"  => lun,
                   "createOption" => "Attach",
                   "caching"      => caching,
                   "managedDisk"  => { "id" => disk_id }
@@ -125,7 +117,7 @@ describe Bosh::AzureCloud::AzureClient2 do
 
         expect(
           azure_client2.attach_disk_to_virtual_machine(vm_name, disk_params)
-        ).to eq(disk)
+        ).to eq(lun)
       end
     end
 
@@ -141,16 +133,7 @@ describe Bosh::AzureCloud::AzureClient2 do
           :managed   => false
          }
       }
-      let(:disk) {
-        {
-          :name          => disk_name,
-          :lun           => 2,
-          :create_option => 'Attach',
-          :caching       => caching,
-          :disk_size_gb  => disk_size,
-          :vhd           => { :uri => disk_uri }
-        }
-      }
+      let(:lun) { 2 }
       let(:request_body) {
         {
           "id" => "fake-id",
@@ -165,7 +148,7 @@ describe Bosh::AzureCloud::AzureClient2 do
                 { "lun" => 1 },
                 {
                   "name" => disk_name,
-                  "lun"  => 2,
+                  "lun"  => lun,
                   "createOption" => "Attach",
                   "caching"      => caching,
                   "diskSizeGb"   => disk_size,
@@ -227,7 +210,7 @@ describe Bosh::AzureCloud::AzureClient2 do
 
           expect(
             azure_client2.attach_disk_to_virtual_machine(vm_name, disk_params)
-          ).to eq(disk)
+          ).to eq(2)
         end
       end
 
@@ -287,7 +270,7 @@ describe Bosh::AzureCloud::AzureClient2 do
 
           expect(
             azure_client2.attach_disk_to_virtual_machine(vm_name, disk_params)
-          ).to eq(disk)
+          ).to eq(2)
         end
       end
 

--- a/src/bosh_azure_cpi/spec/unit/blob_manager_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/blob_manager_spec.rb
@@ -60,7 +60,9 @@ describe Bosh::AzureCloud::BlobManager do
           :request_id => request_id
         })
 
-      blob_manager.delete_blob(MOCK_DEFAULT_STORAGE_ACCOUNT_NAME, container_name, blob_name)
+      expect {
+        blob_manager.delete_blob(MOCK_DEFAULT_STORAGE_ACCOUNT_NAME, container_name, blob_name)
+      }.not_to raise_error
     end
   end
 
@@ -82,7 +84,26 @@ describe Bosh::AzureCloud::BlobManager do
           :request_id => request_id
         })
 
-      blob_manager.delete_blob_snapshot(MOCK_DEFAULT_STORAGE_ACCOUNT_NAME, container_name, blob_name, snapshot_time)
+      expect {
+        blob_manager.delete_blob_snapshot(MOCK_DEFAULT_STORAGE_ACCOUNT_NAME, container_name, blob_name, snapshot_time)
+      }.not_to raise_error
+    end
+  end  
+
+  describe "#get_blob_size_in_bytes" do
+    let(:blob) { instance_double("Blob") }
+
+    before do
+      allow(blob_service).to receive(:get_blob_properties).
+        with(container_name, blob_name).
+        and_return(blob) 
+      allow(blob).to receive(:properties).and_return({:content_length => 1024})
+    end
+
+    it "gets the size of the blob" do
+      expect(
+        blob_manager.get_blob_size_in_bytes(MOCK_DEFAULT_STORAGE_ACCOUNT_NAME, container_name, blob_name)
+      ).to eq(1024)
     end
   end  
 
@@ -307,7 +328,10 @@ describe Bosh::AzureCloud::BlobManager do
     it "should get metadata of the blob" do
       expect(blob_service).to receive(:set_blob_metadata).
         with(container_name, blob_name, encoded_metadata, options)
-      blob_manager.set_blob_metadata(MOCK_DEFAULT_STORAGE_ACCOUNT_NAME, container_name, blob_name, metadata)
+
+      expect {
+        blob_manager.set_blob_metadata(MOCK_DEFAULT_STORAGE_ACCOUNT_NAME, container_name, blob_name, metadata)
+      }.not_to raise_error
     end
   end
 
@@ -657,7 +681,9 @@ describe Bosh::AzureCloud::BlobManager do
           and_return(true)
         expect(blob_service).to receive(:set_container_acl).with('stemcell', 'blob', options)
 
-        blob_manager.prepare(another_storage_account_name, containers: [container_name], is_default_storage_account: true)
+        expect {
+          blob_manager.prepare(another_storage_account_name, containers: [container_name], is_default_storage_account: true)
+        }.not_to raise_error
       end
     end
 
@@ -668,7 +694,9 @@ describe Bosh::AzureCloud::BlobManager do
           and_return(true)
         expect(blob_service).not_to receive(:set_container_acl)
 
-        blob_manager.prepare(another_storage_account_name, containers: [container_name])
+        expect {
+          blob_manager.prepare(another_storage_account_name, containers: [container_name])
+        }.not_to raise_error
       end
     end
   end

--- a/src/bosh_azure_cpi/spec/unit/disk_manager_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/disk_manager_spec.rb
@@ -22,7 +22,9 @@ describe Bosh::AzureCloud::DiskManager do
         expect(blob_manager).to receive(:delete_blob).
           with(storage_account_name, disk_container, "#{disk_name}.vhd")
 
-        disk_manager.delete_disk(disk_name)
+        expect {
+          disk_manager.delete_disk(disk_name)
+        }.not_to raise_error
       end
     end
 
@@ -35,7 +37,9 @@ describe Bosh::AzureCloud::DiskManager do
       it "does not delete the disk" do
         expect(blob_manager).not_to receive(:delete_blob)
 
-        disk_manager.delete_disk(disk_name)
+        expect {
+          disk_manager.delete_disk(disk_name)
+        }.not_to raise_error
       end
     end
   end  
@@ -54,7 +58,9 @@ describe Bosh::AzureCloud::DiskManager do
       expect(blob_manager).to receive(:delete_blob).
         with(storage_account_name, "bosh", "b.status")
 
-      disk_manager.delete_vm_status_files(storage_account_name, "")
+      expect {
+        disk_manager.delete_vm_status_files(storage_account_name, "")
+      }.not_to raise_error
     end
   end  
 
@@ -81,7 +87,9 @@ describe Bosh::AzureCloud::DiskManager do
       expect(blob_manager).to receive(:delete_blob_snapshot).
         with(storage_account_name, disk_container, "#{disk_name}.vhd", snapshot_time)
 
-      disk_manager.delete_snapshot(snapshot_id)
+      expect {
+        disk_manager.delete_snapshot(snapshot_id)
+      }.not_to raise_error
     end
   end  
 
@@ -127,13 +135,29 @@ describe Bosh::AzureCloud::DiskManager do
       expect(blob_manager).to receive(:get_blob_uri).
         with(storage_account_name, disk_container, "#{disk_name}.vhd")
 
-      disk_manager.get_disk_uri(disk_name)
+      expect {
+        disk_manager.get_disk_uri(disk_name)
+      }.not_to raise_error
     end
   end
 
   describe "#get_data_disk_caching" do
     it "returns the right caching" do
       expect(disk_manager.get_data_disk_caching(disk_name)).to eq("None")
+    end
+  end
+
+  describe "#get_disk_size_in_gb" do
+    let(:disk_size) { 42 * 1024 * 1024 * 1024 }
+
+    before do
+      expect(blob_manager).to receive(:get_blob_size_in_bytes).
+        with(storage_account_name, disk_container, "#{disk_name}.vhd").
+        and_return(disk_size)
+    end
+
+    it "returns the disk size" do
+      expect(disk_manager.get_disk_size_in_gb(disk_name)).to eq(42)
     end
   end
 

--- a/src/bosh_azure_cpi/spec/unit/vm_manager_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/vm_manager_spec.rb
@@ -1477,17 +1477,30 @@ describe Bosh::AzureCloud::VMManager do
     context "When the disk is unmanaged disk" do
       let(:instance_id) { "#{MOCK_DEFAULT_STORAGE_ACCOUNT_NAME}-e55144a3-0c06-4240-8f15-9a7bc7b35d1f" }
       let(:disk_uri) { "fake-disk-uri" }
+      let(:disk_size) { 42 }
+      let(:disk_params) {
+        {
+          :disk_name => disk_name,
+          :caching   => caching,
+          :disk_uri  => disk_uri,
+          :disk_size => disk_size,
+          :managed   => false
+        }
+      }
+
       before do
         allow(disk_manager).to receive(:get_disk_uri).
           with(disk_name).and_return(disk_uri)
+        allow(disk_manager).to receive(:get_data_disk_caching).
+          with(disk_name).
+          and_return(caching)
+        allow(disk_manager).to receive(:get_disk_size_in_gb).
+          with(disk_name).and_return(disk_size)
       end
 
       it "attaches the disk to an instance" do
-        expect(disk_manager).to receive(:get_data_disk_caching).
-          with(disk_name).
-          and_return(caching)
         expect(client2).to receive(:attach_disk_to_virtual_machine).
-          with(instance_id, disk_name, disk_uri, caching).
+          with(instance_id, disk_params).
           and_return(disk)
         expect(vm_manager.attach_disk(instance_id, disk_name)).to eq("1")
       end
@@ -1497,18 +1510,27 @@ describe Bosh::AzureCloud::VMManager do
       let(:instance_id) { "e55144a3-0c06-4240-8f15-9a7bc7b35d1f" }
       let(:managed_disk_id) { "fake-id" }
       let(:managed_disk) { {:id => managed_disk_id} }
+      let(:disk_params) {
+        {
+          :disk_name => disk_name,
+          :caching   => caching,
+          :disk_id   => managed_disk_id,
+          :managed   => true
+        }
+      }
+
       before do
         allow(client2).to receive(:get_managed_disk_by_name).
           with(disk_name).
           and_return(managed_disk)
+        allow(disk_manager2).to receive(:get_data_disk_caching).
+          with(disk_name).
+          and_return(caching)
       end
 
       it "attaches the disk to an instance" do
-        expect(disk_manager2).to receive(:get_data_disk_caching).
-          with(disk_name).
-          and_return(caching)
         expect(client2).to receive(:attach_disk_to_virtual_machine).
-          with(instance_id, disk_name, managed_disk_id, caching, true).
+          with(instance_id, disk_params).
           and_return(disk)
         expect(vm_manager2.attach_disk(instance_id, disk_name)).to eq("1")
       end
@@ -1517,17 +1539,30 @@ describe Bosh::AzureCloud::VMManager do
     context "When the vm is unmanaged vm and use_managed_disks is true" do
       let(:instance_id) { "#{MOCK_DEFAULT_STORAGE_ACCOUNT_NAME}-e55144a3-0c06-4240-8f15-9a7bc7b35d1f" }
       let(:disk_uri) { "fake-disk-uri" }
+      let(:disk_size) { 42 }
+      let(:disk_params) {
+        {
+          :disk_name => disk_name,
+          :caching   => caching,
+          :disk_uri  => disk_uri,
+          :disk_size => disk_size,
+          :managed   => false
+        }
+      }
+
       before do
         allow(disk_manager).to receive(:get_disk_uri).
           with(disk_name).and_return(disk_uri)
+        allow(disk_manager).to receive(:get_data_disk_caching).
+          with(disk_name).
+          and_return(caching)
+        allow(disk_manager).to receive(:get_disk_size_in_gb).
+          with(disk_name).and_return(disk_size)
       end
 
       it "attaches the disk to an instance" do
-        expect(disk_manager).to receive(:get_data_disk_caching).
-          with(disk_name).
-          and_return(caching)
         expect(client2).to receive(:attach_disk_to_virtual_machine).
-          with(instance_id, disk_name, disk_uri, caching).
+          with(instance_id, disk_params).
           and_return(disk)
         expect(vm_manager2.attach_disk(instance_id, disk_name)).to eq("1")
       end

--- a/src/bosh_azure_cpi/spec/unit/vm_manager_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/vm_manager_spec.rb
@@ -1472,7 +1472,7 @@ describe Bosh::AzureCloud::VMManager do
   describe "#attach_disk" do
     let(:caching) { "None" }
     let(:disk_name) { "fake-disk-name-#{caching}" }
-    let(:disk) { {:lun => 1} }
+    let(:lun) { 1 }
 
     context "When the disk is unmanaged disk" do
       let(:instance_id) { "#{MOCK_DEFAULT_STORAGE_ACCOUNT_NAME}-e55144a3-0c06-4240-8f15-9a7bc7b35d1f" }
@@ -1501,8 +1501,8 @@ describe Bosh::AzureCloud::VMManager do
       it "attaches the disk to an instance" do
         expect(client2).to receive(:attach_disk_to_virtual_machine).
           with(instance_id, disk_params).
-          and_return(disk)
-        expect(vm_manager.attach_disk(instance_id, disk_name)).to eq("1")
+          and_return(lun)
+        expect(vm_manager.attach_disk(instance_id, disk_name)).to eq("#{lun}")
       end
     end
 
@@ -1531,8 +1531,8 @@ describe Bosh::AzureCloud::VMManager do
       it "attaches the disk to an instance" do
         expect(client2).to receive(:attach_disk_to_virtual_machine).
           with(instance_id, disk_params).
-          and_return(disk)
-        expect(vm_manager2.attach_disk(instance_id, disk_name)).to eq("1")
+          and_return(lun)
+        expect(vm_manager2.attach_disk(instance_id, disk_name)).to eq("#{lun}")
       end
     end
 
@@ -1563,8 +1563,8 @@ describe Bosh::AzureCloud::VMManager do
       it "attaches the disk to an instance" do
         expect(client2).to receive(:attach_disk_to_virtual_machine).
           with(instance_id, disk_params).
-          and_return(disk)
-        expect(vm_manager2.attach_disk(instance_id, disk_name)).to eq("1")
+          and_return(lun)
+        expect(vm_manager2.attach_disk(instance_id, disk_name)).to eq("#{lun}")
       end
     end
   end


### PR DESCRIPTION
- [x] Please check this box once you have run the unit tests
  ```
  pushd src/bosh_azure_cpi
    bundle install
    bundle exec rspec spec/unit/*
  popd
  ```

`523 examples, 0 failures. 2509 / 2749 LOC (91.27%) covered.` => `525 examples. 2520 / 2760 LOC (91.3%) covered.`

### Changelog

* Specify the disk size when attaching an unmanaged disk. Otherwise, the disk size can't be shown by Azure Portal or Azure CLI.
* Returns lun directly when attaching disks in azure_client2
