### PR TITLE
Use the same SCSI ID in Azure & AzureStack

### DIFF
--- a/src/bosh_azure_cpi/lib/cloud/azure/cloud.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/cloud.rb
@@ -396,9 +396,9 @@ module Bosh::AzureCloud
         update_agent_settings(instance_id) do |settings|
           settings["disks"] ||= {}
           settings["disks"]["persistent"] ||= {}
-          settings["disks"]["persistent"][disk_id] =  {
+          settings["disks"]["persistent"][disk_id] = {
             'lun'            => lun,
-            'host_device_id' => get_scsi_host_device_id(azure_properties['environment']),
+            'host_device_id' => AZURE_SCSI_HOST_DEVICE_ID,
 
             # For compatiblity with old stemcells
             'path'           => get_disk_path_name(lun.to_i)
@@ -559,7 +559,7 @@ module Bosh::AzureCloud
         # Azure uses a data disk as the ephermeral disk and the lun is 0
         settings["disks"]["ephemeral"] = {
           'lun'            => '0',
-          'host_device_id' => get_scsi_host_device_id(azure_properties['environment']),
+          'host_device_id' => AZURE_SCSI_HOST_DEVICE_ID,
 
           # For compatiblity with old stemcells
           'path'           => get_disk_path_name(0)
@@ -593,10 +593,6 @@ module Bosh::AzureCloud
       else
         "/dev/sd#{('a'.ord + (lun + 2 - 26) / 26).chr}#{('a'.ord + (lun + 2) % 26).chr}"
       end
-    end
-
-    def get_scsi_host_device_id(environment)
-      environment == ENVIRONMENT_AZURESTACK ? AZURESTACK_SCSI_HOST_DEVICE_ID : AZURE_SCSI_HOST_DEVICE_ID
     end
   end
 end

--- a/src/bosh_azure_cpi/lib/cloud/azure/helpers.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/helpers.rb
@@ -106,7 +106,6 @@ module Bosh::AzureCloud
     LIGHT_STEMCELL_PREFIX           = 'bosh-light-stemcell'
     LIGHT_STEMCELL_PROPERTY         = 'image'
     AZURE_SCSI_HOST_DEVICE_ID       = '{f8b3781b-1e82-4818-a1c3-63d806ec15bb}'
-    AZURESTACK_SCSI_HOST_DEVICE_ID  = '{a8ef3b61-ef7a-467c-89fa-7a3e110d5b9e}'
     METADATA_FOR_MIGRATED_BLOB_DISK = {
       "user_agent" => USER_AGENT_FOR_AZURE_RESOURCE, # The key can't be user-agent because '-' is invalid for blob metadata
       "migrated" => "true"


### PR DESCRIPTION
- [x] Please check this box once you have run the unit tests
  ```
  pushd src/bosh_azure_cpi
    bundle install
    bundle exec rspec spec/unit/*
  popd
  ```

The coverage is changed from `525 examples, 2520 / 2760 LOC (91.3%)` to `525 examples, 2517 / 2757 LOC (91.29%)`. It makes sense because this PR removes three lines of codes.
 
### Changelog

* AzureStack has used the same SCSI host device ID with Azure. With this PR, CPI can work with the stemcell v3232.5+ in AzureStack. 