### PR TITLE
Refine locks

### DIFF
--- a/src/bosh_azure_cpi/lib/cloud/azure/storage_account_manager.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/storage_account_manager.rb
@@ -14,6 +14,20 @@ module Bosh::AzureCloud
       @default_storage_account = nil
     end
 
+    def generate_storage_account_name()
+      available = false
+      until available do
+        # The length of the random storage account name is 24, twice of 12.
+        storage_account_name = "#{SecureRandom.hex(12)}"
+        @logger.debug("generate_storage_account_name - generating a new storage account name")
+        result = @azure_client2.check_storage_account_name_availability(storage_account_name)
+        available = result[:available]
+        @logger.debug("generate_storage_account_name - The generated storage account name is not available") unless available
+      end
+      @logger.debug("generate_storage_account_name - The storage account name `#{storage_account_name}' is available")
+      storage_account_name
+    end
+
     def create_storage_account(storage_account_name, storage_account_type, storage_account_location, tags = {}, is_default_storage_account = false)
       @logger.debug("create_storage_account(#{storage_account_name}, #{storage_account_type}, #{storage_account_location}, #{tags})")
 
@@ -171,7 +185,7 @@ module Bosh::AzureCloud
       end
 
       @logger.debug("Cannot find any valid storage account in the location `#{location}'")
-      storage_account_name = "#{SecureRandom.hex(12)}"
+      storage_account_name = generate_storage_account_name()
       @logger.debug("Creating a storage account `#{storage_account_name}' with the tags `#{STEMCELL_STORAGE_ACCOUNT_TAGS}' in the location `#{location}'")
       create_storage_account(storage_account_name, STORAGE_ACCOUNT_TYPE_STANDARD_LRS, location, STEMCELL_STORAGE_ACCOUNT_TAGS, true)
       @logger.debug("The default storage account is `#{storage_account_name}'")

--- a/src/bosh_azure_cpi/spec/unit/stemcell_manager2_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/stemcell_manager2_spec.rb
@@ -208,7 +208,6 @@ describe Bosh::AzureCloud::StemcellManager2 do
               :location => "#{location}-different"
             }
           }
-
           before do
             allow(storage_account_manager).to receive(:default_storage_account).
               and_return(default_storage_account)
@@ -236,77 +235,136 @@ describe Bosh::AzureCloud::StemcellManager2 do
                 and_return(stemcell_blob_metadata)
             end
 
-            context "when the stemcell exists in the exising storage account" do
+            let(:lock_creating_storage_account) { instance_double(Bosh::AzureCloud::Helpers::FileMutex) }
+            let(:lock_copy_blob) { instance_double(Bosh::AzureCloud::Helpers::FileMutex) }
+            before do
+              allow(Bosh::AzureCloud::Helpers::FileMutex).to receive(:new).and_return(lock_creating_storage_account, lock_copy_blob)
+              allow(lock_creating_storage_account).to receive(:lock).and_return(true)
+              allow(lock_creating_storage_account).to receive(:unlock)
+            end
+
+            context "when the lock of copying blob is not acquired" do
               before do
-                allow(blob_manager).to receive(:get_blob_properties).
-                  with(existing_storage_account_name, stemcell_container, "#{stemcell_name}.vhd").
-                  and_return({"foo"=>"bar"}) # The stemcell exists in the existing storage account
+                allow(lock_copy_blob).to receive(:lock).and_return(false)
+                allow(lock_copy_blob).to receive(:expired).and_return("fake-expired-value")
               end
 
-              it "should create a new user image and return the user image information" do
-                expect(blob_manager).not_to receive(:get_blob_uri).
-                  with(MOCK_DEFAULT_STORAGE_ACCOUNT_NAME, stemcell_container, "#{stemcell_name}.vhd")
-                expect(blob_manager).not_to receive(:copy_blob)
-                stemcell_info = stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location)
-                expect(stemcell_info.uri).to eq(user_image_id)
-                expect(stemcell_info.metadata).to eq(tags)
+              context "when copying blob timeouts" do
+                before do
+                  allow(lock_copy_blob).to receive(:wait).and_raise("timeout")
+                end
+
+                it "should raise a timeout error" do
+                  expect(blob_manager).not_to receive(:get_blob_uri)
+                  expect(blob_manager).not_to receive(:copy_blob)
+                  expect {
+                    stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location)
+                  }.to raise_error /get_user_image: Failed to finish the copying process of the stemcell/
+                end
+              end
+
+              context "when copying blob finishes before it timeouts" do
+                before do
+                  allow(lock_copy_blob).to receive(:wait)
+                end
+
+                it "should create a new user image and return the user image information" do
+                  expect(blob_manager).not_to receive(:copy_blob)
+                  stemcell_info = stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location)
+                  expect(stemcell_info.uri).to eq(user_image_id)
+                  expect(stemcell_info.metadata).to eq(tags)
+                end
               end
             end
 
-            context "when the stemcell doesn't exist in the exising storage account" do
-              let(:lock_copy_blob) { instance_double(Bosh::AzureCloud::Helpers::FileMutex) }
+            context "when the lock of copying blob is acquired" do
               before do
-                allow(blob_manager).to receive(:get_blob_properties).
-                  with(existing_storage_account_name, stemcell_container, "#{stemcell_name}.vhd").
-                  and_return(nil) # The stemcell doesn't exist in the existing storage account
-                allow(lock_copy_blob).to receive(:synchronize)
+                allow(lock_copy_blob).to receive(:lock).and_return(true)
               end
 
-              it "should copy the stemcell from default storage account to an existing storage account, create a new user image and return the user image information" do
-                expect(blob_manager).to receive(:get_blob_uri).
-                  with(MOCK_DEFAULT_STORAGE_ACCOUNT_NAME, stemcell_container, "#{stemcell_name}.vhd").
-                  and_return(stemcell_blob_uri)
-                expect(blob_manager).to receive(:copy_blob).
-                  with(existing_storage_account_name, stemcell_container, "#{stemcell_name}.vhd", stemcell_blob_uri)
-                stemcell_info = stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location)
-                expect(stemcell_info.uri).to eq(user_image_id)
-                expect(stemcell_info.metadata).to eq(tags)
+              context "when the stemcell exists in the exising storage account" do
+                before do
+                  allow(blob_manager).to receive(:get_blob_properties).
+                    with(existing_storage_account_name, stemcell_container, "#{stemcell_name}.vhd").
+                    and_return({"foo"=>"bar"}) # The stemcell exists in the existing storage account
+                  allow(lock_copy_blob).to receive(:unlock)
+                end
+
+                it "should create a new user image and return the user image information" do
+                  expect(blob_manager).not_to receive(:get_blob_uri).
+                    with(MOCK_DEFAULT_STORAGE_ACCOUNT_NAME, stemcell_container, "#{stemcell_name}.vhd")
+                  expect(blob_manager).not_to receive(:copy_blob)
+                  stemcell_info = stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location)
+                  expect(stemcell_info.uri).to eq(user_image_id)
+                  expect(stemcell_info.metadata).to eq(tags)
+                end
+              end
+
+              context "when the stemcell doesn't exist in the exising storage account" do
+                before do
+                  allow(blob_manager).to receive(:get_blob_properties).
+                    with(existing_storage_account_name, stemcell_container, "#{stemcell_name}.vhd").
+                    and_return(nil) # The stemcell doesn't exist in the existing storage account
+                end
+
+                context "when copying blob is successful" do
+                  before do
+                    allow(lock_copy_blob).to receive(:update)
+                    allow(lock_copy_blob).to receive(:unlock)
+                  end
+
+                  it "should copy the stemcell from default storage account to an existing storage account, create a new user image and return the user image information" do
+                    expect(blob_manager).to receive(:get_blob_uri).
+                      with(MOCK_DEFAULT_STORAGE_ACCOUNT_NAME, stemcell_container, "#{stemcell_name}.vhd").
+                      and_return(stemcell_blob_uri)
+                    expect(blob_manager).to receive(:copy_blob).
+                      with(existing_storage_account_name, stemcell_container, "#{stemcell_name}.vhd", stemcell_blob_uri)
+                    stemcell_info = stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location)
+                    expect(stemcell_info.uri).to eq(user_image_id)
+                    expect(stemcell_info.metadata).to eq(tags)
+                  end
+                end
+
+                context "when copying blob raises an error" do
+                  before do
+                    allow(blob_manager).to receive(:get_blob_uri).
+                      with(MOCK_DEFAULT_STORAGE_ACCOUNT_NAME, stemcell_container, "#{stemcell_name}.vhd").
+                      and_return(stemcell_blob_uri)
+                    expect(blob_manager).to receive(:copy_blob).
+                      with(existing_storage_account_name, stemcell_container, "#{stemcell_name}.vhd", stemcell_blob_uri).
+                      and_raise("Error when copying blobs")
+                  end
+
+                  it "should raise an error" do
+                    expect(lock_copy_blob).not_to receive(:unlock)
+                    expect {
+                      stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location)
+                    }.to raise_error /Error when copying blobs/
+                  end
+                end
               end
             end
           end
 
           context "when the storage account with tags doesn't exist in the specified location" do
-            let(:new_storage_account_name) { "54657da5936725e199fd616e" }
-            let(:storage_account) {
-              [
-                {
-                  :name => new_storage_account_name,
-                  :location => location
-                }
-              ]
-            }
-
-            before do
-              allow(client2).to receive(:list_storage_accounts).and_return([])
-              allow(SecureRandom).to receive(:hex).and_return(new_storage_account_name)
-            end
-
             context "when it fails to create the new storage account" do
               let(:lock_creating_storage_account) { instance_double(Bosh::AzureCloud::Helpers::FileMutex) }
               before do
-                allow(Bosh::AzureCloud::Helpers::FileMutex).to receive(:new).with('/tmp/bosh-lock-create-storage-account', anything).
+                allow(Bosh::AzureCloud::Helpers::FileMutex).to receive(:new).with("/tmp/bosh-lock-create-storage-account-#{location}", anything).
                   and_return(lock_creating_storage_account)
               end
 
               context "when an error is thrown when creating the new storage account" do
                 before do
-                  # The error should be raised by @storage_account_manager.create_storage_account. But it will be filtered by mutex.synchronize and not catched.
-                  # So, to make the case passed, we just raise the error from mutex.synchronize
-                  allow(lock_creating_storage_account).to receive(:synchronize).
+                  allow(lock_creating_storage_account).to receive(:lock).and_return(true)
+                  allow(client2).to receive(:list_storage_accounts).and_return([])
+                  allow(storage_account_manager).to receive(:generate_storage_account_name)
+                  allow(storage_account_manager).to receive(:create_storage_account).
                     and_raise("Error when creating storage account")
                 end
 
                 it "raise an error" do
+                  expect(lock_creating_storage_account).not_to receive(:unlock)
                   expect {
                     stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location)
                   }.to raise_error /Error when creating storage account/
@@ -315,11 +373,14 @@ describe Bosh::AzureCloud::StemcellManager2 do
 
               context "when it timeouts to create the new storage account" do
                 before do
-                  allow(lock_creating_storage_account).to receive(:synchronize).
+                  allow(lock_creating_storage_account).to receive(:lock).and_return(false)
+                  allow(lock_creating_storage_account).to receive(:wait).
                     and_raise('timeout')
+                  allow(lock_creating_storage_account).to receive(:expired).and_return("fake-expired-value")
                 end
 
                 it "raise an error" do
+                  expect(lock_creating_storage_account).not_to receive(:unlock)
                   expect {
                     stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location)
                   }.to raise_error /Failed to finish the creation of the storage account/
@@ -327,13 +388,31 @@ describe Bosh::AzureCloud::StemcellManager2 do
               end
             end
 
-            context "when it creates the new storage account successfully" do
+            context "when it creates the new storage account successfully, and copies the stemcell from default storage account to the new storage account" do
+              let(:new_storage_account_name) { "54657da5936725e199fd616e" }
+              let(:storage_account) {
+                [
+                  {
+                    :name => new_storage_account_name,
+                    :location => location,
+                    :tags => STEMCELL_STORAGE_ACCOUNT_TAGS
+                  }
+                ]
+              }
               let(:lock_creating_storage_account) { instance_double(Bosh::AzureCloud::Helpers::FileMutex) }
               let(:lock_copy_blob) { instance_double(Bosh::AzureCloud::Helpers::FileMutex) }
 
               before do
+                allow(Bosh::AzureCloud::Helpers::FileMutex).to receive(:new).and_return(lock_creating_storage_account, lock_copy_blob)
+
+                # Create a new storage account
+                allow(lock_creating_storage_account).to receive(:lock).and_return(true)
+                allow(lock_creating_storage_account).to receive(:unlock)
+                allow(storage_account_manager).to receive(:generate_storage_account_name).and_return(new_storage_account_name)
                 allow(storage_account_manager).to receive(:create_storage_account).
                   with(new_storage_account_name, storage_account_type, location, STEMCELL_STORAGE_ACCOUNT_TAGS)
+                allow(client2).to receive(:list_storage_accounts).and_return([], storage_account) # The first return value nil means the storage account doesn't exist, the second value is returned after the storage account is created.
+
                 # The following two allows are for get_stemcell_info of stemcell_manager.rb
                 allow(blob_manager).to receive(:get_blob_uri).
                   with(new_storage_account_name, stemcell_container, "#{stemcell_name}.vhd").
@@ -344,59 +423,21 @@ describe Bosh::AzureCloud::StemcellManager2 do
                 allow(blob_manager).to receive(:get_blob_properties).
                   with(new_storage_account_name, stemcell_container, "#{stemcell_name}.vhd").
                   and_return(nil) # The stemcell doesn't exist in the new storage account
-                allow(Bosh::AzureCloud::Helpers::FileMutex).to receive(:new).and_return(lock_creating_storage_account, lock_copy_blob)
-                allow(lock_creating_storage_account).to receive(:synchronize)
+
+                # Copy blob
+                allow(lock_copy_blob).to receive(:lock).and_return(true)
+                allow(lock_copy_blob).to receive(:unlock)
+                allow(blob_manager).to receive(:get_blob_uri).
+                  with(MOCK_DEFAULT_STORAGE_ACCOUNT_NAME, stemcell_container, "#{stemcell_name}.vhd").
+                  and_return(stemcell_blob_uri)
+                allow(blob_manager).to receive(:copy_blob).
+                  with(new_storage_account_name, stemcell_container, "#{stemcell_name}.vhd", stemcell_blob_uri)
               end
 
-              context "when an error is thrown when copying the stemcell from default storage account to the new storage account" do
-                before do
-                  allow(blob_manager).to receive(:get_blob_uri).
-                    with(MOCK_DEFAULT_STORAGE_ACCOUNT_NAME, stemcell_container, "#{stemcell_name}.vhd").
-                    and_return(stemcell_blob_uri)
-                  # The error should be raised by @blob_manager.copy_blob. But it will be filtered by mutex.synchronize and not catched.
-                  # So, to make the case passed, we just raise the error from mutex.synchronize
-                  allow(lock_copy_blob).to receive(:synchronize).
-                    and_raise("Error when copying blobs")
-                end
-
-                it "raise an error" do
-                  expect {
-                    stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location)
-                  }.to raise_error /Error when copying blobs/
-                end
-              end
-
-              context "when it timeouts to copy the stemcell from default storage account to the new storage account" do
-                before do
-                  allow(blob_manager).to receive(:get_blob_uri).
-                    with(MOCK_DEFAULT_STORAGE_ACCOUNT_NAME, stemcell_container, "#{stemcell_name}.vhd").
-                    and_return(stemcell_blob_uri)
-                  allow(lock_copy_blob).to receive(:synchronize).
-                    and_raise("timeout")
-                end
-
-                it "raise an error" do
-                  expect {
-                    stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location)
-                  }.to raise_error /Failed to finish the copying process of the stemcell/
-                end
-              end
-
-              context "when it copies the stemcell from default storage account to the new storage account" do
-                before do
-                  allow(blob_manager).to receive(:get_blob_uri).
-                    with(MOCK_DEFAULT_STORAGE_ACCOUNT_NAME, stemcell_container, "#{stemcell_name}.vhd").
-                    and_return(stemcell_blob_uri)
-                  allow(blob_manager).to receive(:copy_blob).
-                    with(new_storage_account_name, stemcell_container, "#{stemcell_name}.vhd", stemcell_blob_uri)
-                  allow(lock_copy_blob).to receive(:synchronize)
-                end
-
-                it "should create a new user image and return the user image information" do
-                  stemcell_info = stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location)
-                  expect(stemcell_info.uri).to eq(user_image_id)
-                  expect(stemcell_info.metadata).to eq(tags)
-                end
+              it "should create a new user image and return the user image information" do
+                stemcell_info = stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location)
+                expect(stemcell_info.uri).to eq(user_image_id)
+                expect(stemcell_info.metadata).to eq(tags)
               end
             end
           end
@@ -438,15 +479,8 @@ describe Bosh::AzureCloud::StemcellManager2 do
             end
           end
 
-          context "when the provisioning state of user image is Succeeded finally" do
-            let(:user_image_in_progress) {
-              {
-                :id => user_image_id,
-                :tags => tags,
-                :provisioning_state => "InProgress"
-              }
-            }
-            let(:user_image_succeeded) {
+          context "when the user image is created successfully" do
+            let(:user_image) {
               {
                 :id => user_image_id,
                 :tags => tags,
@@ -457,71 +491,13 @@ describe Bosh::AzureCloud::StemcellManager2 do
             before do
               allow(client2).to receive(:get_user_image_by_name).
                 with(user_image_name).
-                and_return(nil, user_image_in_progress, user_image_in_progress, user_image_succeeded) # The first return value nil means the user image doesn't exist, the others are returned after the image is created.
+                and_return(user_image)
             end
 
-            it "should create a new user image and check the provisionging state" do
+            it "should return the new user image" do
               stemcell_info = stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location)
               expect(stemcell_info.uri).to eq(user_image_id)
               expect(stemcell_info.metadata).to eq(tags)
-            end
-          end
-
-          context "when the provisioning state of user image is Failed finally" do
-            let(:user_image_in_progress) {
-              {
-                :id => user_image_id,
-                :tags => tags,
-                :provisioning_state => "InProgress"
-              }
-            }
-            let(:user_image_failed) {
-              {
-                :id => user_image_id,
-                :tags => tags,
-                :provisioning_state => "Failed"
-              }
-            }
-
-            before do
-              allow(client2).to receive(:get_user_image_by_name).
-                with(user_image_name).
-                and_return(nil, user_image_in_progress, user_image_in_progress, user_image_failed) # The first return value nil means the user image doesn't exist, the others are returned after the image is created.
-            end
-
-            it "should raise an error" do
-              expect {
-                stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location)
-              }.to raise_error(/get_user_image: Failed to create a user image `#{user_image_name}' whose provisioning state is `Failed'/)
-            end
-          end
-
-          context "when the provisioning state of user image is Canceled finally" do
-            let(:user_image_in_progress) {
-              {
-                :id => user_image_id,
-                :tags => tags,
-                :provisioning_state => "InProgress"
-              }
-            }
-            let(:user_image_canceled) {
-              {
-                :id => user_image_id,
-                :tags => tags,
-                :provisioning_state => "Canceled"
-              }
-            }
-
-            before do
-              allow(client2).to receive(:get_user_image_by_name).
-                with(user_image_name).
-                and_return(nil, user_image_in_progress, user_image_in_progress, user_image_canceled) # The first return value nil means the user image doesn't exist, the others are returned after the image is created.
-            end
-
-            it "should raise an error" do
-              expect {
-                stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location)
-              }.to raise_error(/get_user_image: Failed to create a user image `#{user_image_name}' whose provisioning state is `Canceled'/)
             end
           end
         end


### PR DESCRIPTION
- [x] Please check this box once you have run the unit tests
  ```
  pushd src/bosh_azure_cpi
    bundle install
    bundle exec rspec spec/unit/*
  popd
  ```

The unit test coverage is increased from `633 examples, 0 failures. 2760 / 2928 LOC (94.26%) covered` to `643 examples, 0 failures. 2786 / 2945 LOC (94.6%) covered.`.

### Changelog

* Remove the method `synchronize` of `FileMutex`. Use `lock` & `unlock` directly.
* Fix `lock` & `wait` to avoid race condition.
* Fix a bug of the lock file name, so that the specific resource can be locked.
