### PR TITLE
Set the correct OS disk size for Windows

### DIFF
--- a/src/bosh_azure_cpi/lib/cloud/azure/disk_manager2.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/disk_manager2.rb
@@ -141,27 +141,13 @@ module Bosh::AzureCloud
       "#{MANAGED_OS_DISK_PREFIX}-#{vm_name}-#{EPHEMERAL_DISK_POSTFIX}"
     end
 
-    def os_disk(vm_name, minimum_disk_size)
-      disk_size = nil
-      root_disk = @resource_pool.fetch('root_disk', {})
-      size = root_disk.fetch('size', nil)
-      unless size.nil?
-        validate_disk_size_type(size)
-        cloud_error("root_disk.size `#{size}' is smaller than the default OS disk size `#{minimum_disk_size}' MiB") if size < minimum_disk_size
-        disk_size = (size/1024.0).ceil
-        validate_disk_size(disk_size*1024)
-      end
-
+    def os_disk(vm_name, stemcell_info)
       disk_caching = @resource_pool.fetch('caching', 'ReadWrite')
       validate_disk_caching(disk_caching)
 
-      # The default OS disk size depends on the size of the VHD in the stemcell which is 3 GiB for now.
-      # When using OS disk to store the ephemeral data and root_disk.size is not set,
-      # resize it to the minimum disk size if the minimum disk size is larger than 30 GiB;
-      # resize it to 30 GiB if the minimum disk size is smaller than 30 GiB.
-      if disk_size.nil? && ephemeral_disk(vm_name).nil?
-        disk_size = (minimum_disk_size/1024.0).ceil < 30 ? 30 : (minimum_disk_size/1024.0).ceil
-      end
+      root_disk_size = @resource_pool.fetch('root_disk', {}).fetch('size', nil)
+      use_root_disk_for_ephemeral_data = @resource_pool.fetch('ephemeral_disk', {}).fetch('use_root_disk', false)
+      disk_size = get_os_disk_size(root_disk_size, stemcell_info, use_root_disk_for_ephemeral_data)
 
       return {
         :disk_name    => generate_os_disk_name(vm_name),

--- a/src/bosh_azure_cpi/lib/cloud/azure/light_stemcell_manager.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/light_stemcell_manager.rb
@@ -61,6 +61,7 @@ module Bosh::AzureCloud
       @logger.debug("list_platform_image_versions(#{location}, #{stemcell_info.image['publisher']}, #{stemcell_info.image['offer']}, #{stemcell_info.image['sku']})")
       versions = @azure_client2.list_platform_image_versions(location, stemcell_info.image['publisher'], stemcell_info.image['offer'], stemcell_info.image['sku'])
       version = versions.find{|v| v[:name] == stemcell_info.image['version'] }
+      @logger.debug("list_platform_image_versions: The version `#{stemcell_info.image['version']}' of the image is not found") if version.nil?
       !version.nil?
     end
   end

--- a/src/bosh_azure_cpi/lib/cloud/azure/vm_manager.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/vm_manager.rb
@@ -30,11 +30,11 @@ module Bosh::AzureCloud
 
       # Raise errors if the properties are not valid before doing others.
       if @use_managed_disks
-        os_disk = @disk_manager2.os_disk(vm_name, stemcell_info.disk_size)
+        os_disk = @disk_manager2.os_disk(vm_name, stemcell_info)
         ephemeral_disk = @disk_manager2.ephemeral_disk(vm_name)
       else
         storage_account_name = instance_id.storage_account_name()
-        os_disk = @disk_manager.os_disk(storage_account_name, vm_name, stemcell_info.disk_size)
+        os_disk = @disk_manager.os_disk(storage_account_name, vm_name, stemcell_info)
         ephemeral_disk = @disk_manager.ephemeral_disk(storage_account_name, vm_name)
       end
 

--- a/src/bosh_azure_cpi/spec/unit/helpers_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/helpers_spec.rb
@@ -601,14 +601,8 @@ describe Bosh::AzureCloud::Helpers do
           {
             "name" => "fake-name",
             "version" => "fake-version",
-            "infrastructure" => "azure",
-            "hypervisor" => "hyperv",
             "disk" => "3072",
-            "disk_format" => "vhd",
-            "container_format" => "bare",
             "os_type" => "linux",
-            "os_distro" => "ubuntu",
-            "architecture" => "x86_64",
           }
         }
 
@@ -618,7 +612,7 @@ describe Bosh::AzureCloud::Helpers do
           expect(stemcell_info.os_type).to eq("linux")
           expect(stemcell_info.name).to eq("fake-name")
           expect(stemcell_info.version).to eq("fake-version")
-          expect(stemcell_info.disk_size).to eq(3072)
+          expect(stemcell_info.image_size).to eq(3072)
           expect(stemcell_info.is_light_stemcell?).to be(false)
           expect(stemcell_info.image_reference).to be(nil)
         end
@@ -630,14 +624,8 @@ describe Bosh::AzureCloud::Helpers do
           {
             "name" => "fake-name",
             "version" => "fake-version",
-            "infrastructure" => "azure",
-            "hypervisor" => "hyperv",
             "disk" => "3072",
-            "disk_format" => "vhd",
-            "container_format" => "bare",
             "os_type" => "linux",
-            "os_distro" => "ubuntu",
-            "architecture" => "x86_64",
             "image" => {"publisher"=>"bosh", "offer"=>"UbuntuServer", "sku"=>"trusty", "version"=>"fake-version"}
           }
         }
@@ -648,12 +636,86 @@ describe Bosh::AzureCloud::Helpers do
           expect(stemcell_info.os_type).to eq("linux")
           expect(stemcell_info.name).to eq("fake-name")
           expect(stemcell_info.version).to eq("fake-version")
-          expect(stemcell_info.disk_size).to eq(3072)
+          expect(stemcell_info.image_size).to eq(3072)
           expect(stemcell_info.is_light_stemcell?).to be(true)
           expect(stemcell_info.image_reference['publisher']).to eq('bosh')
           expect(stemcell_info.image_reference['offer']).to eq('UbuntuServer')
           expect(stemcell_info.image_reference['sku']).to eq('trusty')
           expect(stemcell_info.image_reference['version']).to eq('fake-version')
+        end
+      end
+
+      context "when os_type is linux" do
+        context "when disk is not specified" do
+          let(:uri) { "fake-uri" }
+          let(:metadata) {
+            {
+              "name" => "fake-name",
+              "version" => "fake-version",
+              "os_type" => "linux",
+            }
+          }
+
+          it "should return the default image size" do
+            stemcell_info = Bosh::AzureCloud::Helpers::StemcellInfo.new(uri, metadata)
+            expect(stemcell_info.os_type).to eq("linux")
+            expect(stemcell_info.image_size).to eq(3 * 1024)
+          end
+        end
+
+        context "when disk is specified" do
+          let(:uri) { "fake-uri" }
+          let(:metadata) {
+            {
+              "name" => "fake-name",
+              "version" => "fake-version",
+              "disk" => "12345",
+              "os_type" => "linux",
+            }
+          }
+
+          it "should return the image size specified in the stemcell properties" do
+            stemcell_info = Bosh::AzureCloud::Helpers::StemcellInfo.new(uri, metadata)
+            expect(stemcell_info.os_type).to eq("linux")
+            expect(stemcell_info.image_size).to eq(12345)
+          end
+        end
+      end
+
+      context "when os_type is windows" do
+        context "when disk is not specified" do
+          let(:uri) { "fake-uri" }
+          let(:metadata) {
+            {
+              "name" => "fake-name",
+              "version" => "fake-version",
+              "os_type" => "windows",
+            }
+          }
+
+          it "should return the default image size" do
+            stemcell_info = Bosh::AzureCloud::Helpers::StemcellInfo.new(uri, metadata)
+            expect(stemcell_info.os_type).to eq("windows")
+            expect(stemcell_info.image_size).to eq(128 * 1024)
+          end
+        end
+
+        context "when disk is specified" do
+          let(:uri) { "fake-uri" }
+          let(:metadata) {
+            {
+              "name" => "fake-name",
+              "version" => "fake-version",
+              "disk" => "12345",
+              "os_type" => "windows",
+            }
+          }
+
+          it "should return the image size specified in the stemcell properties" do
+            stemcell_info = Bosh::AzureCloud::Helpers::StemcellInfo.new(uri, metadata)
+            expect(stemcell_info.os_type).to eq("windows")
+            expect(stemcell_info.image_size).to eq(12345)
+          end
         end
       end
     end
@@ -667,7 +729,7 @@ describe Bosh::AzureCloud::Helpers do
         expect(stemcell_info.os_type).to eq('linux')
         expect(stemcell_info.name).to be(nil)
         expect(stemcell_info.version).to be(nil)
-        expect(stemcell_info.disk_size).to eq(3072)
+        expect(stemcell_info.image_size).to eq(3072)
       end
     end
   end

--- a/src/bosh_azure_cpi/spec/unit/vm_manager/create_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/vm_manager/create_spec.rb
@@ -123,7 +123,7 @@ describe Bosh::AzureCloud::VMManager do
         and_return(os_type)
       allow(stemcell_info).to receive(:is_windows?).
         and_return(false)
-      allow(stemcell_info).to receive(:disk_size).
+      allow(stemcell_info).to receive(:image_size).
         and_return(nil)
       allow(stemcell_info).to receive(:is_light_stemcell?).
         and_return(false)


### PR DESCRIPTION
Fixes #282 

- [x] Please check this box once you have run the unit tests
  ```
  pushd src/bosh_azure_cpi
    bundle install
    bundle exec rspec spec/unit/*
  popd
  ```

The unit test coverage is increased from `643 examples, 0 failures. 2786 / 2945 LOC (94.6%) covered.` to `656 examples, 0 failures. 2798 / 2954 LOC (94.72%) covered.`.

### Changelog

* Set the correct OS disk size for Windows
* Add a message if the version of the Windows image is not found
