### PR TITLE
Refine http retry policy and logging redaction list

### DIFF
--- a/src/bosh_azure_cpi/lib/cloud/azure/azure_client2.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/azure_client2.rb
@@ -2035,7 +2035,7 @@ module Bosh::AzureCloud
         raise e
       rescue => e
         # Below error message depends on require "resolv-replace.rb" in lib/cloud/azure.rb
-        if e.inspect.include?(ERROR_SOCKET_UNKNOWN_HOSTNAME) && retry_count < AZURE_MAX_RETRY_COUNT
+        if (e.inspect.include?(ERROR_SOCKET_UNKNOWN_HOSTNAME) || e.inspect.include?(ERROR_CONNECTION_REFUSED)) && retry_count < AZURE_MAX_RETRY_COUNT
           @logger.warn("http_get_response - Fail for a DNS resolve error. Will retry after #{retry_after} seconds.")
           retry_count += 1
           sleep(retry_after)

--- a/src/bosh_azure_cpi/lib/cloud/azure/helpers.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/helpers.rb
@@ -131,6 +131,7 @@ module Bosh::AzureCloud
     # REST Connection Errors
     ERROR_OPENSSL_RESET           = 'SSL_connect'
     ERROR_SOCKET_UNKNOWN_HOSTNAME = 'SocketError: Hostname not known'
+    ERROR_CONNECTION_REFUSED      = 'Connection refused'
 
     # Length of instance id
     UUID_LENGTH                   = 36

--- a/src/bosh_azure_cpi/spec/unit/azure_client2/azure_client2_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client2/azure_client2_spec.rb
@@ -279,7 +279,31 @@ describe Bosh::AzureCloud::AzureClient2 do
             ).not_to be_nil
           end
         end
+        
+        context "when 'Connection refused - connect(2) for \"xx.xxx.xxx.xx\" port 443'  is raised at the first time but returns 200 at the second time" do
+          before do
+            stub_request(:post, token_uri).
+              to_raise('Connection refused - connect(2) for \"xx.xxx.xxx.xx\" port 443').then.
+              to_return(
+                :status => 200,
+                :body => {
+                  "access_token" => valid_access_token,
+                  "expires_on" => expires_on
+                }.to_json,
+                :headers => {})
+            stub_request(:get, resource_uri).to_return(
+              :status => 200,
+              :body => response_body,
+              :headers => {})
+          end
 
+          it "should return the resource if response body is not null" do
+            expect(
+              azure_client2.get_resource_by_id(url, { 'api-version' => api_version })
+            ).not_to be_nil
+          end
+        end
+        
         context "when OpenSSL::SSL::SSLError with specified message 'SSL_connect' is raised at the first time but returns 200 at the second time" do
           before do
             stub_request(:post, token_uri).

--- a/src/bosh_azure_cpi/spec/unit/azure_client2/create_virtual_machine_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client2/create_virtual_machine_spec.rb
@@ -925,7 +925,7 @@ describe Bosh::AzureCloud::AzureClient2 do
               :headers => {})
             stub_request(:put, vm_uri).with(body: request_body).to_return(
               :status => 200,
-              :body => '',
+              :body => request_body.to_json.to_s,
               :headers => {
                 "azure-asyncoperation" => operation_status_link
               })
@@ -941,7 +941,7 @@ describe Bosh::AzureCloud::AzureClient2 do
             logs = logger_strio.string
             expect(logs.include?(windows_password)).to be(false)
             expect(logs.include?(MOCK_AZURE_CLIENT_SECRET)).to be(false)
-            expect(logs.scan('<redacted>').count).to eq(2)
+            expect(logs.scan('<redacted>').count).to eq(5)
           end
         end
 

--- a/src/bosh_azure_cpi/spec/unit/azure_client2/get_operation_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client2/get_operation_spec.rb
@@ -712,6 +712,29 @@ describe Bosh::AzureCloud::AzureClient2 do
           azure_client2.get_storage_account_by_name(storage_account_name)
         }.not_to raise_error
       end
+      
+      it "should not raise error if it raises 'Connection refused - connect(2) for \"xx.xxx.xxx.xx\" port 443' at the first time but returns 200 at the second time" do
+        stub_request(:post, token_uri).to_return(
+          :status => 200,
+          :body => {
+            "access_token" => valid_access_token,
+            "expires_on" => expires_on
+          }.to_json,
+          :headers => {})
+        stub_request(:get, storage_account_uri).
+            to_raise('Connection refused - connect(2) for \"xx.xxx.xxx.xx\" port 443').then.
+            to_return(
+              {
+                :status => 200,
+                :body => '',
+                :headers => {}
+              }
+            )
+
+        expect {
+          azure_client2.get_storage_account_by_name(storage_account_name)
+        }.not_to raise_error
+      end
     end
 
     context "when token is valid, getting response succeeds" do


### PR DESCRIPTION
Thanks for submitting a pull request!

All pull request submitters and commit authors must have a Contributor License Agreement (CLA) on-file with us. Please sign the appropriate CLA ([individual](http://cloudfoundry.org/pdfs/CFF_Individual_CLA.pdf) or [corporate](http://cloudfoundry.org/pdfs/CFF_Corporate_CLA.pdf)).

When sending signed CLA please provide your github username in case of individual CLA or the list of github usernames that can make pull requests on behalf of your organization.

If you are confident that you're covered under a Corporate CLA, please make sure you've publicized your membership in the appropriate Github Org, per [these instructions](https://help.github.com/articles/publicizing-or-concealing-organization-membership/).

- [x] Please check this box once you have run the unit tests
  ```
  pushd src/bosh_azure_cpi
    bundle install
    bundle exec rspec spec/unit/*
  popd
  ```

### Changelog

* Solve https://github.com/cloudfoundry-incubator/bosh-azure-cpi-release/issues/292 . Add connection refused error as a scenario to retry.
* Solve https://github.com/cloudfoundry-incubator/bosh-azure-cpi-release/issues/296 . Redact custom data in logging in both request body and response body.
