### PR TITLE
Support CA cert in Azure Stack

### DIFF
--- a/jobs/azure_cpi/spec
+++ b/jobs/azure_cpi/spec
@@ -4,6 +4,7 @@ name: azure_cpi
 templates:
   cpi.erb: bin/cpi
   cpi.json.erb: config/cpi.json
+  azure_stack_ca_cert.pem.erb: config/azure_stack_ca_cert.pem
 
 packages:
 - ruby_azure_cpi
@@ -61,6 +62,12 @@ properties:
   azure.azure_stack.use_http_to_access_storage_account:
     description: Flag for using HTTP to access storage account rather than the default HTTPS
     default: false
+  azure.azure_stack.ca_cert:
+    description: All required custom CA certificates for AzureStack
+    example:
+      -----BEGIN CERTIFICATE-----
+      MII...
+      -----END CERTIFICATE-----
 
   registry.username:
     description: User to access the Registry

--- a/jobs/azure_cpi/templates/azure_stack_ca_cert.pem.erb
+++ b/jobs/azure_cpi/templates/azure_stack_ca_cert.pem.erb
@@ -1,0 +1,1 @@
+<%= p('azure.azure_stack.ca_cert', '') %>

--- a/src/bosh_azure_cpi/lib/cloud/azure/azure_client2.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/azure_client2.rb
@@ -1878,8 +1878,13 @@ module Bosh::AzureCloud
     def http(uri)
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true
-      if @azure_properties['environment'] == ENVIRONMENT_AZURESTACK && @azure_properties['azure_stack']['skip_ssl_validation']
-        http.verify_mode = OpenSSL::SSL::VERIFY_NONE 
+      if @azure_properties['environment'] == ENVIRONMENT_AZURESTACK
+        if @azure_properties['azure_stack']['skip_ssl_validation']
+          http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+        else
+          # The CA cert is only specified for the requests to AzureStack domain. If specified for other domains, the request will fail.
+          http.ca_file = get_ca_file_path if uri.host.include?(@azure_properties['azure_stack']['domain'])
+        end
       end
       # The default value for read_timeout is 60 seconds.
       # The default value for open_timeout is nil before ruby 2.3.0 so set it to 60 seconds here.

--- a/src/bosh_azure_cpi/lib/cloud/azure/storage_account_manager.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/storage_account_manager.rb
@@ -198,9 +198,7 @@ module Bosh::AzureCloud
     def has_stemcell_table?(name)
       storage_account = @azure_client2.get_storage_account_by_name(name)
       storage_account[:key] = @azure_client2.get_storage_account_keys_by_name(name)[0]
-      use_http = false
-      use_http = @azure_properties['azure_stack']['use_http_to_access_storage_account'] if @azure_properties['environment'] == ENVIRONMENT_AZURESTACK
-      azure_storage_client = initialize_azure_storage_client(storage_account, 'table', use_http)
+      azure_storage_client = initialize_azure_storage_client(storage_account, @azure_properties)
       table_service_client = azure_storage_client.table_client
       table_service_client.with_filter(Azure::Storage::Core::Filter::ExponentialRetryPolicyFilter.new)
       table_service_client.with_filter(Azure::Core::Http::DebugFilter.new) if is_debug_mode(@azure_properties)

--- a/src/bosh_azure_cpi/lib/cloud/azure/table_manager.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/table_manager.rb
@@ -11,9 +11,7 @@ module Bosh::AzureCloud
 
       storage_account = @storage_account_manager.default_storage_account
       storage_account[:key] = @azure_client2.get_storage_account_keys_by_name(storage_account[:name])[0]
-      use_http = false
-      use_http = @azure_properties['azure_stack']['use_http_to_access_storage_account'] if @azure_properties['environment'] == ENVIRONMENT_AZURESTACK
-      azure_storage_client = initialize_azure_storage_client(storage_account, 'table', use_http)
+      azure_storage_client = initialize_azure_storage_client(storage_account, @azure_properties)
       @table_service_client = azure_storage_client.table_client
       @table_service_client.with_filter(Azure::Storage::Core::Filter::ExponentialRetryPolicyFilter.new)
       @table_service_client.with_filter(Azure::Core::Http::DebugFilter.new) if is_debug_mode(@azure_properties)

--- a/src/bosh_azure_cpi/spec/unit/azure_client2/azure_stack_ca_cert_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client2/azure_stack_ca_cert_spec.rb
@@ -1,0 +1,79 @@
+require 'spec_helper'
+
+describe Bosh::AzureCloud::AzureClient2 do
+  let(:logger) { Bosh::Clouds::Config.logger }
+  let(:azure_stack_domain) { "fake-azure-stack-domain" }
+  let(:http) { instance_double(Net::HTTP) }
+
+  before do
+    allow(Net::HTTP).to receive(:new).and_return(http)
+  end
+
+  describe "#azure_stack_ca_cert" do
+    context "when ssl validation is skipped" do
+      let(:azure_client2) {
+        Bosh::AzureCloud::AzureClient2.new(
+          mock_cloud_options["properties"]["azure"].merge!({
+            "environment" => "AzureStack",
+            "azure_stack" => {
+              "domain"              => azure_stack_domain,
+              "resource"            => "fake-resource",
+              "skip_ssl_validation" => true
+            }
+          }),
+          logger
+        )
+      }
+      let(:uri) { URI("https://fake-host") }
+
+      it "should use the mode VERIFY_NONE" do
+        expect(http).to receive(:use_ssl=).with(true)
+        expect(http).to receive(:verify_mode=).with(OpenSSL::SSL::VERIFY_NONE)
+        expect(http).to receive(:open_timeout=).with(60)
+        azure_client2.send(:http, uri)
+      end
+    end
+
+    context "when ssl validation is not skipped and the ca file is specified" do
+      let(:azure_client2) {
+        Bosh::AzureCloud::AzureClient2.new(
+          mock_cloud_options["properties"]["azure"].merge!({
+            "environment" => "AzureStack",
+            "azure_stack" => {
+              "domain"              => azure_stack_domain,
+              "resource"            => "fake-resource",
+              "skip_ssl_validation" => false,
+              "ca_cert"             => "fake-ca-cert-content"
+            }
+          }),
+          logger
+        )
+      }
+      let(:ca_file_path) { "/var/vcap/jobs/azure_cpi/config/azure_stack_ca_cert.pem" }
+
+      context "when the uri doesn't contain the AzureStack domain" do
+        let(:uri) { URI("https://fake-host") }
+
+        it "should not use the mode VERIFY_NONE, and the ca file is not configured" do
+          expect(http).to receive(:use_ssl=).with(true)
+          expect(http).not_to receive(:verify_mode=).with(OpenSSL::SSL::VERIFY_NONE)
+          expect(http).not_to receive(:ca_file=).with(ca_file_path)
+          expect(http).to receive(:open_timeout=).with(60)
+          azure_client2.send(:http, uri)
+        end
+      end
+
+      context "when the uri contains the AzureStack domain" do
+        let(:uri) { URI("https://#{azure_stack_domain}") }
+
+        it "should not use the mode VERIFY_NONE, and the ca file is configured" do
+          expect(http).to receive(:use_ssl=).with(true)
+          expect(http).not_to receive(:verify_mode=).with(OpenSSL::SSL::VERIFY_NONE)
+          expect(http).to receive(:ca_file=).with(ca_file_path)
+          expect(http).to receive(:open_timeout=).with(60)
+          azure_client2.send(:http, uri)
+        end
+      end
+    end
+  end
+end

--- a/src/bosh_azure_cpi/spec/unit/blob_manager_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/blob_manager_spec.rb
@@ -12,7 +12,8 @@ describe Bosh::AzureCloud::BlobManager do
   let(:azure_client) { instance_double(Azure::Storage::Client) }
   let(:blob_service) { instance_double(Azure::Storage::Blob::BlobService) }
   let(:customized_retry) { instance_double(Bosh::AzureCloud::CustomizedRetryPolicyFilter) }
-  let(:blob_host) { "fake-blob-endpoint" }
+  let(:storage_dns_suffix) { "fake-storage-dns-suffix" }
+  let(:blob_host) { "https://#{MOCK_DEFAULT_STORAGE_ACCOUNT_NAME}.blob.#{storage_dns_suffix}" }
   let(:storage_account) {
     {
       :id => "foo",
@@ -20,8 +21,7 @@ describe Bosh::AzureCloud::BlobManager do
       :location => "bar",
       :provisioning_state => "bar",
       :account_type => "foo",
-      :storage_blob_host => "fake-blob-endpoint",
-      :storage_table_host => "fake-table-endpoint"
+      :storage_blob_host => blob_host
     }
   }
   let(:request_id) { 'fake-client-request-id' }
@@ -42,7 +42,6 @@ describe Bosh::AzureCloud::BlobManager do
     allow(azure_client2).to receive(:get_storage_account_by_name).
       with(MOCK_DEFAULT_STORAGE_ACCOUNT_NAME).
       and_return(storage_account)
-    allow(azure_client).to receive(:storage_blob_host=)
     allow(azure_client).to receive(:storage_blob_host).and_return(blob_host)
     allow(azure_client).to receive(:blob_client).
       and_return(blob_service)
@@ -441,8 +440,7 @@ describe Bosh::AzureCloud::BlobManager do
         :location => "bar",
         :provisioning_state => "bar",
         :account_type => "foo",
-        :storage_blob_host => "fake-blob-endpoint",
-        :storage_table_host => "fake-table-endpoint"
+        :storage_blob_host => "https://another-storage-account.blob.#{storage_dns_suffix}"
       }
     }
     let(:blob) { instance_double(Azure::Storage::Blob::Blob) }
@@ -663,8 +661,7 @@ describe Bosh::AzureCloud::BlobManager do
         :location => "bar",
         :provisioning_state => "bar",
         :account_type => "foo",
-        :storage_blob_host => "fake-blob-endpoint",
-        :storage_table_host => "fake-table-endpoint"
+        :storage_blob_host => "https://another-storage-account.blob.#{storage_dns_suffix}"
       }
     }
 

--- a/src/bosh_azure_cpi/spec/unit/table_manager_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/table_manager_spec.rb
@@ -12,6 +12,9 @@ describe Bosh::AzureCloud::TableManager do
   let(:azure_client) { instance_double(Azure::Storage::Client) }
   let(:table_service) { instance_double(Azure::Storage::Table::TableService) }
   let(:exponential_retry) { instance_double(Azure::Storage::Core::Filter::ExponentialRetryPolicyFilter) }
+  let(:storage_dns_suffix) { "fake-storage-dns-suffix" }
+  let(:blob_host) { "https://#{MOCK_DEFAULT_STORAGE_ACCOUNT_NAME}.blob.#{storage_dns_suffix}" }
+  let(:table_host) { "https://#{MOCK_DEFAULT_STORAGE_ACCOUNT_NAME}.table.#{storage_dns_suffix}" }
   let(:storage_account) {
     {
       :id => "foo",
@@ -19,8 +22,8 @@ describe Bosh::AzureCloud::TableManager do
       :location => "bar",
       :provisioning_state => "bar",
       :account_type => "foo",
-      :storage_blob_host => "fake-blob-endpoint",
-      :storage_table_host => "fake-table-endpoint"
+      :storage_blob_host => blob_host,
+      :storage_table_host => table_host
     }
   }
   let(:request_id) { 'fake-client-request-id' }
@@ -43,8 +46,6 @@ describe Bosh::AzureCloud::TableManager do
       with(MOCK_DEFAULT_STORAGE_ACCOUNT_NAME).
       and_return(storage_account)
 
-    allow(azure_client).to receive(:storage_table_host=)
-    allow(azure_client).to receive(:storage_table_host)
     allow(azure_client).to receive(:table_client).
       and_return(table_service)
     allow(Azure::Storage::Core::Filter::ExponentialRetryPolicyFilter).to receive(:new).


### PR DESCRIPTION
In CPI v26, users have to specify `skip_ssl_validation` and `use_http_to_access_storage_account` to true so that CPI would skip the ssl validation when it calls Azure Stack management endpoint and storage endpoint.
With this change, users can provide the CA cert of Azure Stack and they don't need to specify  `skip_ssl_validation` and `use_http_to_access_storage_account`.

- [x] Please check this box once you have run the unit tests
  ```
  pushd src/bosh_azure_cpi
    bundle install
    bundle exec rspec spec/unit/*
  popd
  ```

The coverage rate is increased from `2843 / 3002 LOC (94.7%) covered` to `2812 / 2966 LOC (94.81%) covered`.

### Changelog

* Support `azure_stack.ca_cert` in global configurations 
