### PR TITLE
Use boshcli v2 in promote-candidate

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -268,6 +268,7 @@ jobs:
         - {trigger: false, get: bosh-cpi-release, resource: bosh-cpi-dev-artifacts, passed: [integration-unmanaged-disks, integration-managed-disks, integration-windows-unmanaged-disks, integration-windows-managed-disks, bats-unmanaged-disks, bats-managed-disks]}
         - {trigger: false, get: bosh-cpi-src, resource: bosh-cpi-src-out}
         - {trigger: false, get: release-version-semver, params: {bump: major}}
+        - {trigger: false, get: bosh-cli}
       - task: promote
         file: bosh-cpi-src/ci/tasks/promote-candidate.yml
         params:

--- a/ci/tasks/promote-candidate.sh
+++ b/ci/tasks/promote-candidate.sh
@@ -5,6 +5,7 @@ set -e -x
 : ${S3_ACCESS_KEY_ID:?}
 : ${S3_SECRET_ACCESS_KEY:?}
 
+source bosh-cpi-src/ci/utils.sh
 source /etc/profile.d/chruby.sh
 chruby ${RUBY_VERSION}
 
@@ -18,7 +19,6 @@ cp -r bosh-cpi-src promoted/repo
 dev_release=$(realpath bosh-cpi-release/*.tgz)
 
 pushd promoted/repo > /dev/null
-  set +x
   echo creating config/private.yml with blobstore secrets
   cat > config/private.yml << EOF
 ---
@@ -27,13 +27,9 @@ blobstore:
     access_key_id: ${S3_ACCESS_KEY_ID}
     secret_access_key: ${S3_SECRET_ACCESS_KEY}
 EOF
-  set -x
-
-  echo "using bosh CLI version..."
-  bosh version
 
   echo "finalizing CPI release..."
-  bosh finalize release ${dev_release} --version ${integer_version}
+  bosh2 finalize-release ${dev_release} --version ${integer_version}
 
   rm config/private.yml
 

--- a/ci/tasks/promote-candidate.yml
+++ b/ci/tasks/promote-candidate.yml
@@ -8,6 +8,7 @@ inputs:
   - name: bosh-cpi-src
   - name: bosh-cpi-release
   - name: release-version-semver
+  - name: bosh-cli
 
 outputs:
   - name: promoted


### PR DESCRIPTION
No need to run unit tests.

### Changelog

* Use boshcli v2 in promote-candidate
