### PR TITLE
Fix an issue introduced by azure-storage-ruby 0.14.0-preview

### DIFF
--- a/ci/tasks/run-integration-windows.sh
+++ b/ci/tasks/run-integration-windows.sh
@@ -22,6 +22,7 @@ export BOSH_AZURE_CLIENT_SECRET=${AZURE_CLIENT_SECRET}
 export BOSH_AZURE_DEFAULT_RESOURCE_GROUP_NAME=$(echo ${metadata} | jq -e --raw-output ".default_resource_group_name")
 export BOSH_AZURE_ADDITIONAL_RESOURCE_GROUP_NAME=$(echo ${metadata} | jq -e --raw-output ".additional_resource_group_name")
 export BOSH_AZURE_STORAGE_ACCOUNT_NAME=$(echo ${metadata} | jq -e --raw-output ".storage_account_name")
+export BOSH_AZURE_EXTRA_STORAGE_ACCOUNT_NAME=$(echo ${metadata} | jq -e --raw-output ".extra_storage_account_name")
 export BOSH_AZURE_VNET_NAME=$(echo ${metadata} | jq -e --raw-output ".vnet_name")
 export BOSH_AZURE_SUBNET_NAME=$(echo ${metadata} | jq -e --raw-output ".subnet_1_name")
 export BOSH_AZURE_SECOND_SUBNET_NAME=$(echo ${metadata} | jq -e --raw-output ".subnet_2_name")
@@ -62,5 +63,9 @@ az storage blob upload --file /tmp/root.vhd --container-name stemcell --name ${B
 export BOSH_AZURE_USE_MANAGED_DISKS=${AZURE_USE_MANAGED_DISKS}
 pushd bosh-cpi-src/src/bosh_azure_cpi > /dev/null
   bundle install
-  bundle exec rspec spec/integration/lifecycle_spec.rb
+  if [ "${AZURE_USE_MANAGED_DISKS}" == "false" ]; then
+    bundle exec rspec spec/integration/lifecycle_spec.rb --tag ~heavy_stemcell
+  else
+    bundle exec rspec spec/integration/lifecycle_spec.rb --tag ~heavy_stemcell --tag ~unmanaged_disks
+  fi
 popd > /dev/null

--- a/ci/tasks/run-integration.sh
+++ b/ci/tasks/run-integration.sh
@@ -22,6 +22,7 @@ export BOSH_AZURE_CLIENT_SECRET=${AZURE_CLIENT_SECRET}
 export BOSH_AZURE_DEFAULT_RESOURCE_GROUP_NAME=$(echo ${metadata} | jq -e --raw-output ".default_resource_group_name")
 export BOSH_AZURE_ADDITIONAL_RESOURCE_GROUP_NAME=$(echo ${metadata} | jq -e --raw-output ".additional_resource_group_name")
 export BOSH_AZURE_STORAGE_ACCOUNT_NAME=$(echo ${metadata} | jq -e --raw-output ".storage_account_name")
+export BOSH_AZURE_EXTRA_STORAGE_ACCOUNT_NAME=$(echo ${metadata} | jq -e --raw-output ".extra_storage_account_name")
 export BOSH_AZURE_VNET_NAME=$(echo ${metadata} | jq -e --raw-output ".vnet_name")
 export BOSH_AZURE_SUBNET_NAME=$(echo ${metadata} | jq -e --raw-output ".subnet_1_name")
 export BOSH_AZURE_SECOND_SUBNET_NAME=$(echo ${metadata} | jq -e --raw-output ".subnet_2_name")
@@ -35,36 +36,36 @@ az cloud set --name ${AZURE_ENVIRONMENT}
 az login --service-principal -u ${AZURE_CLIENT_ID} -p ${AZURE_CLIENT_SECRET} --tenant ${AZURE_TENANT_ID}
 
 export BOSH_AZURE_STEMCELL_ID="bosh-stemcell-00000000-0000-0000-0000-0AZURECPICI0"
+export BOSH_AZURE_STEMCELL_PATH="/tmp/image"
 account_name=${BOSH_AZURE_STORAGE_ACCOUNT_NAME}
 account_key=$(az storage account keys list --account-name ${account_name} --resource-group ${BOSH_AZURE_DEFAULT_RESOURCE_GROUP_NAME} | jq '.[0].value' -r)
 # Always upload the latest stemcell for lifecycle test
 tar -xf $(realpath stemcell/*.tgz) -C /tmp/
-tar -xf /tmp/image -C /tmp/
+tar -xf ${BOSH_AZURE_STEMCELL_PATH} -C /tmp/
 az storage blob upload --file /tmp/root.vhd --container-name stemcell --name ${BOSH_AZURE_STEMCELL_ID}.vhd --type page --account-name ${account_name} --account-key ${account_key}
 
 source /etc/profile.d/chruby.sh
 chruby ${RUBY_VERSION}
 
-export BOSH_AZURE_USE_MANAGED_DISKS=${AZURE_USE_MANAGED_DISKS}
 pushd bosh-cpi-src/src/bosh_azure_cpi > /dev/null
   bundle install
-  bundle exec rspec spec/integration/lifecycle_spec.rb
-popd > /dev/null
 
-# Only run migration test when AZURE_USE_MANAGED_DISKS is set to false initially
-if [ "${AZURE_USE_MANAGED_DISKS}" == "false" ]; then
-  unset BOSH_AZURE_USE_MANAGED_DISKS
-  pushd bosh-cpi-src/src/bosh_azure_cpi > /dev/null
-    bundle install
+  export BOSH_AZURE_USE_MANAGED_DISKS=${AZURE_USE_MANAGED_DISKS}
+  if [ "${AZURE_USE_MANAGED_DISKS}" == "false" ]; then
+    bundle exec rspec spec/integration/lifecycle_spec.rb --tag ~light_stemcell
+  else
+    bundle exec rspec spec/integration/lifecycle_spec.rb --tag ~light_stemcell --tag ~unmanaged_disks
+  fi
+
+  # Only run migration test when AZURE_USE_MANAGED_DISKS is set to false initially
+  if [ "${AZURE_USE_MANAGED_DISKS}" == "false" ]; then
+    unset BOSH_AZURE_USE_MANAGED_DISKS
     bundle exec rspec spec/integration/managed_disks_migration_spec.rb
-  popd > /dev/null
-fi
-
-# The azure_cpi test doesn't care whether managed disks are used. Only run it when AZURE_USE_MANAGED_DISKS is set to true
-if [ "${AZURE_USE_MANAGED_DISKS}" == "true" ]; then
-  export BOSH_AZURE_USE_MANAGED_DISKS=true
-  pushd bosh-cpi-src/src/bosh_azure_cpi > /dev/null
-    bundle install
+  fi
+  
+  # The azure_cpi test doesn't care whether managed disks are used. Only run it when AZURE_USE_MANAGED_DISKS is set to true
+  if [ "${AZURE_USE_MANAGED_DISKS}" == "true" ]; then
+    export BOSH_AZURE_USE_MANAGED_DISKS=true
     bundle exec rspec spec/integration/azure_cpi_spec.rb
-  popd > /dev/null
-fi
+  fi
+popd > /dev/null

--- a/src/bosh_azure_cpi/spec/unit/stemcell_manager_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/stemcell_manager_spec.rb
@@ -177,7 +177,7 @@ describe Bosh::AzureCloud::StemcellManager do
               'PartitionKey' => stemcell_name,
               'RowKey'       => storage_account_name,
               'Status'       => 'pending',
-              'Timestamp'    => Time.now - ( 20 * 60 - 1 )  # The default timeout of copying stemcell is 20 * 60 seconds
+              'Timestamp'    => (Time.now - ( 20 * 60 - 1 )).to_s  # The default timeout of copying stemcell is 20 * 60 seconds
             }
           ]
         }


### PR DESCRIPTION
- [x] Please check this box and fill the data as below once you have run the unit tests.
      Code coverage before your change: `703 examples, 0 failures 2970 / 3120 LOC (95.19%) covered`
      Code coverage with your change:   `703 examples, 0 failures 2971 / 3121 LOC (95.19%) covered`

  ```
  pushd src/bosh_azure_cpi
    ./bin/test-unit
  popd
  ```

  NOTE: Please see how to setup dev environment and run unit tests in docs/development.md.

### Changelog

* In azure-storage-ruby 0.14.0-preview, timestamp of the entity is a String instead of a Date. This PR converts the string timestamp to a Date.
* Added lifecycle test cases to cover the multiple storage account scenario and create_stemcell.
* Updated the `integration/terraform.tf` to use `account_tier` and `account_replication_type` which are required by terraform azure provider v0.3.0
