### PR TITLE
Add a new global configuration keep_failed_vms

### DIFF
--- a/jobs/azure_cpi/spec
+++ b/jobs/azure_cpi/spec
@@ -45,6 +45,9 @@ properties:
   azure.pip_idle_timeout_in_minutes:
     description: Idle timeouts in minutes for dynamic public IPs
     default: 4
+  azure.keep_failed_vms:
+    description: Enable keeping the VM which failed in provisioning for troubleshooting
+    default: false
   azure.azure_stack.domain:
     description: The domain for your AzureStack deployment
     default: local.azurestack.external

--- a/jobs/azure_cpi/templates/cpi.json.erb
+++ b/jobs/azure_cpi/templates/cpi.json.erb
@@ -15,7 +15,8 @@
           'default_security_group' => p('azure.default_security_group'),
           'debug_mode' => p('azure.debug_mode'),
           'use_managed_disks' => p('azure.use_managed_disks'),
-          'pip_idle_timeout_in_minutes' => p('azure.pip_idle_timeout_in_minutes')
+          'pip_idle_timeout_in_minutes' => p('azure.pip_idle_timeout_in_minutes'),
+          'keep_failed_vms' => p('azure.keep_failed_vms')
         },
         'registry' => {
           'user' => p('registry.username'),

--- a/src/bosh_azure_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
@@ -68,6 +68,7 @@ describe 'cpi.json.erb' do
             'default_security_group'      => 'fake-default-security-group',
             'parallel_upload_thread_num'  => 16,
             'debug_mode'                  => false,
+            'keep_failed_vms'             => false,
             'use_managed_disks'           => false,
             'pip_idle_timeout_in_minutes' => 4
           },
@@ -110,6 +111,16 @@ describe 'cpi.json.erb' do
 
       it 'is able to render use_managed_disks to true' do
         expect(subject['cloud']['properties']['azure']['use_managed_disks']).to be(true)
+      end
+    end
+
+    context 'when the keep_failed_vms are enabled' do
+      before do
+        manifest['properties']['azure']['keep_failed_vms'] = true
+      end
+
+      it 'is able to render keep_failed_vms to true' do
+        expect(subject['cloud']['properties']['azure']['keep_failed_vms']).to be(true)
       end
     end
 

--- a/src/bosh_azure_cpi/spec/unit/vm_manager/create/vm_is_not_created_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/vm_manager/create/vm_is_not_created_spec.rb
@@ -6,8 +6,8 @@ describe Bosh::AzureCloud::VMManager do
 
   describe "#create" do
     context "when VM is not created" do
-      context " and client2.create_virtual_machine raises an normal error" do
-        context " and no more error occurs" do
+      context "and client2.create_virtual_machine raises an normal error" do
+        context "and no more error occurs" do
           before do
             allow(client2).to receive(:create_virtual_machine).
               and_raise('virtual machine is not created')
@@ -50,8 +50,8 @@ describe Bosh::AzureCloud::VMManager do
         end
       end
 
-      context " and client2.create_virtual_machine raises an AzureAsynchronousError" do
-        context " and AzureAsynchronousError.status is not Failed" do
+      context "and client2.create_virtual_machine raises an AzureAsynchronousError" do
+        context "and AzureAsynchronousError.status is not Failed" do
           before do
             allow(client2).to receive(:create_virtual_machine).
               and_raise(Bosh::AzureCloud::AzureAsynchronousError)
@@ -74,50 +74,188 @@ describe Bosh::AzureCloud::VMManager do
           end
         end
 
-        context " and AzureAsynchronousError.status is Failed" do
+        context "and AzureAsynchronousError.status is Failed" do
           before do
             allow(client2).to receive(:create_virtual_machine).
               and_raise(Bosh::AzureCloud::AzureAsynchronousError.new('Failed'))
           end
 
-          context " and use_managed_disks is false" do
-            context " and ephemeral_disk does not exist" do
-              before do
-                allow(disk_manager).to receive(:ephemeral_disk).
-                  and_return(nil)
+          context "and keep_failed_vms is false in global configuration" do
+            context "and use_managed_disks is false" do
+              context "and ephemeral_disk does not exist" do
+                before do
+                  allow(disk_manager).to receive(:ephemeral_disk).
+                    and_return(nil)
+                end
+
+                it "should delete vm and then raise an error" do
+                  expect(client2).to receive(:create_virtual_machine).exactly(3).times
+                  expect(client2).to receive(:delete_virtual_machine).exactly(3).times
+                  expect(disk_manager).to receive(:delete_disk).with(storage_account_name, os_disk_name).exactly(3).times
+                  expect(disk_manager).to receive(:delete_vm_status_files).
+                    with(storage_account_name, vm_name).exactly(3).times
+                  expect(disk_manager).not_to receive(:delete_disk).with(storage_account_name, ephemeral_disk_name)
+                  expect(client2).to receive(:delete_network_interface).twice
+
+                  expect {
+                    vm_manager.create(instance_id, location, stemcell_info, resource_pool, network_configurator, env)
+                  }.to raise_error { |error|
+                    expect(error.inspect).to match(/Bosh::AzureCloud::AzureAsynchronousError/)
+                    expect(error.inspect).not_to match(/This VM fails in provisioning after multiple retries/)
+                  }
+                end
               end
 
-              it "should not delete vm and then raise an error" do
-                expect(client2).to receive(:create_virtual_machine).exactly(3).times
-                expect(client2).to receive(:delete_virtual_machine).twice
-                expect(disk_manager).to receive(:delete_disk).with(storage_account_name, os_disk_name).twice
-                expect(disk_manager).to receive(:delete_vm_status_files).
-                  with(storage_account_name, vm_name).twice
-                expect(disk_manager).not_to receive(:delete_disk).with(storage_account_name, ephemeral_disk_name)
-                expect(client2).not_to receive(:delete_network_interface)
+              context "and ephemeral_disk exists" do
+                context "and all the vm resources are deleted successfully" do
+                  it "should delete vm and then raise an error" do
+                    expect(client2).to receive(:create_virtual_machine).exactly(3).times
+                    expect(client2).to receive(:delete_virtual_machine).exactly(3).times
+                    expect(disk_manager).to receive(:delete_disk).with(storage_account_name, os_disk_name).exactly(3).times
+                    expect(disk_manager).to receive(:delete_disk).with(storage_account_name, ephemeral_disk_name).exactly(3).times
+                    expect(disk_manager).to receive(:delete_vm_status_files).
+                      with(storage_account_name, vm_name).exactly(3).times
+                    expect(client2).to receive(:delete_network_interface).twice
 
-                expect {
-                  vm_manager.create(instance_id, location, stemcell_info, resource_pool, network_configurator, env)
-                }.to raise_error { |error|
-                  expect(error.inspect).to match(/Bosh::AzureCloud::AzureAsynchronousError/)
-                  expect(error.inspect).to match(/This VM fails in provisioning after multiple retries/)
-                }
+                    expect {
+                      vm_manager.create(instance_id, location, stemcell_info, resource_pool, network_configurator, env)
+                    }.to raise_error { |error|
+                      expect(error.inspect).to match(/Bosh::AzureCloud::AzureAsynchronousError/)
+                      expect(error.inspect).not_to match(/This VM fails in provisioning after multiple retries/)
+                    }
+                  end
+                end
+
+                context "and an error occurs when deleting vm" do
+                  before do
+                    allow(client2).to receive(:delete_virtual_machine).
+                      and_raise('cannot delete the vm')
+                  end
+
+                  it "should try to delete vm, then raise an error, but not delete the NICs" do
+                    expect(client2).to receive(:create_virtual_machine).once
+                    expect(client2).to receive(:delete_virtual_machine).exactly(3).times
+                    expect(disk_manager).not_to receive(:delete_disk).with(storage_account_name, os_disk_name)
+                    expect(disk_manager).not_to receive(:delete_disk).with(storage_account_name, ephemeral_disk_name)
+                    expect(disk_manager).not_to receive(:delete_vm_status_files).
+                      with(storage_account_name, vm_name)
+                    expect(client2).not_to receive(:delete_network_interface)
+
+                    expect {
+                      vm_manager.create(instance_id, location, stemcell_info, resource_pool, network_configurator, env)
+                    }.to raise_error { |error|
+                      expect(error.inspect).to match(/cannot delete the vm/)
+                      expect(error.inspect).to match(/The VM fails in provisioning but an error is thrown in cleanuping VM/)
+                      # If the cleanup fails, then the VM resources have to be kept
+                      expect(error.inspect).to match(/This VM fails in provisioning after multiple retries/)
+                    }
+                  end
+                end
+
+                context "and an error occurs when deleting vm for the first time but the vm is deleted successfully after retrying" do
+                  before do
+                    call_count = 0
+                    allow(client2).to receive(:delete_virtual_machine) do
+                      call_count += 1
+                      call_count == 1 ? raise('cannot delete the vm') : true
+                    end
+                  end
+
+                  it "should delete vm and then raise an error" do
+                    expect(client2).to receive(:create_virtual_machine).exactly(3).times
+                    expect(client2).to receive(:delete_virtual_machine).exactly(4).times # Failed once and succeeded 3 times
+                    expect(disk_manager).to receive(:delete_disk).with(storage_account_name, os_disk_name).exactly(3).times
+                    expect(disk_manager).to receive(:delete_disk).with(storage_account_name, ephemeral_disk_name).exactly(3).times
+                    expect(disk_manager).to receive(:delete_vm_status_files).
+                      with(storage_account_name, vm_name).exactly(3).times
+                    expect(client2).to receive(:delete_network_interface).twice
+
+                    expect {
+                      vm_manager.create(instance_id, location, stemcell_info, resource_pool, network_configurator, env)
+                    }.to raise_error { |error|
+                      expect(error.inspect).to match(/Bosh::AzureCloud::AzureAsynchronousError/)
+                      expect(error.inspect).not_to match(/This VM fails in provisioning after multiple retries/)
+                    }
+                  end
+                end
               end
             end
 
-            context " and ephemeral_disk exists" do
-              context " and no more error occurs" do
+            context "and use_managed_disks is true" do
+              context "and ephemeral_disk does not exist" do
+                before do
+                  allow(disk_manager2).to receive(:ephemeral_disk).
+                    and_return(nil)
+                end
+
+                it "should delete vm and then raise an error" do
+                  expect(client2).to receive(:create_virtual_machine).exactly(3).times
+                  expect(client2).to receive(:delete_virtual_machine).exactly(3).times
+                  expect(disk_manager2).to receive(:delete_disk).with(resource_group_name, os_disk_name).exactly(3).times
+                  expect(disk_manager2).not_to receive(:delete_disk).with(resource_group_name, ephemeral_disk_name)
+                  expect(client2).to receive(:delete_network_interface).twice
+
+                  expect {
+                    vm_manager2.create(instance_id, location, stemcell_info, resource_pool, network_configurator, env)
+                  }.to raise_error { |error|
+                    expect(error.inspect).to match(/Bosh::AzureCloud::AzureAsynchronousError/)
+                    expect(error.inspect).not_to match(/This VM fails in provisioning after multiple retries/)
+                  }
+                end
+              end
+
+              context "and ephemeral_disk exists" do
+                it "should delete vm and then raise an error" do
+                  expect(client2).to receive(:create_virtual_machine).exactly(3).times
+                  expect(client2).to receive(:delete_virtual_machine).exactly(3).times
+                  expect(disk_manager2).to receive(:delete_disk).with(resource_group_name, os_disk_name).exactly(3).times
+                  expect(disk_manager2).to receive(:delete_disk).with(resource_group_name, ephemeral_disk_name).exactly(3).times
+                  expect(client2).to receive(:delete_network_interface).twice
+
+                  expect {
+                    vm_manager2.create(instance_id, location, stemcell_info, resource_pool, network_configurator, env)
+                  }.to raise_error { |error|
+                    expect(error.inspect).to match(/Bosh::AzureCloud::AzureAsynchronousError/)
+                    expect(error.inspect).not_to match(/This VM fails in provisioning after multiple retries/)
+                  }
+                end
+              end
+            end
+          end
+
+          context "and keep_failed_vms is true in global configuration" do
+            let(:azure_properties_to_keep_failed_vms) {
+              mock_azure_properties_merge({
+                'keep_failed_vms' => true
+              })
+            }
+            let(:vm_manager_to_keep_failed_vms) { Bosh::AzureCloud::VMManager.new(azure_properties_to_keep_failed_vms, registry_endpoint, disk_manager, disk_manager2, client2, storage_account_manager) }
+            let(:azure_properties_managed_to_keep_failed_vms) {
+              mock_azure_properties_merge({
+                'use_managed_disks' => true,
+                'keep_failed_vms'   => true
+              })
+            }
+            let(:vm_manager2_to_keep_failed_vms) { Bosh::AzureCloud::VMManager.new(azure_properties_managed_to_keep_failed_vms, registry_endpoint, disk_manager, disk_manager2, client2, storage_account_manager) }
+
+            context "and use_managed_disks is false" do
+              context "and ephemeral_disk does not exist" do
+                before do
+                  allow(disk_manager).to receive(:ephemeral_disk).
+                    and_return(nil)
+                end
+
                 it "should not delete vm and then raise an error" do
                   expect(client2).to receive(:create_virtual_machine).exactly(3).times
                   expect(client2).to receive(:delete_virtual_machine).twice
                   expect(disk_manager).to receive(:delete_disk).with(storage_account_name, os_disk_name).twice
-                  expect(disk_manager).to receive(:delete_disk).with(storage_account_name, ephemeral_disk_name).twice
                   expect(disk_manager).to receive(:delete_vm_status_files).
                     with(storage_account_name, vm_name).twice
+                  expect(disk_manager).not_to receive(:delete_disk).with(storage_account_name, ephemeral_disk_name)
                   expect(client2).not_to receive(:delete_network_interface)
 
                   expect {
-                    vm_manager.create(instance_id, location, stemcell_info, resource_pool, network_configurator, env)
+                    vm_manager_to_keep_failed_vms.create(instance_id, location, stemcell_info, resource_pool, network_configurator, env)
                   }.to raise_error { |error|
                     expect(error.inspect).to match(/Bosh::AzureCloud::AzureAsynchronousError/)
                     expect(error.inspect).to match(/This VM fails in provisioning after multiple retries/)
@@ -125,66 +263,119 @@ describe Bosh::AzureCloud::VMManager do
                 end
               end
 
-              context "and an error occurs when deleting vm" do
+              context "and ephemeral_disk exists" do
+                context "and all the vm resources are deleted successfully" do
+                  it "should not delete vm and then raise an error" do
+                    expect(client2).to receive(:create_virtual_machine).exactly(3).times
+                    expect(client2).to receive(:delete_virtual_machine).twice # CPI doesn't delete the VM for the last time
+                    expect(disk_manager).to receive(:delete_disk).with(storage_account_name, os_disk_name).twice
+                    expect(disk_manager).to receive(:delete_disk).with(storage_account_name, ephemeral_disk_name).twice
+                    expect(disk_manager).to receive(:delete_vm_status_files).
+                      with(storage_account_name, vm_name).twice
+                    expect(client2).not_to receive(:delete_network_interface)
+
+                    expect {
+                      vm_manager_to_keep_failed_vms.create(instance_id, location, stemcell_info, resource_pool, network_configurator, env)
+                    }.to raise_error { |error|
+                      expect(error.inspect).to match(/Bosh::AzureCloud::AzureAsynchronousError/)
+                      expect(error.inspect).to match(/This VM fails in provisioning after multiple retries/)
+                    }
+                  end
+                end
+
+                context "and an error occurs when deleting vm" do
+                  before do
+                    allow(client2).to receive(:delete_virtual_machine).
+                      and_raise('cannot delete the vm')
+                  end
+
+                  it "should not delete vm and then raise an error" do
+                    expect(client2).to receive(:create_virtual_machine).once
+                    expect(client2).to receive(:delete_virtual_machine).exactly(3).times
+                    expect(disk_manager).not_to receive(:delete_disk).with(storage_account_name, os_disk_name)
+                    expect(disk_manager).not_to receive(:delete_disk).with(storage_account_name, ephemeral_disk_name)
+                    expect(disk_manager).not_to receive(:delete_vm_status_files).
+                      with(storage_account_name, vm_name)
+                    expect(client2).not_to receive(:delete_network_interface)
+
+                    expect {
+                      vm_manager_to_keep_failed_vms.create(instance_id, location, stemcell_info, resource_pool, network_configurator, env)
+                    }.to raise_error { |error|
+                      expect(error.inspect).to match(/cannot delete the vm/)
+                      expect(error.inspect).to match(/The VM fails in provisioning but an error is thrown in cleanuping VM/)
+                      # If the cleanup fails, then the VM resources have to be kept
+                      expect(error.inspect).to match(/This VM fails in provisioning after multiple retries/)
+                    }
+                  end
+                end
+
+                context "and an error occurs when deleting vm for the first time but the vm is deleted successfully after retrying" do
+                  before do
+                    call_count = 0
+                    allow(client2).to receive(:delete_virtual_machine) do
+                      call_count += 1
+                      call_count == 1 ? raise('cannot delete the vm') : true
+                    end
+                  end
+
+                  it "should not delete vm and then raise an error" do
+                    expect(client2).to receive(:create_virtual_machine).exactly(3).times
+                    expect(client2).to receive(:delete_virtual_machine).exactly(3).times # Failed once; succeeded 2 times; CPI should not delete the VM for the last time
+                    expect(disk_manager).to receive(:delete_disk).with(storage_account_name, os_disk_name).twice
+                    expect(disk_manager).to receive(:delete_disk).with(storage_account_name, ephemeral_disk_name).twice
+                    expect(disk_manager).to receive(:delete_vm_status_files).
+                      with(storage_account_name, vm_name).twice
+                    expect(client2).not_to receive(:delete_network_interface)
+
+                    expect {
+                      vm_manager_to_keep_failed_vms.create(instance_id, location, stemcell_info, resource_pool, network_configurator, env)
+                    }.to raise_error { |error|
+                      expect(error.inspect).to match(/Bosh::AzureCloud::AzureAsynchronousError/)
+                      expect(error.inspect).to match(/This VM fails in provisioning after multiple retries/)
+                    }
+                  end
+                end
+              end
+            end
+
+            context "and use_managed_disks is true" do
+              context "and ephemeral_disk does not exist" do
                 before do
-                  allow(client2).to receive(:delete_virtual_machine).
-                    and_raise('cannot delete the vm')
+                  allow(disk_manager2).to receive(:ephemeral_disk).
+                    and_return(nil)
                 end
 
                 it "should not delete vm and then raise an error" do
-                  expect(client2).to receive(:create_virtual_machine).once
-                  expect(client2).to receive(:delete_virtual_machine).once
-                  expect(disk_manager).not_to receive(:delete_disk).with(storage_account_name, os_disk_name)
-                  expect(disk_manager).not_to receive(:delete_disk).with(storage_account_name, ephemeral_disk_name)
-                  expect(disk_manager).not_to receive(:delete_vm_status_files).
-                    with(storage_account_name, vm_name)
+                  expect(client2).to receive(:create_virtual_machine).exactly(3).times
+                  expect(client2).to receive(:delete_virtual_machine).twice
+                  expect(disk_manager2).to receive(:delete_disk).with(resource_group_name, os_disk_name).twice
+                  expect(disk_manager2).not_to receive(:delete_disk).with(resource_group_name, ephemeral_disk_name)
                   expect(client2).not_to receive(:delete_network_interface)
 
                   expect {
-                    vm_manager.create(instance_id, location, stemcell_info, resource_pool, network_configurator, env)
-                  }.to raise_error /cannot delete the vm/
+                    vm_manager2_to_keep_failed_vms.create(instance_id, location, stemcell_info, resource_pool, network_configurator, env)
+                  }.to raise_error { |error|
+                    expect(error.inspect).to match(/Bosh::AzureCloud::AzureAsynchronousError/)
+                    expect(error.inspect).to match(/This VM fails in provisioning after multiple retries/)
+                  }
                 end
               end
-            end
-          end
 
-          context " and use_managed_disks is true" do
-            context " and ephemeral_disk does not exist" do
-              before do
-                allow(disk_manager2).to receive(:ephemeral_disk).
-                  and_return(nil)
-              end
+              context "and ephemeral_disk exists" do
+                it "should not delete vm and then raise an error" do
+                  expect(client2).to receive(:create_virtual_machine).exactly(3).times
+                  expect(client2).to receive(:delete_virtual_machine).twice
+                  expect(disk_manager2).to receive(:delete_disk).with(resource_group_name, os_disk_name).twice
+                  expect(disk_manager2).to receive(:delete_disk).with(resource_group_name, ephemeral_disk_name).twice
+                  expect(client2).not_to receive(:delete_network_interface)
 
-              it "should not delete vm and then raise an error" do
-                expect(client2).to receive(:create_virtual_machine).exactly(3).times
-                expect(client2).to receive(:delete_virtual_machine).twice
-                expect(disk_manager2).to receive(:delete_disk).with(resource_group_name, os_disk_name).twice
-                expect(disk_manager2).not_to receive(:delete_disk).with(resource_group_name, ephemeral_disk_name)
-                expect(client2).not_to receive(:delete_network_interface)
-
-                expect {
-                  vm_manager2.create(instance_id, location, stemcell_info, resource_pool, network_configurator, env)
-                }.to raise_error { |error|
-                  expect(error.inspect).to match(/Bosh::AzureCloud::AzureAsynchronousError/)
-                  expect(error.inspect).to match(/This VM fails in provisioning after multiple retries/)
-                }
-              end
-            end
-
-            context " and ephemeral_disk exists" do
-              it "should not delete vm and then raise an error" do
-                expect(client2).to receive(:create_virtual_machine).exactly(3).times
-                expect(client2).to receive(:delete_virtual_machine).twice
-                expect(disk_manager2).to receive(:delete_disk).with(resource_group_name, os_disk_name).twice
-                expect(disk_manager2).to receive(:delete_disk).with(resource_group_name, ephemeral_disk_name).twice
-                expect(client2).not_to receive(:delete_network_interface)
-
-                expect {
-                  vm_manager2.create(instance_id, location, stemcell_info, resource_pool, network_configurator, env)
-                }.to raise_error { |error|
-                  expect(error.inspect).to match(/Bosh::AzureCloud::AzureAsynchronousError/)
-                  expect(error.inspect).to match(/This VM fails in provisioning after multiple retries/)
-                }
+                  expect {
+                    vm_manager2_to_keep_failed_vms.create(instance_id, location, stemcell_info, resource_pool, network_configurator, env)
+                  }.to raise_error { |error|
+                    expect(error.inspect).to match(/Bosh::AzureCloud::AzureAsynchronousError/)
+                    expect(error.inspect).to match(/This VM fails in provisioning after multiple retries/)
+                  }
+                end
               end
             end
           end


### PR DESCRIPTION
Fixes #330.

- [x] Please check this box and fill the data as below once you have run the unit tests.
      Code coverage before your change: `716 examples, 0 failures. 3013 / 3160 LOC (95.35%) covered.`
      Code coverage with your change:     `724 examples, 0 failures. 3014 / 3161 LOC (95.35%) covered.`

  ```
  pushd src/bosh_azure_cpi
    ./bin/test-unit
  popd
  ```

  NOTE: Please see how to setup dev environment and run unit tests in docs/development.md.

### Changelog

* Allow externally control "keep failed vms" functionality.
