### PR TITLE
Fix a bug of using ip configuration properties to check whether the NIC is primary

### DIFF
--- a/src/bosh_azure_cpi/spec/unit/azure_client2/list_network_interfaces_by_keyword_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client2/list_network_interfaces_by_keyword_spec.rb
@@ -49,304 +49,129 @@ describe Bosh::AzureCloud::AzureClient2 do
       end
     end
 
-    context "when network interfaces are found" do
-      context "when the first one of the network interface array is the primary NIC" do
-        let(:result) {
-          {
-            "value" => [
-              {
-                "name"  => "#{instance_id}-0",
-                "id"  => "a",
-                "location"  => "b",
-                "tags"  => {},
-                "properties"  => {
-                  "provisioningState"  => "c",
-                  "ipConfigurations"  => [
-                    {
-                      "id"  => "d0",
-                      "properties"  => {
-                        "primary" => true,
-                        "privateIPAddress"  => "e0",
-                        "privateIPAllocationMethod"  => "f0"
-                      }
+    context "when network interfaces are found and some of them have the keyword in the name" do
+      let(:result) {
+        {
+          "value" => [
+            {
+              "name"  => "#{instance_id}-0",
+              "id"  => "a",
+              "location"  => "b",
+              "tags"  => {},
+              "properties"  => {
+                "provisioningState"  => "c",
+                "ipConfigurations"  => [
+                  {
+                    "id"  => "d0",
+                    "properties"  => {
+                      "privateIPAddress"  => "e0",
+                      "privateIPAllocationMethod"  => "f0"
                     }
-                  ],
-                  "dnsSettings"  => {
-                     "dnsServers"  => [
-                        "g",
-                        "h"
-                     ]
                   }
-                }
-              },
-              {
-                "name"  => "#{instance_id}-1",
-                "id"  => "a",
-                "location"  => "b",
-                "tags"  => {},
-                "properties"  => {
-                  "provisioningState"  => "c",
-                  "ipConfigurations"  => [
-                    {
-                      "id"  => "d1",
-                      "properties"  => {
-                        "privateIPAddress"  => "e1",
-                        "privateIPAllocationMethod"  => "f1"
-                      }
-                    }
-                  ],
-                  "dnsSettings"  => {
-                     "dnsServers"  => [
-                        "g",
-                        "h"
-                     ]
-                  }
+                ],
+                "dnsSettings"  => {
+                   "dnsServers"  => [
+                      "g",
+                      "h"
+                   ]
                 }
               }
-            ]
-          }.to_json
-        }
-        let(:network_interface_0) {
-          {
-            :id=>"a",
-            :name=>"#{instance_id}-0",
-            :location=>"b",
-            :tags=>{},
-            :provisioning_state=>"c",
-            :dns_settings=>["g", "h"],
-            :ip_configuration_id=>"d0",
-            :private_ip=>"e0",
-            :private_ip_allocation_method=>"f0",
-            :primary => true
-          }
-        }
-        let(:network_interface_1) {
-          {
-            :id=>"a",
-            :name=>"#{instance_id}-1",
-            :location=>"b",
-            :tags=>{},
-            :provisioning_state=>"c",
-            :dns_settings=>["g", "h"],
-            :ip_configuration_id=>"d1",
-            :private_ip=>"e1",
-            :private_ip_allocation_method=>"f1"
-          }
-        }
-
-        it "should return network interfaces" do
-          stub_request(:post, token_uri).to_return(
-            :status => 200,
-            :body => {
-              "access_token" => valid_access_token,
-              "expires_on" => expires_on
-            }.to_json,
-            :headers => {})
-          stub_request(:get, network_interfaces_url).to_return(
-            :status => 200,
-            :body => result,
-            :headers => {
-            })
-
-          expect(
-            azure_client2.list_network_interfaces_by_keyword(resource_group, instance_id)
-          ).to eq([network_interface_0, network_interface_1])
-        end
-      end
-
-      context "when the first one of the network interface array is not the primary NIC" do
-        let(:result) {
-          {
-            "value" => [
-              {
-                "name"  => "#{instance_id}-0",
-                "id"  => "a",
-                "location"  => "b",
-                "tags"  => {},
-                "properties"  => {
-                  "provisioningState"  => "c",
-                  "ipConfigurations"  => [
-                    {
-                      "id"  => "d0",
-                      "properties"  => {
-                        "privateIPAddress"  => "e0",
-                        "privateIPAllocationMethod"  => "f0"
-                      }
+            },
+            {
+              "name"  => "#{instance_id}-1",
+              "id"  => "a",
+              "location"  => "b",
+              "tags"  => {},
+              "properties"  => {
+                "provisioningState"  => "c",
+                "ipConfigurations"  => [
+                  {
+                    "id"  => "d1",
+                    "properties"  => {
+                      "privateIPAddress"  => "e1",
+                      "privateIPAllocationMethod"  => "f1"
                     }
-                  ],
-                  "dnsSettings"  => {
-                     "dnsServers"  => [
-                        "g",
-                        "h"
-                     ]
                   }
-                }
-              },
-              {
-                "name"  => "#{instance_id}-1",
-                "id"  => "a",
-                "location"  => "b",
-                "tags"  => {},
-                "properties"  => {
-                  "provisioningState"  => "c",
-                  "ipConfigurations"  => [
-                    {
-                      "id"  => "d1",
-                      "properties"  => {
-                        "primary" => true,
-                        "privateIPAddress"  => "e1",
-                        "privateIPAllocationMethod"  => "f1"
-                      }
-                    }
-                  ],
-                  "dnsSettings"  => {
-                     "dnsServers"  => [
-                        "g",
-                        "h"
-                     ]
-                  }
+                ],
+                "dnsSettings"  => {
+                   "dnsServers"  => [
+                      "g",
+                      "h"
+                   ]
                 }
               }
-            ]
-          }.to_json
-        }
-        let(:network_interface_0) {
-          {
-            :id=>"a",
-            :name=>"#{instance_id}-0",
-            :location=>"b",
-            :tags=>{},
-            :provisioning_state=>"c",
-            :dns_settings=>["g", "h"],
-            :ip_configuration_id=>"d0",
-            :private_ip=>"e0",
-            :private_ip_allocation_method=>"f0"
-          }
-        }
-        let(:network_interface_1) {
-          {
-            :id=>"a",
-            :name=>"#{instance_id}-1",
-            :location=>"b",
-            :tags=>{},
-            :provisioning_state=>"c",
-            :dns_settings=>["g", "h"],
-            :ip_configuration_id=>"d1",
-            :private_ip=>"e1",
-            :private_ip_allocation_method=>"f1",
-            :primary => true
-          }
-        }
-
-        it "should return network interfaces" do
-          stub_request(:post, token_uri).to_return(
-            :status => 200,
-            :body => {
-              "access_token" => valid_access_token,
-              "expires_on" => expires_on
-            }.to_json,
-            :headers => {})
-          stub_request(:get, network_interfaces_url).to_return(
-            :status => 200,
-            :body => result,
-            :headers => {
-            })
-
-          expect(
-            azure_client2.list_network_interfaces_by_keyword(resource_group, instance_id)
-          ).to eq([network_interface_1, network_interface_0])
-        end
-      end
-
-      context "when some of the network interface array have the keyword in the name" do
-        let(:result) {
-          {
-            "value" => [
-              {
-                "name"  => "#{instance_id}-0",
-                "id"  => "a",
-                "location"  => "b",
-                "tags"  => {},
-                "properties"  => {
-                  "provisioningState"  => "c",
-                  "ipConfigurations"  => [
-                    {
-                      "id"  => "d0",
-                      "properties"  => {
-                        "primary" => true,
-                        "privateIPAddress"  => "e0",
-                        "privateIPAllocationMethod"  => "f0"
-                      }
+            },
+            {
+              "name"  => "the-name-witout-keyword",
+              "id"  => "a",
+              "location"  => "b",
+              "tags"  => {},
+              "properties"  => {
+                "provisioningState"  => "c",
+                "ipConfigurations"  => [
+                  {
+                    "id"  => "d2",
+                    "properties"  => {
+                      "privateIPAddress"  => "e2",
+                      "privateIPAllocationMethod"  => "f2"
                     }
-                  ],
-                  "dnsSettings"  => {
-                     "dnsServers"  => [
-                        "g",
-                        "h"
-                     ]
                   }
-                }
-              },
-              {
-                "name"  => "the-name-witout-keyword",
-                "id"  => "a",
-                "location"  => "b",
-                "tags"  => {},
-                "properties"  => {
-                  "provisioningState"  => "c",
-                  "ipConfigurations"  => [
-                    {
-                      "id"  => "d1",
-                      "properties"  => {
-                        "privateIPAddress"  => "e1",
-                        "privateIPAllocationMethod"  => "f1"
-                      }
-                    }
-                  ],
-                  "dnsSettings"  => {
-                     "dnsServers"  => [
-                        "g",
-                        "h"
-                     ]
-                  }
+                ],
+                "dnsSettings"  => {
+                   "dnsServers"  => [
+                      "g",
+                      "h"
+                   ]
                 }
               }
-            ]
-          }.to_json
+            }
+          ]
+        }.to_json
+      }
+      let(:network_interface_0) {
+        {
+          :id=>"a",
+          :name=>"#{instance_id}-0",
+          :location=>"b",
+          :tags=>{},
+          :provisioning_state=>"c",
+          :dns_settings=>["g", "h"],
+          :ip_configuration_id=>"d0",
+          :private_ip=>"e0",
+          :private_ip_allocation_method=>"f0"
         }
-        let(:network_interface_0) {
-          {
-            :id=>"a",
-            :name=>"#{instance_id}-0",
-            :location=>"b",
-            :tags=>{},
-            :provisioning_state=>"c",
-            :dns_settings=>["g", "h"],
-            :ip_configuration_id=>"d0",
-            :private_ip=>"e0",
-            :private_ip_allocation_method=>"f0",
-            :primary => true
-          }
+      }
+      let(:network_interface_1) {
+        {
+          :id=>"a",
+          :name=>"#{instance_id}-1",
+          :location=>"b",
+          :tags=>{},
+          :provisioning_state=>"c",
+          :dns_settings=>["g", "h"],
+          :ip_configuration_id=>"d1",
+          :private_ip=>"e1",
+          :private_ip_allocation_method=>"f1"
         }
+      }
 
-        it "should return network interfaces with the keyword" do
-          stub_request(:post, token_uri).to_return(
-            :status => 200,
-            :body => {
-              "access_token" => valid_access_token,
-              "expires_on" => expires_on
-            }.to_json,
-            :headers => {})
-          stub_request(:get, network_interfaces_url).to_return(
-            :status => 200,
-            :body => result,
-            :headers => {
-            })
+      it "should return network interfaces" do
+        stub_request(:post, token_uri).to_return(
+          :status => 200,
+          :body => {
+            "access_token" => valid_access_token,
+            "expires_on" => expires_on
+          }.to_json,
+          :headers => {})
+        stub_request(:get, network_interfaces_url).to_return(
+          :status => 200,
+          :body => result,
+          :headers => {
+          })
 
-          expect(
-            azure_client2.list_network_interfaces_by_keyword(resource_group, instance_id)
-          ).to eq([network_interface_0])
-        end
+        expect(
+          azure_client2.list_network_interfaces_by_keyword(resource_group, instance_id)
+        ).to eq([network_interface_0, network_interface_1])
       end
     end
   end


### PR DESCRIPTION
- [x] Please check this box and fill the data as below once you have run the unit tests.
      Code coverage before your change: `760 examples, 0 failures. 3165 / 3312 LOC (95.56%) covered.`
      Code coverage with your change:   `758 examples, 0 failures. 3159 / 3305 LOC (95.58%) covered.`

  ```
  pushd src/bosh_azure_cpi
    ./bin/test-unit
  popd
  ```

  NOTE: Please see how to setup dev environment and run unit tests in docs/development.md.

### Changelog

* The `:primary` property of the ip configuration is not related to whether the NIC is primary or not. Only the [`networkInterfaces.primary` in VM properties](https://docs.microsoft.com/en-us/rest/api/compute/virtualmachines/virtualmachines-create-or-update) can specify the primary network interface.
