### PR TITLE
Change the format of user image name

### DIFF
--- a/ci/tasks/run-integration-windows.sh
+++ b/ci/tasks/run-integration-windows.sh
@@ -64,6 +64,32 @@ stemcell_metadata=$(ruby -r yaml -r json -e '
   puts metadata' < /tmp/stemcell.MF)
 dd if=/dev/zero of=/tmp/root.vhd bs=1K count=1
 az storage blob upload --file /tmp/root.vhd --container-name stemcell --name ${BOSH_AZURE_STEMCELL_ID}.vhd --type page --metadata ${stemcell_metadata} --account-name ${account_name} --account-key ${account_key}
+export BOSH_AZURE_WINDOWS_LIGHT_STEMCELL_SKU=$(ruby -r yaml -r json -e '
+  data = YAML::load(STDIN.read)
+  stemcell_properties = data["cloud_properties"]
+  stemcell_properties.each do |key, value|
+    if key == "image"
+      value.each do |k, v|
+        if k == "sku"
+          puts v
+          break
+        end
+      end
+    end
+  end' < /tmp/stemcell.MF)
+export BOSH_AZURE_WINDOWS_LIGHT_STEMCELL_VERSION=$(ruby -r yaml -r json -e '
+  data = YAML::load(STDIN.read)
+  stemcell_properties = data["cloud_properties"]
+  stemcell_properties.each do |key, value|
+    if key == "image"
+      value.each do |k, v|
+        if k == "version"
+          puts v
+          break
+        end
+      end
+    end
+  end' < /tmp/stemcell.MF)
 
 export BOSH_AZURE_USE_MANAGED_DISKS=${AZURE_USE_MANAGED_DISKS}
 pushd bosh-cpi-src/src/bosh_azure_cpi > /dev/null

--- a/jobs/azure_cpi/spec
+++ b/jobs/azure_cpi/spec
@@ -55,7 +55,7 @@ properties:
     description: The domain for your AzureStack deployment
     default: local.azurestack.external
   azure.azure_stack.authentication:
-    description: The authentication type for your AzureStack deployment. AzureAD, AzureStackAD or AzureStack
+    description: The authentication type for your AzureStack deployment. Only AzureAD is supported for now.
     default: AzureAD
   azure.azure_stack.resource:
     description: The token resource for your AzureStack deployment

--- a/src/bosh_azure_cpi/spec/integration/lifecycle_spec.rb
+++ b/src/bosh_azure_cpi/spec/integration/lifecycle_spec.rb
@@ -101,6 +101,8 @@ describe Bosh::AzureCloud::Cloud do
     end
 
     context 'with light stemcell', light_stemcell: true do
+      let(:windows_light_stemcell_sku)     { ENV.fetch('BOSH_AZURE_WINDOWS_LIGHT_STEMCELL_SKU', '2012r2') }
+      let(:windows_light_stemcell_version) { ENV.fetch('BOSH_AZURE_WINDOWS_LIGHT_STEMCELL_VERSION', '1200.7.001001') }
       let(:stemcell_properties) {
         {
           'infrastructure' => 'azure',
@@ -108,8 +110,8 @@ describe Bosh::AzureCloud::Cloud do
           'image' => {
             'offer'     => 'bosh-windows-server',
             'publisher' => 'pivotal',
-            'sku'       => '2012r2',
-            'version'   => '1089.0.1'
+            'sku'       => windows_light_stemcell_sku,
+            'version'   => windows_light_stemcell_version
           }
         }
       }


### PR DESCRIPTION
- [x] Please check this box and fill the data as below once you have run the unit tests.
      Code coverage before your change: `759 examples, 0 failures. 3166 / 3312 LOC (95.59%) covered.`
      Code coverage with your change:   `759 examples, 0 failures. 3170 / 3316 LOC (95.6%) covered.`

### Changelog

* Change the format of user image name. In old format, the user image name length exceeds Azure limits (80) in some region, e.g. `Australia Southeast`.
* fetch the windows stemcell sku and version from the metadata of azure-windows-stemcell
* Update the description of AzureStack authentication
