### PR TITLE
always verify SSL in Azure Stack

### DIFF
--- a/docs/advanced/azure-stack/README.md
+++ b/docs/advanced/azure-stack/README.md
@@ -1,0 +1,99 @@
+# Deploy Cloud Foundry on Azure Stack
+
+[Microsoft Azure Stack](https://azure.microsoft.com/en-us/overview/azure-stack/) is a hybrid cloud platform that lets you provide Azure services from your datacenter. Learn [how to deploy Azure Stack and offer services](https://docs.microsoft.com/en-us/azure/azure-stack/).
+
+Before deploying the BOSH director, you need to update the [global configurations](http://bosh.io/docs/azure-cpi.html#global), including setting the `environment` to `AzureStack` and configuring the `azure_stack` properties.
+
+## Environment
+
+You need to set the `environment` to `AzureStack`. The Ops file [custom-environment.yml](https://github.com/cloudfoundry/bosh-deployment/blob/master/azure/custom-environment.yml) can be used.
+
+```
+azure:
+  environment: AzureStack
+```
+
+## Azure Stack Properties
+
+* Domain
+
+  For Azure Stack development kit, this value is set to `local.azurestack.external`. To get this value for Azure Stack integrated systems, contact your service provider.
+
+  ```
+  azure:
+    azure_stack:
+      domain: ((azure_stack_domain))
+  ```
+
+* Active Directory Service Endpoint Resource ID
+
+  ```
+  azure:
+    azure_stack:
+      resource: ((azure_stack_ad_service_endpoint_resource_id))
+  ```
+
+  You can get the resource ID using the Powershell script:
+
+  ```
+  Get-AzureRmEnvironment "<YOUR-ENVIRONMENT-NAME>" | Select-Object -ExpandProperty ActiveDirectoryServiceEndpointResourceId
+  ```
+
+* Management Endpoint Prefix
+
+  ```
+  azure:
+    azure_stack:
+      endpoint_prefix: management
+  ```
+
+  The prefix is for the resource manager url (`https://<endpoint_prefix>.<azure_stack_domain>`). The default value is `management`.
+
+* Authentication
+
+  Azure Stack uses either Azure Active Directory (AzureAD) or Active Directory Federation Services (AD FS) as an identity provider. For Azure CPI, only `AzureAD` is supported.
+
+  * Azure Active Directory
+
+    Please specify the authentication to `AzureAD`, and provide the service principal with password (`tenant_id`, `client_id` and `client_secret`).
+
+    ```
+    azure:
+      tenant_id: <TENANT-ID>
+      client_id: <CLIENT-ID>
+      client_secret: <CLIENT-SECRET>
+      azure_stack:
+        authentication: AzureAD
+    ```
+
+* CA Cert
+
+  If you use a self-signed root certificate when deploying Azure Stack, you need to specify the cert so that CPI can verify and establish the https connection with Azure Stack endpoints. The Azure Stack CA root certificate is available on the development kit. Sign in to your development kit and run the following Powershell script to export the Azure Stack root certificate in PEM format:
+
+  ```
+  $label = "AzureStackSelfSignedRootCert"
+  Write-Host "Getting certificate from the current user trusted store with subject CN=$label"
+  $root = Get-ChildItem Cert:\CurrentUser\Root | Where-Object Subject -eq "CN=$label" | select -First 1
+  if (-not $root)
+  {
+      Log-Error "Cerficate with subject CN=$label not found"
+      return
+  }
+  
+  Write-Host "Exporting certificate"
+  Export-Certificate -Type CERT -FilePath root.cer -Cert $root
+  
+  Write-Host "Converting certificate to PEM format"
+  certutil -encode root.cer root.pem
+  ```
+
+  Please specify the `ca_cert` in the global configuration.
+
+  ```
+  azure:
+    azure_stack:
+      ca_cert: |-
+        -----BEGIN CERTIFICATE-----
+        MII...
+        -----END CERTIFICATE-----
+  ```

--- a/docs/guidance.md
+++ b/docs/guidance.md
@@ -2,7 +2,12 @@
 
 In Microsoft Azure, there are serveral different environments, such as AzureCloud for global Azure, AzureUSGovernment for Azure Government, and AzureChinaCloud for Azure operated by 21Vianet in China.
 
-This document describes how to deploy [BOSH](http://bosh.io/) and [Cloud Foundry](https://www.cloudfoundry.org/) on [AzureCloud](https://azure.microsoft.com/en-us/), [AzureChinaCloud](https://www.azure.cn/) and [AzureUSGovernment](http://www.azure.com/gov).
+This document describes how to deploy [BOSH](http://bosh.io/) and [Cloud Foundry](https://www.cloudfoundry.org/) on:
+* [AzureCloud](https://azure.microsoft.com/en-us/)
+* [AzureChinaCloud](https://www.azure.cn/)
+* [AzureGermanCloud](https://azure.microsoft.com/en-us/overview/clouds/germany/)
+* [AzureUSGovernment](http://www.azure.com/gov)
+* [AzureStack](https://azure.microsoft.com/en-us/overview/azure-stack/)
 
 # 1 Prerequisites
 
@@ -10,6 +15,7 @@ You can create an Azure account according to the environment where Cloud Foundry
 
 * [Creating an Azure account for AzureCloud](https://azure.microsoft.com/en-us/pricing/free-trial/)
 * [Creating an Azure account for AzureChinaCloud](https://www.azure.cn/pricing/pia/)
+* [Creating an Azure account for AzureGermanCloud](https://azure.microsoft.com/en-us/free/germany/)
 * [Creating an Azure account for AzureUSGovernment](https://azuregov.microsoft.com/trial/azuregovtrial)
 
 # 2 Get Started
@@ -48,6 +54,7 @@ In this step, you will install Cloud Foundry Command Line Interface and push you
   * [Configure resource groups](./advanced/configure-resource-groups/)
   * [Deploy multiple network interfaces for a Cloud Foundry instance](./advanced/deploy-multiple-network-interfaces/)
   * [Use application security groups in Cloud Foundry](./advanced/application-security-groups/)
+  * [Deploy Cloud Foundry on Azure Stack](./advanced/azure-stack/)
 * Cloud Foundry Scenarios
   * [Update Cloud Foundry to use Diego](./advanced/switch-to-diego-default-architecture/)
   * [Push your first .NET application to Cloud Foundry on Azure](./advanced/push-your-first-net-application-to-cloud-foundry-on-azure/)

--- a/jobs/azure_cpi/spec
+++ b/jobs/azure_cpi/spec
@@ -62,12 +62,6 @@ properties:
   azure.azure_stack.endpoint_prefix:
     description: The endpoint prefix for your AzureStack deployment
     default: management
-  azure.azure_stack.skip_ssl_validation:
-    description: Toggles verification of the Azure Resource Manager REST API SSL certificate
-    default: false
-  azure.azure_stack.use_http_to_access_storage_account:
-    description: Flag for using HTTP to access storage account rather than the default HTTPS
-    default: false
   azure.azure_stack.ca_cert:
     description: All required custom CA certificates for AzureStack
     example:

--- a/jobs/azure_cpi/templates/cpi.json.erb
+++ b/jobs/azure_cpi/templates/cpi.json.erb
@@ -68,8 +68,6 @@
     params['cloud']['properties']['azure']['azure_stack']['authentication'] = p('azure.azure_stack.authentication')
     params['cloud']['properties']['azure']['azure_stack']['resource'] = resource
     params['cloud']['properties']['azure']['azure_stack']['endpoint_prefix'] = p('azure.azure_stack.endpoint_prefix')
-    params['cloud']['properties']['azure']['azure_stack']['skip_ssl_validation'] = p('azure.azure_stack.skip_ssl_validation')
-    params['cloud']['properties']['azure']['azure_stack']['use_http_to_access_storage_account'] = p('azure.azure_stack.use_http_to_access_storage_account')
   end
 
   if_p('blobstore') do

--- a/src/bosh_azure_cpi/lib/cloud/azure/azure_client2.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/azure_client2.rb
@@ -2132,12 +2132,8 @@ module Bosh::AzureCloud
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true
       if @azure_properties['environment'] == ENVIRONMENT_AZURESTACK
-        if @azure_properties['azure_stack']['skip_ssl_validation']
-          http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-        else
-          # The CA cert is only specified for the requests to AzureStack domain. If specified for other domains, the request will fail.
-          http.ca_file = get_ca_file_path if uri.host.include?(@azure_properties['azure_stack']['domain'])
-        end
+        # The CA cert is only specified for the requests to AzureStack domain. If specified for other domains, the request will fail.
+        http.ca_file = get_ca_file_path if uri.host.include?(@azure_properties['azure_stack']['domain'])
       end
       # The default value for read_timeout is 60 seconds.
       # The default value for open_timeout is nil before ruby 2.3.0 so set it to 60 seconds here.

--- a/src/bosh_azure_cpi/lib/cloud/azure/helpers.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/helpers.rb
@@ -235,15 +235,7 @@ module Bosh::AzureCloud
         :storage_dns_suffix   => URI.parse(storage_account[:storage_blob_host]).host.split(".")[2..-1].join("."),
         :user_agent_prefix    => USER_AGENT_FOR_REST
       }
-
-      if azure_properties['environment'] == ENVIRONMENT_AZURESTACK
-        use_http = azure_properties['azure_stack']['use_http_to_access_storage_account']
-        if use_http
-          options[:default_endpoints_protocol] = 'http'
-        else
-          options[:ca_file] = get_ca_file_path
-        end
-      end
+      options[:ca_file] = get_ca_file_path if azure_properties['environment'] == ENVIRONMENT_AZURESTACK
 
       Azure::Storage::Client.create(options)
     end

--- a/src/bosh_azure_cpi/spec/unit/azure_client2/azure_stack_ca_cert_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client2/azure_stack_ca_cert_spec.rb
@@ -10,69 +10,41 @@ describe Bosh::AzureCloud::AzureClient2 do
   end
 
   describe "#azure_stack_ca_cert" do
-    context "when ssl validation is skipped" do
-      let(:azure_client2) {
-        Bosh::AzureCloud::AzureClient2.new(
-          mock_cloud_options["properties"]["azure"].merge!({
-            "environment" => "AzureStack",
-            "azure_stack" => {
-              "domain"              => azure_stack_domain,
-              "resource"            => "fake-resource",
-              "skip_ssl_validation" => true
-            }
-          }),
-          logger
-        )
-      }
+    let(:azure_client2) {
+      Bosh::AzureCloud::AzureClient2.new(
+        mock_cloud_options["properties"]["azure"].merge!({
+          "environment" => "AzureStack",
+          "azure_stack" => {
+            "domain"              => azure_stack_domain,
+            "resource"            => "fake-resource",
+            "skip_ssl_validation" => false,
+            "ca_cert"             => "fake-ca-cert-content"
+          }
+        }),
+        logger
+      )
+    }
+    let(:ca_file_path) { "/var/vcap/jobs/azure_cpi/config/azure_stack_ca_cert.pem" }
+
+    context "when the uri doesn't contain the AzureStack domain" do
       let(:uri) { URI("https://fake-host") }
 
-      it "should use the mode VERIFY_NONE" do
+      it "should not configure the ca file" do
         expect(http).to receive(:use_ssl=).with(true)
-        expect(http).to receive(:verify_mode=).with(OpenSSL::SSL::VERIFY_NONE)
+        expect(http).not_to receive(:ca_file=).with(ca_file_path)
         expect(http).to receive(:open_timeout=).with(60)
         azure_client2.send(:http, uri)
       end
     end
 
-    context "when ssl validation is not skipped and the ca file is specified" do
-      let(:azure_client2) {
-        Bosh::AzureCloud::AzureClient2.new(
-          mock_cloud_options["properties"]["azure"].merge!({
-            "environment" => "AzureStack",
-            "azure_stack" => {
-              "domain"              => azure_stack_domain,
-              "resource"            => "fake-resource",
-              "skip_ssl_validation" => false,
-              "ca_cert"             => "fake-ca-cert-content"
-            }
-          }),
-          logger
-        )
-      }
-      let(:ca_file_path) { "/var/vcap/jobs/azure_cpi/config/azure_stack_ca_cert.pem" }
+    context "when the uri contains the AzureStack domain" do
+      let(:uri) { URI("https://#{azure_stack_domain}") }
 
-      context "when the uri doesn't contain the AzureStack domain" do
-        let(:uri) { URI("https://fake-host") }
-
-        it "should not use the mode VERIFY_NONE, and the ca file is not configured" do
-          expect(http).to receive(:use_ssl=).with(true)
-          expect(http).not_to receive(:verify_mode=).with(OpenSSL::SSL::VERIFY_NONE)
-          expect(http).not_to receive(:ca_file=).with(ca_file_path)
-          expect(http).to receive(:open_timeout=).with(60)
-          azure_client2.send(:http, uri)
-        end
-      end
-
-      context "when the uri contains the AzureStack domain" do
-        let(:uri) { URI("https://#{azure_stack_domain}") }
-
-        it "should not use the mode VERIFY_NONE, and the ca file is configured" do
-          expect(http).to receive(:use_ssl=).with(true)
-          expect(http).not_to receive(:verify_mode=).with(OpenSSL::SSL::VERIFY_NONE)
-          expect(http).to receive(:ca_file=).with(ca_file_path)
-          expect(http).to receive(:open_timeout=).with(60)
-          azure_client2.send(:http, uri)
-        end
+      it "should configure the ca file" do
+        expect(http).to receive(:use_ssl=).with(true)
+        expect(http).to receive(:ca_file=).with(ca_file_path)
+        expect(http).to receive(:open_timeout=).with(60)
+        azure_client2.send(:http, uri)
       end
     end
   end

--- a/src/bosh_azure_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
@@ -193,20 +193,16 @@ describe 'cpi.json.erb' do
             'authentication'                     => 'AzureAD',
             'resource'                           => 'fake-token-resource',
             'endpoint_prefix'                    => 'management',
-            "skip_ssl_validation"                => false,
-            "use_http_to_access_storage_account" => false,
           })
         end
       end
 
       context 'when maximal properties are provided' do
         before do
-          manifest['properties']['azure']['azure_stack']['domain']                             = 'fake-domain'
-          manifest['properties']['azure']['azure_stack']['authentication']                     = 'fake-authentication'
-          manifest['properties']['azure']['azure_stack']['resource']                           = 'fake-token-resource'
-          manifest['properties']['azure']['azure_stack']['endpoint_prefix']                    = 'fake-endpoint-prefix'
-          manifest['properties']['azure']['azure_stack']['skip_ssl_validation']                = true
-          manifest['properties']['azure']['azure_stack']['use_http_to_access_storage_account'] = true
+          manifest['properties']['azure']['azure_stack']['domain']          = 'fake-domain'
+          manifest['properties']['azure']['azure_stack']['authentication']  = 'fake-authentication'
+          manifest['properties']['azure']['azure_stack']['resource']        = 'fake-token-resource'
+          manifest['properties']['azure']['azure_stack']['endpoint_prefix'] = 'fake-endpoint-prefix'
         end
 
         it 'parses the AzureStack properties' do
@@ -215,8 +211,6 @@ describe 'cpi.json.erb' do
             'authentication'                     => 'fake-authentication',
             'resource'                           => 'fake-token-resource',
             'endpoint_prefix'                    => 'fake-endpoint-prefix',
-            "skip_ssl_validation"                => true,
-            "use_http_to_access_storage_account" => true,
           })
         end
       end

--- a/src/bosh_azure_cpi/spec/unit/helpers_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/helpers_spec.rb
@@ -407,64 +407,30 @@ describe Bosh::AzureCloud::Helpers do
 
     context "when the environment is AzureStack" do
       let(:azure_stack_domain) { "fake-azure-stack-domain" }
-
-      context "when http is used" do
-        let(:azure_properties) {
-          {
-            "environment" => "AzureStack",
-            "azure_stack" => {
-              "domain" => azure_stack_domain,
-              "use_http_to_access_storage_account" => true
-            }
+      let(:azure_properties) {
+        {
+          "environment" => "AzureStack",
+          "azure_stack" => {
+            "domain" => azure_stack_domain
           }
         }
-        let(:options) {
-          {
-            :storage_account_name       => storage_account_name,
-            :storage_access_key         => storage_account_key,
-            :storage_dns_suffix         => storage_dns_suffix,
-            :default_endpoints_protocol => "http",
-            :user_agent_prefix          => "BOSH-AZURE-CPI"
-          }
+      }
+      let(:options) {
+        {
+          :storage_account_name       => storage_account_name,
+          :storage_access_key         => storage_account_key,
+          :storage_dns_suffix         => storage_dns_suffix,
+          :ca_file                    => "/var/vcap/jobs/azure_cpi/config/azure_stack_ca_cert.pem",
+          :user_agent_prefix          => "BOSH-AZURE-CPI"
         }
+      }
 
-        it "should create the storage client with the correct options" do
-          expect(Azure::Storage::Client).to receive(:create).with(options).
-            and_return(azure_client)
-          expect(
-            helpers_tester.initialize_azure_storage_client(storage_account, azure_properties)
-          ).to eq(azure_client)
-        end
-      end
-
-      context "when https is used" do
-        let(:azure_properties) {
-          {
-            "environment" => "AzureStack",
-            "azure_stack" => {
-              "domain" => azure_stack_domain,
-              "use_http_to_access_storage_account" => false
-            }
-          }
-        }
-
-        let(:options) {
-          {
-            :storage_account_name       => storage_account_name,
-            :storage_access_key         => storage_account_key,
-            :storage_dns_suffix         => storage_dns_suffix,
-            :ca_file                    => "/var/vcap/jobs/azure_cpi/config/azure_stack_ca_cert.pem",
-            :user_agent_prefix          => "BOSH-AZURE-CPI"
-          }
-        }
-
-        it "should create the storage client with the correct options" do
-          expect(Azure::Storage::Client).to receive(:create).with(options).
-            and_return(azure_client)
-          expect(
-            helpers_tester.initialize_azure_storage_client(storage_account, azure_properties)
-          ).to eq(azure_client)
-        end
+      it "should create the storage client with the correct options" do
+        expect(Azure::Storage::Client).to receive(:create).with(options).
+          and_return(azure_client)
+        expect(
+          helpers_tester.initialize_azure_storage_client(storage_account, azure_properties)
+        ).to eq(azure_client)
       end
     end
   end


### PR DESCRIPTION
Fixes #308

- [x] Please check this box and fill the data as below once you have run the unit tests.
      Code coverage before your change: `766 examples, 0 failures. 3200 / 3349 LOC (95.55%) covered.`
      Code coverage with your change:   `764 examples, 0 failures. 3194 / 3343 LOC (95.54%) covered.`

  ```
  pushd src/bosh_azure_cpi
    ./bin/test-unit
  popd
  ```

  NOTE: Please see how to setup dev environment and run unit tests in docs/development.md.

### Changelog

* Remove the AzureStack properties skip_ssl_validation and use_http_to_access_storage_account, which means the Azure Stack CA cert must be specified in the global configuration
* Add documents for Cloud Foundry on Azure Stack
