### PR TITLE
Don't associate network security group (NSG) at the NIC level if no NSG is specified

### DIFF
--- a/jobs/azure_cpi/spec
+++ b/jobs/azure_cpi/spec
@@ -49,6 +49,7 @@ properties:
     default: 16
   azure.default_security_group:
     description: The name of the default security group that will be applied to all created VMs
+    default: ""
   azure.debug_mode:
     description: Enable debug mode to log all raw HTTP requests/responses
     default: false

--- a/src/bosh_azure_cpi/lib/cloud/azure/azure_client2.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/azure_client2.rb
@@ -1418,9 +1418,7 @@ module Bosh::AzureCloud
         'location'   => nic_params[:location],
         'tags'       => nic_params[:tags],
         'properties' => {
-          'networkSecurityGroup' => {
-            'id' => nic_params[:network_security_group][:id]
-          },
+          'networkSecurityGroup' => nic_params[:network_security_group].nil? ? nil : { 'id' => nic_params[:network_security_group][:id] },
           'ipConfigurations' => [
             {
               'name'        => nic_params[:ipconfig_name],
@@ -2015,6 +2013,15 @@ module Bosh::AzureCloud
 
         properties = result['properties']
         interface[:provisioning_state] = properties['provisioningState']
+
+        unless properties['networkSecurityGroup'].nil?
+          if recursive
+            interface[:network_security_group] = get_network_security_group(properties['networkSecurityGroup']['id'])
+          else
+            interface[:network_security_group] = {:id => properties['networkSecurityGroup']['id']}
+          end
+        end
+
         unless properties['dnsSettings']['dnsServers'].nil?
           interface[:dns_settings] = []
           properties['dnsSettings']['dnsServers'].each { |dns| interface[:dns_settings].push(dns) }

--- a/src/bosh_azure_cpi/lib/cloud/azure/vm_manager.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/vm_manager.rb
@@ -335,6 +335,7 @@ module Bosh::AzureCloud
       # Network security group name can be specified in resource_pool, networks and global configuration (ordered by priority)
       network_security_group_name = resource_pool.fetch('security_group', network.security_group)
       network_security_group_name = @azure_properties["default_security_group"] if network_security_group_name.nil?
+      return nil if network_security_group_name.nil? || network_security_group_name.empty?
       # The resource group which the NSG belongs to can be specified in networks and global configuration (ordered by priority)
       resource_group_name = network.resource_group_name
       network_security_group = @azure_client2.get_network_security_group_by_name(resource_group_name, network_security_group_name)

--- a/src/bosh_azure_cpi/spec/unit/azure_client2/get_operation_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client2/get_operation_spec.rb
@@ -766,6 +766,62 @@ describe Bosh::AzureCloud::AzureClient2 do
         end
       end
 
+      context "when the network interface is bound to network security group" do
+        let(:nic_response_body) {
+          {
+            "id" => "fake-id",
+            "name" => "fake-name",
+            "location" => "fake-location",
+            "tags" => "fake-tags",
+            "properties" => {
+              "provisioningState" => "fake-state",
+              "networkSecurityGroup" => {
+                "id" => nsg_id
+              },
+              "dnsSettings" => {
+                "dnsServers" => ["168.63.129.16"]
+              },
+              "ipConfigurations" => [
+                {
+                  "id" => "fake-id",
+                  "properties" => {
+                    "privateIPAddress" => "10.0.0.100",
+                    "privateIPAllocationMethod" => "Dynamic"
+                  }
+                }
+              ]
+            }
+          }.to_json
+        }
+        let(:fake_nic) {
+          {
+            :id => "fake-id",
+            :name => "fake-name",
+            :location => "fake-location",
+            :tags => "fake-tags",
+            :provisioning_state => "fake-state",
+            :network_security_group => fake_nsg,
+            :dns_settings => ["168.63.129.16"],
+            :ip_configuration_id => "fake-id",
+            :private_ip => "10.0.0.100",
+            :private_ip_allocation_method => "Dynamic"
+          }
+        }
+        it "should return the network interface with network security group" do
+          stub_request(:get, nsg_uri).to_return(
+            :status => 200,
+            :body => nsg_response_body,
+            :headers => {})
+          stub_request(:get, nic_uri).to_return(
+            :status => 200,
+            :body => nic_response_body,
+            :headers => {})
+          expect(
+            azure_client2.get_network_interface_by_name(resource_group_name, nic_name)
+          ).to eq(fake_nic)
+        end
+      end
+
       context "when the network interface is bound to application security group" do
         let(:nic_response_body) {
           {

--- a/src/bosh_azure_cpi/spec/unit/azure_client2/list_network_interfaces_by_keyword_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client2/list_network_interfaces_by_keyword_spec.rb
@@ -50,7 +50,8 @@ describe Bosh::AzureCloud::AzureClient2 do
     end
 
     context "when network interfaces are found and some of them have the keyword in the name" do
-      let(:result) {
+      # The first NIC's response body includes networkSecurityGroup, publicIPAddress, loadBalancerBackendAddressPools and applicationGatewayBackendAddressPools
+      let(:response_body) {
         {
           "value" => [
             {
@@ -65,7 +66,20 @@ describe Bosh::AzureCloud::AzureClient2 do
                     "id"  => "d0",
                     "properties"  => {
                       "privateIPAddress"  => "e0",
-                      "privateIPAllocationMethod"  => "f0"
+                      "privateIPAllocationMethod"  => "f0",
+                      "publicIPAddress" => {
+                        "id" => "j"
+                      },
+                      "loadBalancerBackendAddressPools" => [
+                        {
+                          "id" => "k"
+                        }
+                      ],
+                      "applicationGatewayBackendAddressPools" => [
+                        {
+                          "id" => "l"
+                        }
+                      ]
                     }
                   }
                 ],
@@ -74,6 +88,9 @@ describe Bosh::AzureCloud::AzureClient2 do
                       "g",
                       "h"
                    ]
+                },
+                "networkSecurityGroup" => {
+                  "id" => "i"
                 }
               }
             },
@@ -138,7 +155,11 @@ describe Bosh::AzureCloud::AzureClient2 do
           :dns_settings=>["g", "h"],
           :ip_configuration_id=>"d0",
           :private_ip=>"e0",
-          :private_ip_allocation_method=>"f0"
+          :private_ip_allocation_method=>"f0",
+          :network_security_group=>{:id=>"i"},
+          :public_ip=>{:id=>"j"},
+          :load_balancer=>{:id=>"k"},
+          :application_gateway=>{:id=>"l"}
         }
       }
       let(:network_interface_1) {
@@ -165,7 +186,7 @@ describe Bosh::AzureCloud::AzureClient2 do
           :headers => {})
         stub_request(:get, network_interfaces_url).to_return(
           :status => 200,
-          :body => result,
+          :body => response_body,
           :headers => {
           })
 

--- a/src/bosh_azure_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
@@ -180,6 +180,16 @@ describe 'cpi.json.erb' do
       end
     end
 
+    context 'when the default security group is not provided' do
+      before do
+        manifest['properties']['azure']['default_security_group'] = nil
+      end
+
+      it 'allows default_security_group to be empty string' do
+        expect(subject['cloud']['properties']['azure']['default_security_group']).to be_empty
+      end
+    end
+
     context 'when the storage account is not provided' do
       before do
         manifest['properties']['azure']['storage_account_name'] = nil


### PR DESCRIPTION
- [x] Please check this box and fill the data as below once you have run the unit tests.
      Code coverage before your change: `774 examples, 0 failures. 3210 / 3359 LOC (95.56%) covered.`
      Code coverage with your change:   `778 examples, 0 failures. 3219 / 3365 LOC (95.66%) covered.`

  ```
  pushd src/bosh_azure_cpi
    ./bin/test-unit
  popd
  ```

  NOTE: Please see how to setup dev environment and run unit tests in docs/development.md.

### Changelog

* allow not specifying the default security group in the global configuration
