### PR TITLE
default_security_group should not have a default value of empty string

### DIFF
--- a/docs/advanced/use-service-principal-with-certificate/README.md
+++ b/docs/advanced/use-service-principal-with-certificate/README.md
@@ -4,19 +4,20 @@ CPI v35+ supports service principal with password (`tenant_id`, `client_id` and 
 
 ## AzureAD authentication
 
-1. You can create service principal with certificate using [Azure CLI 1.0](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-authenticate-service-principal-cli#create-service-principal-with-certificate) or [Powershell](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-authenticate-service-principal#create-service-principal-with-self-signed-certificate). Azure CLI 2 doesn't support the creation of certificate-based authentication credentials.
+1. You can create service principal with certificate using [Azure CLI](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-authenticate-service-principal-cli#create-service-principal-with-certificate).
 
-1. After the above steps, you will get a certificate named `examplecert.pem`. You need to add `certificate` and remove `client_secret` in the [global configurations](https://bosh.io/docs/azure-cpi.html#global).
+1. You will get the certificate from step 1. You need to add a new property `certificate` and remove the property `client_secret` in the [global configurations](https://bosh.io/docs/azure-cpi.html#global).
 
-    ```
+    ```diff
     client_id: <YOUR-CLIENT-ID>
-    certificate: |-
-      -----BEGIN PRIVATE KEY-----
-      MII...
-      -----END PRIVATE KEY-----
-      -----BEGIN CERTIFICATE-----
-      MII...
-      -----END CERTIFICATE-----
+    --- client_secret: <YOUR-CLIENT_SECRET>
+    +++ certificate: |-
+    +++   -----BEGIN PRIVATE KEY-----
+    +++   MII...
+    +++   -----END PRIVATE KEY-----
+    +++   -----BEGIN CERTIFICATE-----
+    +++   MII...
+    +++   -----END CERTIFICATE-----
     ```
 
     Example ops file: [use-certificate-based-service-principal-AzureAD.yml](./use-certificate-based-service-principal-AzureAD.yml).
@@ -59,15 +60,16 @@ CPI v35+ supports service principal with password (`tenant_id`, `client_id` and 
 
 1. You need to add `certificate` and remove `client_secret` in the [global configurations](https://bosh.io/docs/azure-cpi.html#global), and set they authentication to `ADFS` for Azure Stack.
 
-    ```
+    ```diff
     client_id: <YOUR-CLIENT-ID>
-    certificate: |-
-      -----BEGIN PRIVATE KEY-----
-      MII...
-      -----END PRIVATE KEY-----
-      -----BEGIN CERTIFICATE-----
-      MII...
-      -----END CERTIFICATE-----
+    --- client_secret: <YOUR-CLIENT_SECRET>
+    +++ certificate: |-
+    +++   -----BEGIN PRIVATE KEY-----
+    +++   MII...
+    +++   -----END PRIVATE KEY-----
+    +++   -----BEGIN CERTIFICATE-----
+    +++   MII...
+    +++   -----END CERTIFICATE-----
     azure_stack:
       authentication: ADFS
     ```

--- a/jobs/azure_cpi/spec
+++ b/jobs/azure_cpi/spec
@@ -49,7 +49,6 @@ properties:
     default: 16
   azure.default_security_group:
     description: The name of the default security group that will be applied to all created VMs
-    default: ""
   azure.debug_mode:
     description: Enable debug mode to log all raw HTTP requests/responses
     default: false

--- a/jobs/azure_cpi/templates/cpi.json.erb
+++ b/jobs/azure_cpi/templates/cpi.json.erb
@@ -11,7 +11,6 @@
           'client_id' => p('azure.client_id'),
           'ssh_user' => p('azure.ssh_user'),
           'parallel_upload_thread_num' => p('azure.parallel_upload_thread_num'),
-          'default_security_group' => p('azure.default_security_group'),
           'debug_mode' => p('azure.debug_mode'),
           'use_managed_disks' => p('azure.use_managed_disks'),
           'pip_idle_timeout_in_minutes' => p('azure.pip_idle_timeout_in_minutes'),
@@ -57,6 +56,10 @@
     params['cloud']['properties']['azure']['ssh_public_key'] = ssh_public_key
   end.else do
     raise '"ssh_public_key" is not set. Please read https://bosh.io/docs/azure-cpi.html.'
+  end
+
+  if_p('azure.default_security_group') do |default_security_group|
+    params['cloud']['properties']['azure']['default_security_group'] = default_security_group
   end
 
   if p('azure.environment') == 'AzureStack'

--- a/src/bosh_azure_cpi/lib/cloud/azure/vm_manager.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/vm_manager.rb
@@ -335,7 +335,8 @@ module Bosh::AzureCloud
       # Network security group name can be specified in resource_pool, networks and global configuration (ordered by priority)
       network_security_group_name = resource_pool.fetch('security_group', network.security_group)
       network_security_group_name = @azure_properties["default_security_group"] if network_security_group_name.nil?
-      return nil if network_security_group_name.nil? || network_security_group_name.empty?
+      return nil if network_security_group_name.nil?
+      cloud_error("Cannot specify an empty string to the network security group") if network_security_group_name.empty?
       # The resource group which the NSG belongs to can be specified in networks and global configuration (ordered by priority)
       resource_group_name = network.resource_group_name
       network_security_group = @azure_client2.get_network_security_group_by_name(resource_group_name, network_security_group_name)

--- a/src/bosh_azure_cpi/spec/integration/lifecycle_spec.rb
+++ b/src/bosh_azure_cpi/spec/integration/lifecycle_spec.rb
@@ -78,7 +78,7 @@ describe Bosh::AzureCloud::Cloud do
     cloud_options_without_default_nsg = cloud_options.dup
     cloud_options_without_default_nsg['azure']['storage_account_name'] = storage_account_name unless storage_account_name.nil?
     cloud_options_without_default_nsg['azure']['use_managed_disks'] = use_managed_disks
-    cloud_options_without_default_nsg['azure']['default_security_group'] = ""
+    cloud_options_without_default_nsg['azure']['default_security_group'] = nil
     described_class.new(cloud_options_without_default_nsg)
   end
 

--- a/src/bosh_azure_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
@@ -186,7 +186,7 @@ describe 'cpi.json.erb' do
       end
 
       it 'allows default_security_group to be empty string' do
-        expect(subject['cloud']['properties']['azure']['default_security_group']).to be_empty
+        expect(subject['cloud']['properties']['azure']['default_security_group']).to be_nil
       end
     end
 


### PR DESCRIPTION
- [x] Please check this box and fill the data as below once you have run the unit tests.
      Code coverage before your change: `778 examples, 0 failures. 3219 / 3365 LOC (95.66%) covered.`
      Code coverage with your change:   `779 examples, 0 failures. 3220 / 3366 LOC (95.66%) covered.`

  ```
  pushd src/bosh_azure_cpi
    ./bin/test-unit
  popd
  ```

  NOTE: Please see how to setup dev environment and run unit tests in docs/development.md.

### Changelog

* default_security_group should not have a default value of empty string.
  CPI gets the NSG from resource_pool, network spec and global configuration (ordered by priority).
If the NSG is null (not specified), CPI should not associate NSG at a NIC level.
If the NSG is empty string, CPI should throw an error.
* Update docs for creating service principal with certificate.