### PR TITLE
Use semantic versioning when promoting the candidate

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -9,7 +9,9 @@ groups:
       - integration-windows-managed-disks
       - bats-unmanaged-disks
       - bats-managed-disks
-      - promote-candidate
+      - promote-candidate-major
+      - promote-candidate-minor
+      - promote-candidate-patch
 
 shared:
   - &azure-environment-params
@@ -319,7 +321,7 @@ jobs:
           do:
             - <<: *ensure-cleanup
 
-  - name: promote-candidate
+  - name: promote-candidate-major
     plan:
       - aggregate:
         - {trigger: false, get: bosh-cpi-release, resource: bosh-cpi-dev-artifacts, passed: [integration-unmanaged-disks, integration-managed-disks, integration-windows-unmanaged-disks, integration-windows-managed-disks, bats-unmanaged-disks, bats-managed-disks]}
@@ -333,7 +335,43 @@ jobs:
           S3_SECRET_ACCESS_KEY: {{s3_secret_key__promote}}
       - put: bosh-cpi-src
         resource: bosh-cpi-src-out
-        params: {repository: promoted/repo, rebase: true, tag_prefix: "v", tag: promoted/integer_version}
+        params: {repository: promoted/repo, rebase: true, tag_prefix: "v", tag: promoted/semver_version}
+      - put: release-version-semver
+        params: {file: release-version-semver/number}
+
+  - name: promote-candidate-minor
+    plan:
+      - aggregate:
+        - {trigger: false, get: bosh-cpi-release, resource: bosh-cpi-dev-artifacts, passed: [integration-unmanaged-disks, integration-managed-disks, integration-windows-unmanaged-disks, integration-windows-managed-disks, bats-unmanaged-disks, bats-managed-disks]}
+        - {trigger: false, get: bosh-cpi-src, resource: bosh-cpi-src-out}
+        - {trigger: false, get: release-version-semver, params: {bump: minor}}
+        - {trigger: false, get: bosh-cli}
+      - task: promote
+        file: bosh-cpi-src/ci/tasks/promote-candidate.yml
+        params:
+          S3_ACCESS_KEY_ID:     {{s3_access_key__promote}}
+          S3_SECRET_ACCESS_KEY: {{s3_secret_key__promote}}
+      - put: bosh-cpi-src
+        resource: bosh-cpi-src-out
+        params: {repository: promoted/repo, rebase: true, tag_prefix: "v", tag: promoted/semver_version}
+      - put: release-version-semver
+        params: {file: release-version-semver/number}
+
+  - name: promote-candidate-patch
+    plan:
+      - aggregate:
+        - {trigger: false, get: bosh-cpi-release, resource: bosh-cpi-dev-artifacts, passed: [integration-unmanaged-disks, integration-managed-disks, integration-windows-unmanaged-disks, integration-windows-managed-disks, bats-unmanaged-disks, bats-managed-disks]}
+        - {trigger: false, get: bosh-cpi-src, resource: bosh-cpi-src-out}
+        - {trigger: false, get: release-version-semver, params: {bump: patch}}
+        - {trigger: false, get: bosh-cli}
+      - task: promote
+        file: bosh-cpi-src/ci/tasks/promote-candidate.yml
+        params:
+          S3_ACCESS_KEY_ID:     {{s3_access_key__promote}}
+          S3_SECRET_ACCESS_KEY: {{s3_secret_key__promote}}
+      - put: bosh-cpi-src
+        resource: bosh-cpi-src-out
+        params: {repository: promoted/repo, rebase: true, tag_prefix: "v", tag: promoted/semver_version}
       - put: release-version-semver
         params: {file: release-version-semver/number}
 

--- a/ci/tasks/promote-candidate.sh
+++ b/ci/tasks/promote-candidate.sh
@@ -9,10 +9,9 @@ source bosh-cpi-src/ci/utils.sh
 source /etc/profile.d/chruby.sh
 chruby ${RUBY_VERSION}
 
-# Creates an integer version number from the semantic version format
-# May be changed when we decide to fully use semantic versions for releases
-integer_version=`cut -d "." -f1 release-version-semver/number`
-echo ${integer_version} > promoted/integer_version
+# Version info
+semver_version=`cat release-version-semver/number`
+echo $semver_version > promoted/semver_version
 
 cp -r bosh-cpi-src promoted/repo
 
@@ -30,7 +29,7 @@ blobstore:
 EOF
 
   echo "finalizing CPI release..."
-  bosh2 finalize-release ${dev_release} --version ${integer_version}
+  bosh2 finalize-release ${dev_release} --version ${semver_version}
 
   rm config/private.yml
 
@@ -39,5 +38,5 @@ EOF
 
   git config --global user.email cf-bosh-eng@pivotal.io
   git config --global user.name CI
-  git commit -m "New final release v${integer_version}"
+  git commit -m "New final release v${semver_version}"
 popd > /dev/null


### PR DESCRIPTION
No need to run unit tests.

### Changelog

* Use semantic versioning when promoting the candidate
