### PR TITLE
Return better error message when raising error AzureAsynchronousError

### DIFF
--- a/src/bosh_azure_cpi/lib/cloud/azure/azure_client2.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/azure_client2.rb
@@ -15,9 +15,8 @@ module Bosh::AzureCloud
   class AzureAsynchronousError < AzureError
     attr_accessor :status, :error
 
-    def initialize(status = nil, error = nil)
+    def initialize(status = nil)
       @status = status
-      @error = error
     end
   end
 
@@ -1789,7 +1788,7 @@ module Bosh::AzureCloud
                   sleep(retry_after)
                   raise AzureAsynInternalError, error
                 end
-                raise AzureAsynchronousError.new(result['status'], result['error']), error
+                raise AzureAsynchronousError.new(result['status']), error
               end
             end
             return true
@@ -1797,7 +1796,7 @@ module Bosh::AzureCloud
             error = "create_storage_account - http code: #{response.code}. Error message: #{response.body}"
             @logger.warn(error)
           elsif status_code != HTTP_CODE_ACCEPTED
-            raise AzureAsynchronousError.new(nil, "create_storage_account - http code: #{response.code}. Error message: #{response.body}")
+            raise AzureAsynchronousError.new(), "create_storage_account - http code: #{response.code}. Error message: #{response.body}"
           end
         end
       rescue AzureAsynInternalError => e
@@ -2371,13 +2370,13 @@ module Bosh::AzureCloud
         response = http_get_response(uri, request, retry_after)
         status_code = response.code.to_i
         if status_code != HTTP_CODE_OK && status_code != HTTP_CODE_ACCEPTED
-          raise AzureAsynchronousError.new(nil, "check_completion - http code: #{response.code}. Error message: #{response.body}")
+          raise AzureAsynchronousError.new(), "check_completion - http code: #{response.code}. Error message: #{response.body}"
         end
 
-        raise AzureAsynchronousError.new(nil, 'The body of the asynchronous response is empty') if response.body.nil?
+        raise AzureAsynchronousError.new(), 'The body of the asynchronous response is empty' if response.body.nil?
         result = JSON(response.body)
         if result['status'].nil?
-          raise AzureAsynchronousError.new(nil, "The body of the asynchronous response does not contain `status'. Response: #{response.body}")
+          raise AzureAsynchronousError.new(), "The body of the asynchronous response does not contain `status'. Response: #{response.body}"
         end
 
         status = result['status']
@@ -2397,7 +2396,7 @@ module Bosh::AzureCloud
             raise AzureAsynInternalError, error
           end
 
-          raise AzureAsynchronousError.new(status, error)
+          raise AzureAsynchronousError.new(status), error
         end
       end
     end

--- a/src/bosh_azure_cpi/lib/cloud/azure/disk_manager2.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/disk_manager2.rb
@@ -203,7 +203,7 @@ module Bosh::AzureCloud
       else
         error_message = "migrate_to_zone - Can'n find snapshot `#{snapshot_name}' in resource group `#{resource_group_name}', abort migration.\n"
         error_message += "You need to migrate `#{disk_id}' to zone `#{zone}' manually."
-        raise error_message
+        raise Bosh::Clouds::CloudError, error_message
       end
 
       disk_params = {
@@ -229,7 +229,7 @@ module Bosh::AzureCloud
         error_message += "You need to recover `#{disk_id}' mannually from snapshot `#{snapshot_name}' and put it in zone `#{zone}'. Try:\n"
         error_message += "    `az disk create --resource-group #{resource_group_name} --location #{disk[:location]} --sku #{disk[:account_type]} --zone #{zone} --name #{disk_name} --source #{snapshot_name}'\n"
         error_message += "#{e.inspect}\n#{e.backtrace.join("\n")}"
-        raise error_message
+        raise Bosh::Clouds::CloudError, error_message
       end
 
       if has_data_disk?(disk_id)
@@ -239,7 +239,7 @@ module Bosh::AzureCloud
         error_message = "migrate_to_zone - Can'n find disk `#{disk_name}' in resource group `#{resource_group_name}' after migration.\n"
         error_message += "You need to recover `#{disk_id}' manually from snapshot `#{snapshot_name}' and put it in zone `#{zone}'. Try:\n"
         error_message += "    `az disk create --resource-group #{resource_group_name} --location #{disk[:location]} --sku #{disk[:account_type]} --zone #{zone} --name #{disk_name} --source #{snapshot_name}'\n"
-        raise error_message
+        raise Bosh::Clouds::CloudError, error_message
       end
     end
   end

--- a/src/bosh_azure_cpi/lib/cloud/azure/vm_manager.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/vm_manager.rb
@@ -630,9 +630,11 @@ module Bosh::AzureCloud
           rescue => error
             retry if (retry_delete_count += 1) <= max_retries
             @keep_failed_vms = true # If the cleanup fails, then the VM resources have to be kept
-            error_message = 'The VM fails in provisioning but an error is thrown in cleanuping VM, os disk or ephemeral disk before retry.\n'
-            error_message += "#{error.inspect}\n#{error.backtrace.join("\n")}"
-            raise e, error_message
+            error_message = "The VM fails in provisioning.\n"
+            error_message += "#{e.inspect}\n#{e.backtrace.join('\n')}\n\n"
+            error_message += "And an error is thrown in cleanuping VM, os disk or ephemeral disk before retry.\n"
+            error_message += "#{error.inspect}\n#{error.backtrace.join('\n')}"
+            raise Bosh::Clouds::CloudError, error_message
           end
         end
 

--- a/src/bosh_azure_cpi/spec/unit/azure_client2/create_virtual_machine_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client2/create_virtual_machine_spec.rb
@@ -1534,7 +1534,7 @@ describe Bosh::AzureCloud::AzureClient2 do
 
         expect {
           azure_client2.create_virtual_machine(resource_group, vm_params, network_interfaces)
-        }.to raise_error { |error| expect(error.error).to match(/check_completion - http code: 404/) }
+        }.to raise_error /check_completion - http code: 404/
       end
 
       it "should raise an error if create operation failed" do

--- a/src/bosh_azure_cpi/spec/unit/azure_client2/delete_virtual_machine_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client2/delete_virtual_machine_spec.rb
@@ -219,7 +219,7 @@ describe Bosh::AzureCloud::AzureClient2 do
 
           expect {
             azure_client2.delete_virtual_machine(resource_group, vm_name)
-          }.to raise_error { |error| expect(error.error).to match(/The body of the asynchronous response is empty/) }
+          }.to raise_error /The body of the asynchronous response is empty/
         end
 
         it "should raise an error if the body of the asynchronous response does not contain 'status'" do
@@ -239,7 +239,7 @@ describe Bosh::AzureCloud::AzureClient2 do
 
           expect {
             azure_client2.delete_virtual_machine(resource_group, vm_name)
-          }.to raise_error { |error| expect(error.error).to match(/The body of the asynchronous response does not contain `status'/) }
+          }.to raise_error /The body of the asynchronous response does not contain `status'/
         end
 
         it "should raise an error if check completion operation is not accepeted" do
@@ -256,7 +256,7 @@ describe Bosh::AzureCloud::AzureClient2 do
 
           expect {
             azure_client2.delete_virtual_machine(resource_group, vm_name)
-          }.to raise_error { |error| expect(error.error).to match(/check_completion - http code: 404/) }
+          }.to raise_error /check_completion - http code: 404/
         end
 
         it "should raise an error if create peration failed" do

--- a/src/bosh_azure_cpi/spec/unit/azure_client2/restart_virtual_machine_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client2/restart_virtual_machine_spec.rb
@@ -171,7 +171,7 @@ describe Bosh::AzureCloud::AzureClient2 do
 
         expect {
           azure_client2.restart_virtual_machine(resource_group, vm_name)
-        }.to raise_error { |error| expect(error.error).to match(/check_completion - http code: 404/) }
+        }.to raise_error /check_completion - http code: 404/
       end
 
       it "should raise an error if restart operation failed" do

--- a/src/bosh_azure_cpi/spec/unit/vm_manager/create/vm_is_not_created_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/vm_manager/create/vm_is_not_created_spec.rb
@@ -77,7 +77,7 @@ describe Bosh::AzureCloud::VMManager do
         context "and AzureAsynchronousError.status is Failed" do
           before do
             allow(client2).to receive(:create_virtual_machine).
-              and_raise(Bosh::AzureCloud::AzureAsynchronousError.new('Failed'))
+              and_raise(Bosh::AzureCloud::AzureAsynchronousError.new('Failed'), 'fake error message')
           end
 
           context "and keep_failed_vms is false in global configuration" do
@@ -144,8 +144,10 @@ describe Bosh::AzureCloud::VMManager do
                     expect {
                       vm_manager.create(instance_id, location, stemcell_info, resource_pool, network_configurator, env)
                     }.to raise_error { |error|
+                      expect(error.inspect).to match(/The VM fails in provisioning./)
+                      expect(error.inspect).to match(/fake error message/)
+                      expect(error.inspect).to match(/And an error is thrown in cleanuping VM, os disk or ephemeral disk before retry./)
                       expect(error.inspect).to match(/cannot delete the vm/)
-                      expect(error.inspect).to match(/The VM fails in provisioning but an error is thrown in cleanuping VM/)
                       # If the cleanup fails, then the VM resources have to be kept
                       expect(error.inspect).to match(/This VM fails in provisioning after multiple retries/)
                     }
@@ -301,8 +303,10 @@ describe Bosh::AzureCloud::VMManager do
                     expect {
                       vm_manager_to_keep_failed_vms.create(instance_id, location, stemcell_info, resource_pool, network_configurator, env)
                     }.to raise_error { |error|
+                      expect(error.inspect).to match(/The VM fails in provisioning./)
+                      expect(error.inspect).to match(/fake error message/)
+                      expect(error.inspect).to match(/And an error is thrown in cleanuping VM, os disk or ephemeral disk before retry./)
                       expect(error.inspect).to match(/cannot delete the vm/)
-                      expect(error.inspect).to match(/The VM fails in provisioning but an error is thrown in cleanuping VM/)
                       # If the cleanup fails, then the VM resources have to be kept
                       expect(error.inspect).to match(/This VM fails in provisioning after multiple retries/)
                     }


### PR DESCRIPTION
- [x] Please check this box and fill the data as below once you have run the unit tests.
      Code coverage before your change: `779 examples, 0 failures. 3220 / 3366 LOC (95.66%) covered.`
      Code coverage with your change:   `779 examples, 0 failures. 3221 / 3367 LOC (95.66%) covered.`

  ```
  pushd src/bosh_azure_cpi
    ./bin/test-unit
  popd
  ```

  NOTE: Please see how to setup dev environment and run unit tests in docs/development.md.

### Changelog

* Return better error message when raising error AzureAsynchronousError

