### PR TITLE
Update the development docs

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -1,0 +1,23 @@
+# BOSH Azure CPI Concourse Pipeline
+
+In order to run the BOSH Azure CPI Concourse Pipeline you must have an existing [Concourse](http://concourse.ci) environment. See [Deploying Concourse on Azure](https://github.com/Azure/azure-quickstart-templates/tree/master/concourse-ci) for instructions, if you don't have one.
+
+* Target your Concourse CI environment:
+
+```
+fly -t azure login -c <YOUR CONCOURSE URL>
+```
+
+* Update the [credentials.yml](./credentials.yml) file.
+ 
+* Set the BOSH Azure CPI pipeline:
+
+```
+fly -t azure set-pipeline -p bosh-azure-cpi -c pipeline.yml -l credentials.yml
+```
+
+* Unpause the BOSH Azure CPI pipeline:
+
+```
+fly -t azure unpause-pipeline -p bosh-azure-cpi
+```

--- a/ci/credentials.yml
+++ b/ci/credentials.yml
@@ -1,0 +1,35 @@
+github_deployment_key__bosh-azure-cpi-release: | 
+  <DEPLOYMENT-KEY-OF-YOUR-OWN-GITHUB-REPOSITORY> 
+ssh_public_key: <YOUR-PUBLIC-KEY> 
+ssh_private_key: | 
+  <YOUR-PRIVATE-KEY> 
+
+azure_location: 'eastus2' # Only eastus2 and westeurope are allowed because of availability zones preview 
+azure_environment: AzureCloud 
+azure_subscription_id: REPLACE-ME 
+azure_tenant_id: REPLACE-ME 
+azure_client_id: REPLACE-ME 
+azure_client_secret: REPLACE-ME 
+azure_certificate: |-
+  REPLACE-ME 
+
+s3_azure_cpi_pipeline_bucket: <BUCKET-NAME> 
+terraform_bucket: <BUCKET-NAME> 
+s3_access_key__primary: REPLACE-ME 
+s3_secret_key__primary: REPLACE-ME 
+s3_access_key__promote: REPLACE-ME 
+s3_secret_key__promote: REPLACE-ME 
+s3_region__primary: "" 
+
+azure_director_vars_file: | 
+  subscription_id: REPLACE-ME # Same with the value of azure_subscription_id 
+  tenant_id: REPLACE-ME 
+  client_id: REPLACE-ME 
+  client_secret: REPLACE-ME 
+  dns_recursor_ip: 8.8.8.8 
+
+azure_application_gateway_name: REPLACE-ME 
+azure_application_security_group_name: REPLACE-ME 
+azure_application_security_group_tests_enabled: false 
+azure_bats_standard_public_ip_name: REPLACE-ME 
+azure_bats_zone: '1' 

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,118 +1,127 @@
-## Development
+# Development
 
-### Before you start:
+>NOTE: Below commands are tested in Ubuntu 16.04 LTS.
 
-# Install GO (used by the vendoring direnv):
-Please install [GO](https://golang.org/dl/).
+## Prepare the development environment
+
+1. Install dependencies
+
+    ```bash
+    sudo apt-get update
+    sudo apt-get install -y git gcc make libssl-dev libreadline-dev zlib1g-dev
+    ```
+
+1. Create the workspace directory
+
+    ```bash
+    mkdir ~/workspace
+    ```
+
+1. Install GO (used by the vendoring direnv):
+
+    Please install [GO](https://golang.org/dl/).
+
+    ```bash
+    cd ~/workspace
+    wget https://dl.google.com/go/go1.9.3.linux-amd64.tar.gz
+    sudo tar -C /usr/local -xzf go1.9.3.linux-amd64.tar.gz
+    rm go1.9.3.linux-amd64.tar.gz
+    mkdir ~/go
+    echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.bashrc
+    echo 'export GOPATH=$HOME/go' >> ~/.bashrc
+    exec $SHELL
+    ```
+
+1. Install direnv
+
+    Please install [direnv](https://github.com/direnv/direnv#from-source).
+
+    ```bash
+    mkdir -p $GOPATH/src/github.com/direnv
+    git clone https://github.com/direnv/direnv.git $GOPATH/src/github.com/direnv/direnv
+    pushd $GOPATH/src/github.com/direnv/direnv
+      make
+      sudo make install
+    popd
+    echo 'eval "$(direnv hook bash)"' >> ~/.bashrc
+    exec $SHELL
+    ```
+
+1. Install ruby
+
+    Please make sure you have installed ruby `2.4.2` before you start.
+
+    ```bash
+    cd ~/workspace
+    wget -O chruby-0.3.9.tar.gz https://github.com/postmodern/chruby/archive/v0.3.9.tar.gz
+    tar -xzvf chruby-0.3.9.tar.gz
+    pushd chruby-0.3.9/
+      sudo make install
+      echo 'source /usr/local/share/chruby/chruby.sh' >> ~/.bashrc
+    popd
+    exec $SHELL
+
+    wget -O ruby-install-0.6.1.tar.gz https://github.com/postmodern/ruby-install/archive/v0.6.1.tar.gz
+    tar -xzvf ruby-install-0.6.1.tar.gz
+    pushd ruby-install-0.6.1/
+      sudo make install
+    popd
+
+    ruby-install ruby 2.4.2
+    echo 'chruby 2.4.2' >> ~/.bashrc
+    exec $SHELL
+    ruby -v
+    ```
+
+1. Install bundler (used by the vendoring script)
+
+    ```bash
+    gem install bundler
+    ```
+
+1. Clone Azure CPI repository
+
+    ```bash
+    cd ~/workspace
+    git clone https://github.com/cloudfoundry-incubator/bosh-azure-cpi-release
+    cd bosh-azure-cpi-release/
+    direnv allow
+    ```
+
+1. Run vendoring script
+
+    With bundler installed, switch to `./src/bosh_azure_cpi` and run:
+
+    ```bash
+    cd ~/workspace/bosh-azure-cpi-release/src/bosh_azure_cpi
+    ./vendor_gems
+    ```
+
+Your development environment is prepared successfully.
+
+## Run Tests
+
+### Unit tests
+
+The [unit tests](https://github.com/cloudfoundry-incubator/bosh-azure-cpi-release/tree/master/src/bosh_azure_cpi/spec/unit) are **REQUIRED** before you submit a PR. When submitting a PR, you need to provide the test coverage and make sure that the coverage doesn't decrease.
+
+```bash
+cd ~/workspace/bosh-azure-cpi-release/src/bosh_azure_cpi
+./bin/test-unit
+```
+
+If unit tests are passed, you can create a dev release and deploy it for tests.
+
+### CI Pipeline
+
+You can setup a [CI pipeline](../ci/) to run the [integration tests](https://github.com/cloudfoundry-incubator/bosh-azure-cpi-release/tree/master/src/bosh_azure_cpi/spec/integration) and [BATs](https://github.com/cloudfoundry/bosh-acceptance-tests/tree/gocli-bats). It's optional for submitting a PR and required for publishing a new CPI release.
+
+### Test CPI methods
+
+You can use `bosh_azure_console` to test your code changes quickly.
 
   ```bash
-  mkdir ~/workspace ~/go
   cd ~/workspace
-  wget https://storage.googleapis.com/golang/go1.9.linux-amd64.tar.gz
-  sudo tar -C /usr/local -xzf go1.9.linux-amd64.tar.gz
-  echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.bashrc
-  echo 'export GOPATH=$HOME/go' >> ~/.bashrc
-  exec $SHELL
-  ```
-
-# Install direnv
-Please install [direnv](https://github.com/direnv/direnv#from-source).
-
-  ```bash
-  mkdir -p $GOPATH/src/github.com/direnv
-  git clone https://github.com/direnv/direnv.git $GOPATH/src/github.com/direnv/direnv
-  pushd $GOPATH/src/github.com/direnv/direnv
-    make
-    sudo make install
-  popd
-  echo 'eval "$(direnv hook bash)"' >> ~/.bashrc
-  exec $SHELL
-  ```
-
-  **NOTE**: You may need to use `direnv allow .` in the root directory of `bosh-azure-cpi-release`.
-
-# Install ruby
-Please make sure you have installed ruby 2.4.2 before you start. Below commands are tested in Ubuntu 14.04 LTS.
-
-  ```bash
-  # Install ruby 2.4.2 with chruby
-  sudo apt-get update
-  sudo apt-get install -y git gcc make libssl-dev libreadline-dev zlib1g-dev
-
-  cd ~/workspace
-  wget -O chruby-0.3.9.tar.gz https://github.com/postmodern/chruby/archive/v0.3.9.tar.gz
-  tar -xzvf chruby-0.3.9.tar.gz
-  pushd chruby-0.3.9/
-    sudo make install
-    echo 'source /usr/local/share/chruby/chruby.sh' >> ~/.bashrc
-  popd
-  exec $SHELL
-
-  wget -O ruby-install-0.6.1.tar.gz https://github.com/postmodern/ruby-install/archive/v0.6.1.tar.gz
-  tar -xzvf ruby-install-0.6.1.tar.gz
-  pushd ruby-install-0.6.1/
-    sudo make install
-  popd
-
-  ruby-install ruby 2.4.2
-  exec $SHELL
-  chruby 2.4.2
-  ruby -v
-  ```
-
-### Install Ruby gem Bundler (used by the vendoring script):
-
-  ```bash
-  chruby 2.4.2
-  ruby -v
-
-  gem install bundler
-  ```
-
-### Run vendoring script
-
-With bundler installed, switch to `./src/bosh_azure_cpi` and run:
-
-  ```bash
-  chruby 2.4.2
-  ruby -v
-
-  # Assume that you have cloned https://github.com/cloudfoundry-incubator/bosh-azure-cpi-release.git into ~/workspace/bosh-azure-cpi-release
-  cd ~/workspace/bosh-azure-cpi-release/src/bosh_azure_cpi
-  ./vendor_gems
-  ```
-
-### Run unittests script
-
-  ```bash
-  cd ~/workspace/bosh-azure-cpi-release/src/bosh_azure_cpi
-  ./bin/test-unit
-  ```
-
-### Create the BOSH release:
-
-  ```bash
-  chruby 2.4.2
-  ruby -v
-
-  gem install bosh_cli
-  # Assume that you have cloned https://github.com/cloudfoundry-incubator/bosh-azure-cpi-release.git into ~/workspace/bosh-azure-cpi-release
-  cd ~/workspace/bosh-azure-cpi-release
-  cpi_dev_version=35.0.1.dev
-  bosh create-release --name=bosh-azure-cpi --version=${cpi_dev_version} --tarball=/tmp/bosh-azure-cpi-release-${cpi_dev_version}.tgz
-  ```
-
-The release is now ready for use. If everything works, commit the changes including the updated gems.
-
-At the end of the CLI output there will be "Release tarball" path.
-
-## Test Interfaces
-After you change the CPI code, you can use `bosh_azure_console` to test your changes. Below commands are tested in Ubuntu 14.04 LTS.
-
-  ```bash
-  cd ~/workspace
-  chruby 2.4.2
-  ruby -v
 
   # Install postgres which bosh-registry depends on
   sudo apt-get install -y postgresql postgresql-contrib libpq-dev g++ libmysqlclient-dev libsqlite3-dev
@@ -202,34 +211,46 @@ Console 2:
 Examples:
 
   ```ruby
-  cpi.azure_client2.get_resource_group
-  cpi.disk_manager2.has_disk?('bosh-disk-a')
+  # Test the mehodes in azure_client2.rb
+  cpi.azure_client2.get_resource_group('fake-resource-group-name')
+
+  # Test disk_manager2.rb
+  cpi.disk_manager2.has_disk?('fake-resource-group-name', 'bosh-disk-a')
+
+  # Test the CPI method create_stemcell
+  stemcell_properties = {
+    "name" => "fake-name",
+    "version" => "fake-version",
+    "infrastructure" => "azure",
+    "hypervisor" => "hyperv",
+    "disk" => "30720",
+    "disk_format" => "vhd",
+    "container_format" => "bare",
+    "os_type" => "linux",
+    "os_distro" => "ubuntu",
+    "architecture" => "x86_64",
+    "image" => {"publisher"=>"Canonical", "offer"=>"UbuntuServer", "sku"=>"16.04-LTS", "version"=>"16.04.201611220"}
+  }
+  cpi.create_stemcell('', stemcell_properties)
+
+  # Test create_vm with a valid stemcell_id
+  agent_id = "<GUID>"
+  stemcell_id = "<a-valid-stemcell-id>"
+  resource_pool = JSON('{"instance_type":"Standard_F1"}')
+  networks = JSON('{"private":{"cloud_properties":{"subnet_name":"Bosh","virtual_network_name":"boshvnet-crp"},"default":["dns","gateway"],"dns":["168.63.129.16","8.8.8.8"],"gateway":"10.0.0.1","ip":"10.0.0.42","netmask":"255.255.255.0","type":"manual"}}')
+  instance_id = cpi.create_vm(agent_id, stemcell_id, resource_pool, networks)
   ```
 
-Below is an example you can type in `bosh_azure_console` to test fake light stemcells.
+## Create a dev release
 
-  ```ruby
-  begin
-    stemcell_properties = {
-      "name" => "fake-name",
-      "version" => "fake-version",
-      "infrastructure" => "azure",
-      "hypervisor" => "hyperv",
-      "disk" => "30720",
-      "disk_format" => "vhd",
-      "container_format" => "bare",
-      "os_type" => "linux",
-      "os_distro" => "ubuntu",
-      "architecture" => "x86_64",
-      "image" => {"publisher"=>"Canonical", "offer"=>"UbuntuServer", "sku"=>"16.04-LTS", "version"=>"16.04.201611220"}
-    }
-    stemcell_id = cpi.create_stemcell('', stemcell_properties)
-    agent_id = 'abel-test-light-stemcell'
-    resource_pool = JSON('{"instance_type":"Standard_F1"}')
-    networks = JSON('{"private":{"cloud_properties":{"subnet_name":"Bosh","virtual_network_name":"boshvnet-crp"},"default":["dns","gateway"],"dns":["168.63.129.16","8.8.8.8"],"gateway":"10.0.0.1","ip":"10.0.0.4","netmask":"255.255.255.0","type":"manual"}}')
-    instance_id = cpi.create_vm(agent_id, stemcell_id, resource_pool, networks)
-    cpi.delete_vm(instance_id)
-  ensure
-    cpi.delete_stemcell(stemcell_id)
-  end
-  ```
+Follow the [guidance](http://bosh.io/docs/cli-v2.html) to install the latest version of BOSH CLI v2.
+
+**NOTE**: BOSH CLI `v2.0.36+` is required for [`bosh vendor-package`](https://bosh.io/docs/package-vendoring.html).
+
+```bash
+cd ~/workspace/bosh-azure-cpi-release
+cpi_dev_version=35.0.1.dev
+bosh create-release --name=bosh-azure-cpi --version=${cpi_dev_version} --tarball=/tmp/bosh-azure-cpi-release-${cpi_dev_version}.tgz
+```
+
+The release is now ready for use. If everything works, commit the changes including the updated gems.


### PR DESCRIPTION
### Changelog

* BOSH CLI `v2.0.36+` is required to create a release.
* Add a guidance to setup the concourse pipeline.