### PR TITLE
Enable telemetry on CPI calls

### DIFF
--- a/jobs/azure_cpi/spec
+++ b/jobs/azure_cpi/spec
@@ -61,6 +61,9 @@ properties:
   azure.keep_failed_vms:
     description: Enable keeping the VM which failed in provisioning for troubleshooting
     default: false
+  azure.enable_telemetry:
+    description: Enable telemetry on CPI calls
+    default: true
   azure.azure_stack.domain:
     description: The domain for your AzureStack deployment
     default: local.azurestack.external

--- a/jobs/azure_cpi/templates/cpi.json.erb
+++ b/jobs/azure_cpi/templates/cpi.json.erb
@@ -14,7 +14,8 @@
           'debug_mode' => p('azure.debug_mode'),
           'use_managed_disks' => p('azure.use_managed_disks'),
           'pip_idle_timeout_in_minutes' => p('azure.pip_idle_timeout_in_minutes'),
-          'keep_failed_vms' => p('azure.keep_failed_vms')
+          'keep_failed_vms' => p('azure.keep_failed_vms'),
+          'enable_telemetry' => p('azure.enable_telemetry')
         },
         'registry' => {
           'user' => p('registry.username'),

--- a/src/bosh_azure_cpi/lib/cloud/azure.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure.rb
@@ -63,6 +63,12 @@ require 'cloud/azure/disk_id'
 
 require 'cloud/azure/instance_type_mapper'
 
+require 'cloud/azure/version'
+require 'cloud/azure/telemetry/telemetry_manager'
+require 'cloud/azure/telemetry/telemetry_event'
+require 'cloud/azure/telemetry/telemetry_event_handler'
+require 'cloud/azure/telemetry/wire_client'
+
 module Bosh
   module Clouds
     Azure = Bosh::AzureCloud::Cloud

--- a/src/bosh_azure_cpi/lib/cloud/azure/cloud.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/cloud.rb
@@ -24,9 +24,12 @@ module Bosh::AzureCloud
 
       @use_managed_disks = azure_properties['use_managed_disks']
 
-      init_registry
-      init_azure
       init_cpi_lock_dir
+      @telemetry_manager = Bosh::AzureCloud::TelemetryManager.new(azure_properties, @logger)
+      @telemetry_manager.monitor("initialize") do
+        init_registry
+        init_azure
+      end
     end
 
     ##
@@ -38,12 +41,17 @@ module Bosh::AzureCloud
     # @return [String] opaque id later used by {#create_vm} and {#delete_stemcell}
     def create_stemcell(image_path, stemcell_properties)
       with_thread_name("create_stemcell(#{image_path}, #{stemcell_properties})") do
-        if has_light_stemcell_property?(stemcell_properties)
-          @light_stemcell_manager.create_stemcell(stemcell_properties)
-        elsif @use_managed_disks
-          @stemcell_manager2.create_stemcell(image_path, stemcell_properties)
-        else
-          @stemcell_manager.create_stemcell(image_path, stemcell_properties)
+        extras = {
+          "stemcell" => "#{stemcell_properties.fetch("name", "unknown_name")}-#{stemcell_properties.fetch("version", "unknown_version")}"
+        }
+        @telemetry_manager.monitor("create_stemcell", extras: extras) do
+          if has_light_stemcell_property?(stemcell_properties)
+            @light_stemcell_manager.create_stemcell(stemcell_properties)
+          elsif @use_managed_disks
+            @stemcell_manager2.create_stemcell(image_path, stemcell_properties)
+          else
+            @stemcell_manager.create_stemcell(image_path, stemcell_properties)
+          end
         end
       end
     end
@@ -55,12 +63,14 @@ module Bosh::AzureCloud
     # @return [void]
     def delete_stemcell(stemcell_id)
       with_thread_name("delete_stemcell(#{stemcell_id})") do
-        if is_light_stemcell_id?(stemcell_id)
-          @light_stemcell_manager.delete_stemcell(stemcell_id)
-        elsif @use_managed_disks
-          @stemcell_manager2.delete_stemcell(stemcell_id)
-        else
-          @stemcell_manager.delete_stemcell(stemcell_id)
+        @telemetry_manager.monitor("delete_stemcell", id: stemcell_id) do
+          if is_light_stemcell_id?(stemcell_id)
+            @light_stemcell_manager.delete_stemcell(stemcell_id)
+          elsif @use_managed_disks
+            @stemcell_manager2.delete_stemcell(stemcell_id)
+          else
+            @stemcell_manager.delete_stemcell(stemcell_id)
+          end
         end
       end
     end
@@ -131,77 +141,80 @@ module Bosh::AzureCloud
       # env may contain credentials so we must not log it
       @logger.info("create_vm(#{agent_id}, #{stemcell_id}, #{resource_pool}, #{networks}, #{disk_locality}, ...)")
       with_thread_name("create_vm(#{agent_id}, ...)") do
-        # These resources should be in the same location for a VM: VM, NIC, disk(storage account or managed disk).
-        # And NIC must be in the same location with VNET, so CPI will use VNET's location as default location for the resources related to the VM.
-        network_configurator = NetworkConfigurator.new(azure_properties, networks)
-        network = network_configurator.networks[0]
-        vnet = @azure_client2.get_virtual_network_by_name(network.resource_group_name, network.virtual_network_name)
-        cloud_error("Cannot find the virtual network `#{network.virtual_network_name}' under resource group `#{network.resource_group_name}'") if vnet.nil?
-        location = vnet[:location]
-        location_in_global_configuration = azure_properties['location'] 
-        if !location_in_global_configuration.nil? && location_in_global_configuration != location
-          cloud_error("The location in the global configuration `#{location_in_global_configuration}' is different from the location of the virtual network `#{location}'")
-        end
-        resource_group_name = resource_pool.fetch('resource_group_name', azure_properties['resource_group_name'])
+        extras = {"instance_type" => resource_pool.fetch("instance_type", 'unknown_instance_type')}
+        @telemetry_manager.monitor("create_vm", id: agent_id, extras: extras) do
+          # These resources should be in the same location for a VM: VM, NIC, disk(storage account or managed disk).
+          # And NIC must be in the same location with VNET, so CPI will use VNET's location as default location for the resources related to the VM.
+          network_configurator = NetworkConfigurator.new(azure_properties, networks)
+          network = network_configurator.networks[0]
+          vnet = @azure_client2.get_virtual_network_by_name(network.resource_group_name, network.virtual_network_name)
+          cloud_error("Cannot find the virtual network `#{network.virtual_network_name}' under resource group `#{network.resource_group_name}'") if vnet.nil?
+          location = vnet[:location]
+          location_in_global_configuration = azure_properties['location'] 
+          if !location_in_global_configuration.nil? && location_in_global_configuration != location
+            cloud_error("The location in the global configuration `#{location_in_global_configuration}' is different from the location of the virtual network `#{location}'")
+          end
+          resource_group_name = resource_pool.fetch('resource_group_name', azure_properties['resource_group_name'])
 
-        if @use_managed_disks
-          instance_id = InstanceId.create(resource_group_name, agent_id)
+          if @use_managed_disks
+            instance_id = InstanceId.create(resource_group_name, agent_id)
 
-          storage_account_type = resource_pool['storage_account_type']
-          storage_account_type = get_storage_account_type_by_instance_type(resource_pool['instance_type']) if storage_account_type.nil?
+            storage_account_type = resource_pool['storage_account_type']
+            storage_account_type = get_storage_account_type_by_instance_type(resource_pool['instance_type']) if storage_account_type.nil?
 
-          if is_light_stemcell_id?(stemcell_id)
-            raise Bosh::Clouds::VMCreationFailed.new(false), "Given stemcell `#{stemcell_id}' does not exist" unless @light_stemcell_manager.has_stemcell?(location, stemcell_id)
-            stemcell_info = @light_stemcell_manager.get_stemcell_info(stemcell_id)
+            if is_light_stemcell_id?(stemcell_id)
+              raise Bosh::Clouds::VMCreationFailed.new(false), "Given stemcell `#{stemcell_id}' does not exist" unless @light_stemcell_manager.has_stemcell?(location, stemcell_id)
+              stemcell_info = @light_stemcell_manager.get_stemcell_info(stemcell_id)
+            else
+              begin
+                # Treat user_image_info as stemcell_info
+                stemcell_info = @stemcell_manager2.get_user_image_info(stemcell_id, storage_account_type, location)
+              rescue => e
+                raise Bosh::Clouds::VMCreationFailed.new(false), "Failed to get the user image information for the stemcell `#{stemcell_id}': #{e.inspect}\n#{e.backtrace.join("\n")}"
+              end
+            end
           else
-            begin
-              # Treat user_image_info as stemcell_info
-              stemcell_info = @stemcell_manager2.get_user_image_info(stemcell_id, storage_account_type, location)
-            rescue => e
-              raise Bosh::Clouds::VMCreationFailed.new(false), "Failed to get the user image information for the stemcell `#{stemcell_id}': #{e.inspect}\n#{e.backtrace.join("\n")}"
+            cloud_error("Virtual Machines deployed to an Availability Zone must use managed disks") unless resource_pool['availability_zone'].nil?
+            storage_account = @storage_account_manager.get_storage_account_from_resource_pool(resource_pool, location)
+            instance_id = InstanceId.create(resource_group_name, agent_id, storage_account[:name])
+
+            if is_light_stemcell_id?(stemcell_id)
+              raise Bosh::Clouds::VMCreationFailed.new(false), "Given stemcell `#{stemcell_id}' does not exist" unless @light_stemcell_manager.has_stemcell?(location, stemcell_id)
+              stemcell_info = @light_stemcell_manager.get_stemcell_info(stemcell_id)
+            else
+              unless @stemcell_manager.has_stemcell?(storage_account[:name], stemcell_id)
+                raise Bosh::Clouds::VMCreationFailed.new(false), "Given stemcell `#{stemcell_id}' does not exist"
+              end
+              stemcell_info = @stemcell_manager.get_stemcell_info(storage_account[:name], stemcell_id)
             end
           end
-        else
-          cloud_error("Virtual Machines deployed to an Availability Zone must use managed disks") unless resource_pool['availability_zone'].nil?
-          storage_account = @storage_account_manager.get_storage_account_from_resource_pool(resource_pool, location)
-          instance_id = InstanceId.create(resource_group_name, agent_id, storage_account[:name])
 
-          if is_light_stemcell_id?(stemcell_id)
-            raise Bosh::Clouds::VMCreationFailed.new(false), "Given stemcell `#{stemcell_id}' does not exist" unless @light_stemcell_manager.has_stemcell?(location, stemcell_id)
-            stemcell_info = @light_stemcell_manager.get_stemcell_info(stemcell_id)
-          else
-            unless @stemcell_manager.has_stemcell?(storage_account[:name], stemcell_id)
-              raise Bosh::Clouds::VMCreationFailed.new(false), "Given stemcell `#{stemcell_id}' does not exist"
-            end
-            stemcell_info = @stemcell_manager.get_stemcell_info(storage_account[:name], stemcell_id)
-          end
-        end
-
-        vm_params = @vm_manager.create(
-          instance_id,
-          location,
-          stemcell_info,
-          resource_pool,
-          network_configurator,
-          env
-        )
-
-        @logger.info("Created new vm `#{instance_id}'")
-
-        begin
-          registry_settings = initial_agent_settings(
-            agent_id,
-            networks,
-            env,
-            vm_params
+          vm_params = @vm_manager.create(
+            instance_id,
+            location,
+            stemcell_info,
+            resource_pool,
+            network_configurator,
+            env
           )
-          registry.update_settings(instance_id.to_s, registry_settings)
 
-          instance_id.to_s
-        rescue => e
-          @logger.error(%Q[Failed to update registry after new vm was created: #{e.inspect}\n#{e.backtrace.join("\n")}])
-          @vm_manager.delete(instance_id)
-          raise e
+          @logger.info("Created new vm `#{instance_id}'")
+
+          begin
+            registry_settings = initial_agent_settings(
+              agent_id,
+              networks,
+              env,
+              vm_params
+            )
+            registry.update_settings(instance_id.to_s, registry_settings)
+
+            instance_id.to_s
+          rescue => e
+            @logger.error(%Q[Failed to update registry after new vm was created: #{e.inspect}\n#{e.backtrace.join("\n")}])
+            @vm_manager.delete(instance_id)
+            raise e
+          end
         end
       end
     end
@@ -213,8 +226,10 @@ module Bosh::AzureCloud
     # @return [void]
     def delete_vm(instance_id)
       with_thread_name("delete_vm(#{instance_id})") do
-        @logger.info("Deleting instance `#{instance_id}'")
-        @vm_manager.delete(InstanceId.parse(instance_id, azure_properties))
+        @telemetry_manager.monitor("delete_vm", id: instance_id) do
+          @logger.info("Deleting instance `#{instance_id}'")
+          @vm_manager.delete(InstanceId.parse(instance_id, azure_properties))
+        end
       end
     end
 
@@ -225,8 +240,10 @@ module Bosh::AzureCloud
     # @return [Boolean] True if the vm exists
     def has_vm?(instance_id)
       with_thread_name("has_vm?(#{instance_id})") do
-        vm = @vm_manager.find(InstanceId.parse(instance_id, azure_properties))
-        !vm.nil? && vm[:provisioning_state] != 'Deleting'
+        @telemetry_manager.monitor("has_vm?", id: instance_id) do
+          vm = @vm_manager.find(InstanceId.parse(instance_id, azure_properties))
+          !vm.nil? && vm[:provisioning_state] != 'Deleting'
+        end
       end
     end
 
@@ -237,23 +254,25 @@ module Bosh::AzureCloud
     # @return [Boolean] True if the disk exists
     def has_disk?(disk_id)
       with_thread_name("has_disk?(#{disk_id})") do
-        disk_id = DiskId.parse(disk_id, azure_properties)
-        if disk_id.disk_name().start_with?(MANAGED_DATA_DISK_PREFIX)
-           return @disk_manager2.has_data_disk?(disk_id)
-        else
-          ##
-          # when disk name starts with DATA_DISK_PREFIX, the disk could be an unmanaged disk OR a managed disk (migrated from unmanaged disk)
-          #
-          # if @use_managed_disks is true, and
-          #   if the managed disk is found (the unmanaged disk is already migrated to managed disk for sure), return true;
-          #   if the managed disk is not found, but the unmanaged disk is already migrated to managed disk, return false;
-          #   if the managed disk is not found, and the unmanaged disk not yet migrated (bosh is updated but vm is not), check existence of the unmanaged disk.
-          # if @use_managed_disks is false, check existence of the unmanaged disk.
-          if @use_managed_disks
-            return true if @disk_manager2.has_data_disk?(disk_id)
-            return false if @disk_manager.is_migrated?(disk_id) # the managed disk is not found, and the unmanaged disk is already migrated to managed disk
+        @telemetry_manager.monitor("has_disk?", id: disk_id) do
+          disk_id = DiskId.parse(disk_id, azure_properties)
+          if disk_id.disk_name().start_with?(MANAGED_DATA_DISK_PREFIX)
+             return @disk_manager2.has_data_disk?(disk_id)
+          else
+            ##
+            # when disk name starts with DATA_DISK_PREFIX, the disk could be an unmanaged disk OR a managed disk (migrated from unmanaged disk)
+            #
+            # if @use_managed_disks is true, and
+            #   if the managed disk is found (the unmanaged disk is already migrated to managed disk for sure), return true;
+            #   if the managed disk is not found, but the unmanaged disk is already migrated to managed disk, return false;
+            #   if the managed disk is not found, and the unmanaged disk not yet migrated (bosh is updated but vm is not), check existence of the unmanaged disk.
+            # if @use_managed_disks is false, check existence of the unmanaged disk.
+            if @use_managed_disks
+              return true if @disk_manager2.has_data_disk?(disk_id)
+              return false if @disk_manager.is_migrated?(disk_id) # the managed disk is not found, and the unmanaged disk is already migrated to managed disk
+            end
+            return @disk_manager.has_data_disk?(disk_id)
           end
-          return @disk_manager.has_data_disk?(disk_id)
         end
       end
     end
@@ -266,7 +285,9 @@ module Bosh::AzureCloud
     # @return [void]
     def reboot_vm(instance_id, options = nil)
       with_thread_name("reboot_vm(#{instance_id}, #{options})") do
-        @vm_manager.reboot(InstanceId.parse(instance_id, azure_properties))
+        @telemetry_manager.monitor("reboot_vm", id: instance_id) do
+          @vm_manager.reboot(InstanceId.parse(instance_id, azure_properties))
+        end
       end
     end
 
@@ -279,8 +300,10 @@ module Bosh::AzureCloud
     # @param [Hash] metadata metadata key/value pairs
     # @return [void]
     def set_vm_metadata(instance_id, metadata)
-      @logger.info("set_vm_metadata(#{instance_id}, #{metadata})")
-      @vm_manager.set_metadata(InstanceId.parse(instance_id, azure_properties), encode_metadata(metadata))
+      @telemetry_manager.monitor("set_vm_metadata", id: instance_id) do
+        @logger.info("set_vm_metadata(#{instance_id}, #{metadata})")
+        @vm_manager.set_metadata(InstanceId.parse(instance_id, azure_properties), encode_metadata(metadata))
+      end
     end
 
     ##
@@ -290,25 +313,27 @@ module Bosh::AzureCloud
     # @param  [Hash] vm_resources requested cpu, ram, and ephemeral_disk_size
     # @return [Hash] Azure specific cloud_properties describing instance (e.g. instance_type)
     def calculate_vm_cloud_properties(vm_resources)
-      @logger.info("calculate_vm_cloud_properties(#{vm_resources})")
-      location = azure_properties['location']
-      cloud_error("Missing the property `location' in the global configuration") if location.nil?
+      @telemetry_manager.monitor("calculate_vm_cloud_properties") do
+        @logger.info("calculate_vm_cloud_properties(#{vm_resources})")
+        location = azure_properties['location']
+        cloud_error("Missing the property `location' in the global configuration") if location.nil?
 
-      required_keys = ['cpu', 'ram', 'ephemeral_disk_size']
-      missing_keys = required_keys.reject { |key| vm_resources[key] }
-      unless missing_keys.empty?
-        missing_keys.map! { |k| "`#{k}'" }
-        raise "Missing VM cloud properties: #{missing_keys.join(', ')}"
+        required_keys = ['cpu', 'ram', 'ephemeral_disk_size']
+        missing_keys = required_keys.reject { |key| vm_resources[key] }
+        unless missing_keys.empty?
+          missing_keys.map! { |k| "`#{k}'" }
+          raise "Missing VM cloud properties: #{missing_keys.join(', ')}"
+        end
+
+        available_vm_sizes = @azure_client2.list_available_virtual_machine_sizes(location)
+        instance_type = @instance_type_mapper.map(vm_resources, available_vm_sizes)
+        {
+          'instance_type' => instance_type,
+          'ephemeral_disk' => {
+            'size' => (vm_resources['ephemeral_disk_size']/1024.0).ceil * 1024
+          },
+        }
       end
-
-      available_vm_sizes = @azure_client2.list_available_virtual_machine_sizes(location)
-      instance_type = @instance_type_mapper.map(vm_resources, available_vm_sizes)
-      {
-        'instance_type' => instance_type,
-        'ephemeral_disk' => {
-          'size' => (vm_resources['ephemeral_disk_size']/1024.0).ceil * 1024
-        },
-      }
     end
 
     ##
@@ -346,45 +371,49 @@ module Bosh::AzureCloud
     # @return [String] opaque id later used by {#attach_disk}, {#detach_disk}, and {#delete_disk}
     def create_disk(size, cloud_properties, instance_id = nil)
       with_thread_name("create_disk(#{size}, #{cloud_properties})") do
-        validate_disk_size(size)
-        disk_id = nil
-        if @use_managed_disks
-          if instance_id.nil?
-            # If instance_id is nil, the managed disk will be created in the resource group location.
-            resource_group_name = azure_properties['resource_group_name']
-            resource_group = @azure_client2.get_resource_group(resource_group_name)
-            location = resource_group[:location]
-            default_storage_account_type = STORAGE_ACCOUNT_TYPE_STANDARD_LRS
-            zone = nil
+        id = instance_id.nil? ? "" : instance_id
+        extras = {"disk_size" => size}
+        @telemetry_manager.monitor("create_disk", id: id, extras: extras) do
+          validate_disk_size(size)
+          disk_id = nil
+          if @use_managed_disks
+            if instance_id.nil?
+              # If instance_id is nil, the managed disk will be created in the resource group location.
+              resource_group_name = azure_properties['resource_group_name']
+              resource_group = @azure_client2.get_resource_group(resource_group_name)
+              location = resource_group[:location]
+              default_storage_account_type = STORAGE_ACCOUNT_TYPE_STANDARD_LRS
+              zone = nil
+            else
+              instance_id = InstanceId.parse(instance_id, azure_properties)
+              cloud_error("Cannot create a managed disk for a VM with unmanaged disks") unless instance_id.use_managed_disks?()
+              resource_group_name = instance_id.resource_group_name()
+              # If the instance is a managed VM, the managed disk will be created in the location of the VM.
+              vm = @azure_client2.get_virtual_machine_by_name(resource_group_name, instance_id.vm_name())
+              location = vm[:location]
+              instance_type = vm[:vm_size]
+              zone = vm[:zone]
+              default_storage_account_type = get_storage_account_type_by_instance_type(instance_type)
+            end
+            storage_account_type = cloud_properties.fetch('storage_account_type', default_storage_account_type)
+            caching = cloud_properties.fetch('caching', 'None')
+            validate_disk_caching(caching)
+            disk_id = DiskId.create(caching, true, resource_group_name: resource_group_name)
+            @disk_manager2.create_disk(disk_id, location, size/1024, storage_account_type, zone)
           else
-            instance_id = InstanceId.parse(instance_id, azure_properties)
-            cloud_error("Cannot create a managed disk for a VM with unmanaged disks") unless instance_id.use_managed_disks?()
-            resource_group_name = instance_id.resource_group_name()
-            # If the instance is a managed VM, the managed disk will be created in the location of the VM.
-            vm = @azure_client2.get_virtual_machine_by_name(resource_group_name, instance_id.vm_name())
-            location = vm[:location]
-            instance_type = vm[:vm_size]
-            zone = vm[:zone]
-            default_storage_account_type = get_storage_account_type_by_instance_type(instance_type)
+            storage_account_name = azure_properties['storage_account_name']
+            caching = cloud_properties.fetch('caching', 'None')
+            validate_disk_caching(caching)
+            unless instance_id.nil?
+              instance_id = InstanceId.parse(instance_id, azure_properties)
+              @logger.info("Create disk for vm `#{instance_id.vm_name()}'")
+              storage_account_name = instance_id.storage_account_name()
+            end
+            disk_id = DiskId.create(caching, false, storage_account_name: storage_account_name)
+            @disk_manager.create_disk(disk_id, size/1024)
           end
-          storage_account_type = cloud_properties.fetch('storage_account_type', default_storage_account_type)
-          caching = cloud_properties.fetch('caching', 'None')
-          validate_disk_caching(caching)
-          disk_id = DiskId.create(caching, true, resource_group_name: resource_group_name)
-          @disk_manager2.create_disk(disk_id, location, size/1024, storage_account_type, zone)
-        else
-          storage_account_name = azure_properties['storage_account_name']
-          caching = cloud_properties.fetch('caching', 'None')
-          validate_disk_caching(caching)
-          unless instance_id.nil?
-            instance_id = InstanceId.parse(instance_id, azure_properties)
-            @logger.info("Create disk for vm `#{instance_id.vm_name()}'")
-            storage_account_name = instance_id.storage_account_name()
-          end
-          disk_id = DiskId.create(caching, false, storage_account_name: storage_account_name)
-          @disk_manager.create_disk(disk_id, size/1024)
+          disk_id.to_s
         end
-        disk_id.to_s
       end
     end
 
@@ -396,17 +425,19 @@ module Bosh::AzureCloud
     # @return [void]
     def delete_disk(disk_id)
       with_thread_name("delete_disk(#{disk_id})") do
-        disk_id = DiskId.parse(disk_id, azure_properties)
-        if @use_managed_disks
-          # A managed disk may be created from an old blob disk, so its name still starts with 'bosh-data' instead of 'bosh-disk-data'
-          # CPI checks whether the managed disk with the name exists. If not, delete the old blob disk.
-          unless disk_id.disk_name().start_with?(MANAGED_DATA_DISK_PREFIX)
-            disk = @disk_manager2.get_data_disk(disk_id)
-            return @disk_manager.delete_data_disk(disk_id) if disk.nil?
+        @telemetry_manager.monitor("delete_disk", id: disk_id) do
+          disk_id = DiskId.parse(disk_id, azure_properties)
+          if @use_managed_disks
+            # A managed disk may be created from an old blob disk, so its name still starts with 'bosh-data' instead of 'bosh-disk-data'
+            # CPI checks whether the managed disk with the name exists. If not, delete the old blob disk.
+            unless disk_id.disk_name().start_with?(MANAGED_DATA_DISK_PREFIX)
+              disk = @disk_manager2.get_data_disk(disk_id)
+              return @disk_manager.delete_data_disk(disk_id) if disk.nil?
+            end
+            @disk_manager2.delete_data_disk(disk_id)
+          else
+            @disk_manager.delete_data_disk(disk_id)
           end
-          @disk_manager2.delete_data_disk(disk_id)
-        else
-          @disk_manager.delete_data_disk(disk_id)
         end
       end
     end
@@ -417,86 +448,88 @@ module Bosh::AzureCloud
     # @return [void]
     def attach_disk(instance_id, disk_id)
       with_thread_name("attach_disk(#{instance_id},#{disk_id})") do
-        instance_id = InstanceId.parse(instance_id, azure_properties)
-        disk_id = DiskId.parse(disk_id, azure_properties)
-        vm_name = instance_id.vm_name()
-        disk_name = disk_id.disk_name()
+        @telemetry_manager.monitor("attach_disk", id: instance_id) do
+          instance_id = InstanceId.parse(instance_id, azure_properties)
+          disk_id = DiskId.parse(disk_id, azure_properties)
+          vm_name = instance_id.vm_name()
+          disk_name = disk_id.disk_name()
 
-        vm = @vm_manager.find(instance_id)
+          vm = @vm_manager.find(instance_id)
 
-        # Workaround for issue #280
-        # Issue root cause: Attaching a data disk to a VM whose OS disk is busy might lead to OS hang.
-        #                   If `use_root_disk` is true in `resource_pools`, release packages will be copied to OS disk before attaching data disk,
-        #                   it will continuously write the data to OS disk, that is why OS disk is busy.
-        # Workaround: Sleep 30 seconds before attaching data disk, to wait for completion of data writing.
-        has_ephemeral_disk = false
-        vm[:data_disks].each do |disk|
-          has_ephemeral_disk = true if is_ephemeral_disk?(disk[:name])
-        end
-        unless has_ephemeral_disk
-          @logger.debug("Sleep 30 seconds before attaching data disk - workaround for issue #280")
-          sleep(30)
-        end
+          # Workaround for issue #280
+          # Issue root cause: Attaching a data disk to a VM whose OS disk is busy might lead to OS hang.
+          #                   If `use_root_disk` is true in `resource_pools`, release packages will be copied to OS disk before attaching data disk,
+          #                   it will continuously write the data to OS disk, that is why OS disk is busy.
+          # Workaround: Sleep 30 seconds before attaching data disk, to wait for completion of data writing.
+          has_ephemeral_disk = false
+          vm[:data_disks].each do |disk|
+            has_ephemeral_disk = true if is_ephemeral_disk?(disk[:name])
+          end
+          unless has_ephemeral_disk
+            @logger.debug("Sleep 30 seconds before attaching data disk - workaround for issue #280")
+            sleep(30)
+          end
 
-        if @use_managed_disks
-          disk = @disk_manager2.get_data_disk(disk_id)
-          vm_zone = vm[:zone]
-          unless instance_id.use_managed_disks?()
-            cloud_error("Cannot attach a managed disk to a VM with unmanaged disks") unless disk.nil?
-            @logger.debug("attach_disk - although use_managed_disks is enabled, will still attach the unmanaged disk `#{disk_name}' to the VM `#{vm_name}' with unmanaged disks")
-          else
-            if disk.nil?
-              # migrate only if the disk is an unmanaged disk
-              if disk_id.disk_name().start_with?(DATA_DISK_PREFIX)
-                begin
-                  storage_account_name = disk_id.storage_account_name()
-                  blob_uri = @disk_manager.get_data_disk_uri(disk_id)
-                  storage_account = @azure_client2.get_storage_account_by_name(storage_account_name)
-                  location = storage_account[:location]
-                  # Can not use the type of the default storage account because only Standard_LRS and Premium_LRS are supported for managed disk.
-                  account_type = (storage_account[:account_type] == STORAGE_ACCOUNT_TYPE_PREMIUM_LRS) ? STORAGE_ACCOUNT_TYPE_PREMIUM_LRS : STORAGE_ACCOUNT_TYPE_STANDARD_LRS
-                  @logger.debug("attach_disk - Migrating the unmanaged disk `#{disk_name}' to a managed disk")
-                  @disk_manager2.create_disk_from_blob(disk_id, blob_uri, location, account_type, vm_zone)
+          if @use_managed_disks
+            disk = @disk_manager2.get_data_disk(disk_id)
+            vm_zone = vm[:zone]
+            unless instance_id.use_managed_disks?()
+              cloud_error("Cannot attach a managed disk to a VM with unmanaged disks") unless disk.nil?
+              @logger.debug("attach_disk - although use_managed_disks is enabled, will still attach the unmanaged disk `#{disk_name}' to the VM `#{vm_name}' with unmanaged disks")
+            else
+              if disk.nil?
+                # migrate only if the disk is an unmanaged disk
+                if disk_id.disk_name().start_with?(DATA_DISK_PREFIX)
+                  begin
+                    storage_account_name = disk_id.storage_account_name()
+                    blob_uri = @disk_manager.get_data_disk_uri(disk_id)
+                    storage_account = @azure_client2.get_storage_account_by_name(storage_account_name)
+                    location = storage_account[:location]
+                    # Can not use the type of the default storage account because only Standard_LRS and Premium_LRS are supported for managed disk.
+                    account_type = (storage_account[:account_type] == STORAGE_ACCOUNT_TYPE_PREMIUM_LRS) ? STORAGE_ACCOUNT_TYPE_PREMIUM_LRS : STORAGE_ACCOUNT_TYPE_STANDARD_LRS
+                    @logger.debug("attach_disk - Migrating the unmanaged disk `#{disk_name}' to a managed disk")
+                    @disk_manager2.create_disk_from_blob(disk_id, blob_uri, location, account_type, vm_zone)
 
-                  # Set below metadata but not delete it.
-                  # Users can manually delete all blobs in container `bosh` whose names start with `bosh-data` after migration is finished.
-                  @blob_manager.set_blob_metadata(storage_account_name, DISK_CONTAINER, "#{disk_name}.vhd", METADATA_FOR_MIGRATED_BLOB_DISK)
-                rescue => e
-                  if account_type # There are no other functions between defining account_type and @disk_manager2.create_disk_from_blob
-                    begin
-                      @disk_manager2.delete_data_disk(disk_id)
-                    rescue => err
-                      @logger.error("attach_disk - Failed to delete the created managed disk #{disk_name}. Error: #{e.inspect}\n#{e.backtrace.join("\n")}")
+                    # Set below metadata but not delete it.
+                    # Users can manually delete all blobs in container `bosh` whose names start with `bosh-data` after migration is finished.
+                    @blob_manager.set_blob_metadata(storage_account_name, DISK_CONTAINER, "#{disk_name}.vhd", METADATA_FOR_MIGRATED_BLOB_DISK)
+                  rescue => e
+                    if account_type # There are no other functions between defining account_type and @disk_manager2.create_disk_from_blob
+                      begin
+                        @disk_manager2.delete_data_disk(disk_id)
+                      rescue => err
+                        @logger.error("attach_disk - Failed to delete the created managed disk #{disk_name}. Error: #{e.inspect}\n#{e.backtrace.join("\n")}")
+                      end
                     end
+                    cloud_error("attach_disk - Failed to create the managed disk for #{disk_name}. Error: #{e.inspect}\n#{e.backtrace.join("\n")}")
                   end
-                  cloud_error("attach_disk - Failed to create the managed disk for #{disk_name}. Error: #{e.inspect}\n#{e.backtrace.join("\n")}")
                 end
-              end
-            elsif disk[:zone].nil? && !vm_zone.nil? #Only for migration scenario: VM is recreated in a zone while its data disk is still a regional resource.
-              begin
-                @disk_manager2.migrate_to_zone(disk_id, disk, vm_zone)
-              rescue => e
-                cloud_error("attach_disk - Failed to migrate disk #{disk_name} to zone #{vm_zone}. Error: #{e.inspect}\n#{e.backtrace.join("\n")}")
+              elsif disk[:zone].nil? && !vm_zone.nil? #Only for migration scenario: VM is recreated in a zone while its data disk is still a regional resource.
+                begin
+                  @disk_manager2.migrate_to_zone(disk_id, disk, vm_zone)
+                rescue => e
+                  cloud_error("attach_disk - Failed to migrate disk #{disk_name} to zone #{vm_zone}. Error: #{e.inspect}\n#{e.backtrace.join("\n")}")
+                end
               end
             end
           end
+
+          lun = @vm_manager.attach_disk(instance_id, disk_id)
+
+          update_agent_settings(instance_id.to_s) do |settings|
+            settings["disks"] ||= {}
+            settings["disks"]["persistent"] ||= {}
+            settings["disks"]["persistent"][disk_id.to_s] = {
+              'lun'            => lun,
+              'host_device_id' => AZURE_SCSI_HOST_DEVICE_ID,
+
+              # For compatiblity with old stemcells
+              'path'           => get_disk_path_name(lun.to_i)
+            }
+          end
+
+          @logger.info("Attached the disk `#{disk_id}' to the instance `#{instance_id}', lun `#{lun}'")
         end
-
-        lun = @vm_manager.attach_disk(instance_id, disk_id)
-
-        update_agent_settings(instance_id.to_s) do |settings|
-          settings["disks"] ||= {}
-          settings["disks"]["persistent"] ||= {}
-          settings["disks"]["persistent"][disk_id.to_s] = {
-            'lun'            => lun,
-            'host_device_id' => AZURE_SCSI_HOST_DEVICE_ID,
-
-            # For compatiblity with old stemcells
-            'path'           => get_disk_path_name(lun.to_i)
-          }
-        end
-
-        @logger.info("Attached the disk `#{disk_id}' to the instance `#{instance_id}', lun `#{lun}'")
       end
     end
 
@@ -506,19 +539,20 @@ module Bosh::AzureCloud
     # @return [void]
     def detach_disk(instance_id, disk_id)
       with_thread_name("detach_disk(#{instance_id},#{disk_id})") do
+        @telemetry_manager.monitor("detach_disk", id: instance_id) do
+          update_agent_settings(instance_id) do |settings|
+            settings["disks"] ||= {}
+            settings["disks"]["persistent"] ||= {}
+            settings["disks"]["persistent"].delete(disk_id)
+          end
 
-        update_agent_settings(instance_id) do |settings|
-          settings["disks"] ||= {}
-          settings["disks"]["persistent"] ||= {}
-          settings["disks"]["persistent"].delete(disk_id)
+          @vm_manager.detach_disk(
+            InstanceId.parse(instance_id, azure_properties),
+            DiskId.parse(disk_id, azure_properties)
+          )
+
+          @logger.info("Detached `#{disk_id}' from `#{instance_id}'")
         end
-
-        @vm_manager.detach_disk(
-          InstanceId.parse(instance_id, azure_properties),
-          DiskId.parse(disk_id, azure_properties)
-        )
-
-        @logger.info("Detached `#{disk_id}' from `#{instance_id}'")
       end
     end
 
@@ -528,13 +562,15 @@ module Bosh::AzureCloud
     # other disk-related methods on the CPI
     def get_disks(instance_id)
       with_thread_name("get_disks(#{instance_id})") do
-        disks = []
-        vm = @vm_manager.find(InstanceId.parse(instance_id, azure_properties))
-        raise Bosh::Clouds::VMNotFound, "VM `#{instance_id}' cannot be found" if vm.nil?
-        vm[:data_disks].each do |disk|
-          disks << disk[:disk_bosh_id] unless is_ephemeral_disk?(disk[:name])
+        @telemetry_manager.monitor("get_disks", id: instance_id) do
+          disks = []
+          vm = @vm_manager.find(InstanceId.parse(instance_id, azure_properties))
+          raise Bosh::Clouds::VMNotFound, "VM `#{instance_id}' cannot be found" if vm.nil?
+          vm[:data_disks].each do |disk|
+            disks << disk[:disk_bosh_id] unless is_ephemeral_disk?(disk[:name])
+          end
+          disks
         end
-        disks
       end
     end
 
@@ -544,27 +580,29 @@ module Bosh::AzureCloud
     # @return [String] snapshot id
     def snapshot_disk(disk_id, metadata = {})
       with_thread_name("snapshot_disk(#{disk_id},#{metadata})") do
-        disk_id = DiskId.parse(disk_id, azure_properties)
-        resource_group_name = disk_id.resource_group_name()
-        disk_name = disk_id.disk_name()
-        caching = disk_id.caching()
-        if disk_name.start_with?(MANAGED_DATA_DISK_PREFIX)
-          snapshot_id = DiskId.create(caching, true, resource_group_name: resource_group_name)
-          @disk_manager2.snapshot_disk(snapshot_id, disk_name, encode_metadata(metadata))
-        else
-          disk = @disk_manager2.get_data_disk(disk_id)
-          unless disk.nil?
+        @telemetry_manager.monitor("snapshot_disk", id: disk_id) do
+          disk_id = DiskId.parse(disk_id, azure_properties)
+          resource_group_name = disk_id.resource_group_name()
+          disk_name = disk_id.disk_name()
+          caching = disk_id.caching()
+          if disk_name.start_with?(MANAGED_DATA_DISK_PREFIX)
             snapshot_id = DiskId.create(caching, true, resource_group_name: resource_group_name)
             @disk_manager2.snapshot_disk(snapshot_id, disk_name, encode_metadata(metadata))
           else
-            storage_account_name = disk_id.storage_account_name()
-            snapshot_name = @disk_manager.snapshot_disk(storage_account_name, disk_name, encode_metadata(metadata))
-            snapshot_id = DiskId.create(caching, false, disk_name: snapshot_name, storage_account_name: storage_account_name)
+            disk = @disk_manager2.get_data_disk(disk_id)
+            unless disk.nil?
+              snapshot_id = DiskId.create(caching, true, resource_group_name: resource_group_name)
+              @disk_manager2.snapshot_disk(snapshot_id, disk_name, encode_metadata(metadata))
+            else
+              storage_account_name = disk_id.storage_account_name()
+              snapshot_name = @disk_manager.snapshot_disk(storage_account_name, disk_name, encode_metadata(metadata))
+              snapshot_id = DiskId.create(caching, false, disk_name: snapshot_name, storage_account_name: storage_account_name)
+            end
           end
-        end
 
-        @logger.info("Take a snapshot `#{snapshot_id}' for the disk `#{disk_id}'")
-        snapshot_id.to_s
+          @logger.info("Take a snapshot `#{snapshot_id}' for the disk `#{disk_id}'")
+          snapshot_id.to_s
+        end
       end
     end
 
@@ -573,14 +611,16 @@ module Bosh::AzureCloud
     # @return [void]
     def delete_snapshot(snapshot_id)
       with_thread_name("delete_snapshot(#{snapshot_id})") do
-        snapshot_id = DiskId.parse(snapshot_id, azure_properties)
-        snapshot_name = snapshot_id.disk_name()
-        if snapshot_name.start_with?(MANAGED_DATA_DISK_PREFIX)
-          @disk_manager2.delete_snapshot(snapshot_id)
-        else
-          @disk_manager.delete_snapshot(snapshot_id)
+        @telemetry_manager.monitor("delete_snapshot", id: snapshot_id) do
+          snapshot_id = DiskId.parse(snapshot_id, azure_properties)
+          snapshot_name = snapshot_id.disk_name()
+          if snapshot_name.start_with?(MANAGED_DATA_DISK_PREFIX)
+            @disk_manager2.delete_snapshot(snapshot_id)
+          else
+            @disk_manager.delete_snapshot(snapshot_id)
+          end
+          @logger.info("The snapshot `#{snapshot_id}' is deleted")
         end
-        @logger.info("The snapshot `#{snapshot_id}' is deleted")
       end
     end
 
@@ -601,9 +641,11 @@ module Bosh::AzureCloud
    # Information about the CPI
    # @return [Hash] CPI properties
    def info
-     {
-       'stemcell_formats' => %w(azure-vhd azure-light)
-     }
+     @telemetry_manager.monitor("info") do
+       {
+         'stemcell_formats' => %w(azure-vhd azure-light)
+       }
+     end
    end
 
     private

--- a/src/bosh_azure_cpi/lib/cloud/azure/helpers.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/helpers.rb
@@ -128,6 +128,7 @@ module Bosh::AzureCloud
     CPI_LOCK_CREATE_USER_IMAGE           = "#{CPI_LOCK_PREFIX}-create-user-image"
     CPI_LOCK_PREFIX_AVAILABILITY_SET     = "#{CPI_LOCK_PREFIX}-availability-set"
     CPI_LOCK_DELETE                      = "#{CPI_LOCK_DIR}/DELETING-LOCKS"
+    CPI_LOCK_EVENT_HANDLER               = "#{CPI_LOCK_PREFIX}-event-handler"
     class LockError < Bosh::Clouds::CloudError; end
     class LockTimeoutError < LockError; end
     class LockNotFoundError < LockError; end
@@ -151,6 +152,9 @@ module Bosh::AzureCloud
     SERVICE_PRINCIPAL_CERTIFICATE_RELATIVE_PATH = 'azure_cpi/config/service_principal_certificate.pem'
 
     AVAILABILITY_ZONES = ['1', '2', '3']
+
+    CPI_EVENTS_DIR                        = "/tmp/azure_cpi_events"
+    CPI_EVENT_HANDLER_LAST_POST_TIMESTAMP = "/tmp/azure_cpi_events_last_update"
 
     ##
     # Raises CloudError exception

--- a/src/bosh_azure_cpi/lib/cloud/azure/telemetry/telemetry_event.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/telemetry/telemetry_event.rb
@@ -1,0 +1,166 @@
+module Bosh::AzureCloud
+  class TelemetryEventParam
+    attr_writer :value
+
+    PARAM_XML_FORMAT = "<Param Name=\"%{name}\" Value=%{value} T=\"%{type}\" />"
+
+    def initialize(name, value)
+      @name = name
+      @value = value
+    end
+
+    def self.parse_hash(hash)
+      new(hash["name"], hash["value"])
+    end
+
+    def to_hash
+      {"name" => @name, "value" => @value}
+    end
+
+    def to_json
+      to_hash.to_json
+    end
+
+    def to_xml
+      value = @value.is_a?(Hash) ? @value.to_json : @value
+      PARAM_XML_FORMAT % {:name => @name, :value => value.to_s.encode(:xml => :attr), :type => type_of(@value)}
+    end
+
+    private
+
+    def type_of(value)
+      case value
+      when String
+        "mt:wstr"
+      when Integer
+        "mt:uint64"
+      when Float
+        "mt:float64"
+      when TrueClass
+        "mt:bool"
+      when FalseClass
+        "mt:bool"
+      when Hash
+        "mt:wstr"
+      else
+        "mt:wstr"
+      end
+    end
+  end
+
+  # example:
+  # @event = {
+  #   "eventId" => 1,
+  #   "providerId" => "69B669B9-4AF8-4C50-BDC4-6006FA76E975",
+  #   "parameters" => [
+  #     {
+  #       "name" => "Name",
+  #       "value" => "BOSH-CPI"
+  #     },
+  #     {
+  #       "name" => "Version",
+  #       "value" => ""
+  #     }
+  #   ]
+  # }
+  #
+  # allowed parameters:
+  #   "Name": "BOSH-CPI"
+  #   "Version": string. CPI version.
+  #   "Operation": string. CPI callback, e.g. create_vm, create_disk, attach_disk, etc
+  #   "OperationSuccess": true / false. Operation status.
+  #   "ContainerId": string
+  #   "Duration": float. How long the operation takes.
+  #   "Message": A JSON string contains info of
+  #      "msg": "Successed" or error message
+  #      "subscription_id": subscription id
+  #      "vm_size": vm size. (optional)
+  #      "disk_size": disk size. (optional)
+  #
+  class TelemetryEvent
+    attr_reader :event_id, :provider_id, :parameters
+
+    EVENT_XML_FORMAT = "<Provider id=\"%{provider_id}\"><Event id=\"%{event_id}\"><![CDATA[%{params_xml}]]></Event></Provider>"
+    EVENT_XML_WITHOUT_PROVIDER_FORMAT =  "<Event id=\"%{event_id}\"><![CDATA[%{params_xml}]]></Event>"
+
+    def initialize(event_id, provider_id, parameters: [])
+      @event_id = event_id
+      @provider_id = provider_id
+      @parameters = parameters
+    end
+
+    def self.parse_hash(hash)
+      parameters = []
+      hash["parameters"].each do |p|
+        parameters.push(TelemetryEventParam.parse_hash(p))
+      end
+      new(hash["eventId"], hash["providerId"], parameters: parameters)
+    end
+
+    def add_param(parameter)
+      @parameters.push(parameter) if parameter.is_a?(TelemetryEventParam)
+    end
+
+    def to_hash
+      parameters = []
+      @parameters.each do |p|
+        parameters.push(p.to_hash)
+      end
+
+      {
+        "eventId" => @event_id,
+        "providerId" => @provider_id,
+        "parameters" => parameters
+      }
+    end
+
+    def to_json
+      to_hash.to_json
+    end
+
+    # this function is only used in TelemetryEventList which will group the events by provider_id
+    def to_xml_without_provider
+      params_xml = ""
+      @parameters.each do |param|
+        params_xml += param.to_xml
+      end
+      EVENT_XML_WITHOUT_PROVIDER_FORMAT % {:event_id => @event_id, :params_xml => params_xml}
+    end
+  end
+
+  class TelemetryEventList
+    TELEMETRY_XML_FORMAT = "<?xml version=\"1.0\"?><TelemetryData version=\"1.0\">%{events_string}</TelemetryData>"
+    EVENTS_WITH_PROVIDER_FORMAT = "<Provider id=\"%{provider_id}\">%{event_xml_without_provider}</Provider>"
+
+    def initialize(event_list)
+      @event_list = event_list
+    end
+
+    # example:
+    # <?xml version="1.0"?><TelemetryData version="1.0"><Provider id="69B669B9-4AF8-4C50-BDC4-6006FA76E975"><Event id="1"><![CDATA[<Param Name="Name" Value="BOSH-CPI" T="mt:wstr" /><Param Name="Version" Value="" T="mt:wstr" /><Param Name="Operation" Value="create_vm" T="mt:wstr" /><Param Name="OperationSuccess" Value="True" T="mt:bool" /><Param Name="Message" Value='{"msg":"Successed"}' T="mt:wstr" /><Param Name="Duration" Value="510.046195" T="mt:float64" /><Param Name="OSVersion" Value="Linux:ubuntu-14.04-trusty:4.4.0-53-generic" T="mt:wstr" /><Param Name="GAVersion" Value="WALinuxAgent-2.1.3" T="mt:wstr" /><Param Name="RAM" Value="6958" T="mt:uint64" /><Param Name="Processors" Value="2" T="mt:uint64" /><Param Name="VMName" Value="_b9c3354c-3275-4049-680f-3748ad0af496" T="mt:wstr" /><Param Name="TenantName" Value="8c1b2d76-a666-4958-a7ec-6ef464422ad1" T="mt:wstr" /><Param Name="RoleName" Value="_b9c3354c-3275-4049-680f-3748ad0af496" T="mt:wstr" /><Param Name="RoleInstanceName" Value="8c1b2d76-a666-4958-a7ec-6ef464422ad1._b9c3354c-3275-4049-680f-3748ad0af496" T="mt:wstr" /><Param Name="ContainerId" Value="edf9b1e3-90dd-4da5-9c23-6c9a2f419ddc" T="mt:wstr" />]]></Event></Provider></TelemetryData>
+    def format_data_for_wire_server
+      TELEMETRY_XML_FORMAT % {:events_string => to_xml}
+    end
+
+    private
+
+    def to_xml
+      # group the events by provider id
+      events_grouped_by_provider = {}
+      @event_list.each do |event|
+        events_grouped_by_provider[event.provider_id] = [] unless events_grouped_by_provider.has_key?(event.provider_id)
+        events_grouped_by_provider[event.provider_id] << event
+      end
+
+      xml_string_grouped_by_providers = ""
+      events_grouped_by_provider.keys.each do |provider_id|
+        xml_string = ""
+        events_grouped_by_provider[provider_id].each do |event|
+          xml_string += event.to_xml_without_provider
+        end
+        xml_string_grouped_by_providers += (EVENTS_WITH_PROVIDER_FORMAT % {:provider_id => provider_id, :event_xml_without_provider => xml_string})
+      end
+      xml_string_grouped_by_providers
+    end
+  end
+end

--- a/src/bosh_azure_cpi/lib/cloud/azure/telemetry/telemetry_event_handler.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/telemetry/telemetry_event_handler.rb
@@ -1,0 +1,102 @@
+module Bosh::AzureCloud
+  class TelemetryEventHandler
+    include Helpers
+
+    COOLDOWN = 60 # seconds
+
+    def initialize(logger, events_dir = CPI_EVENTS_DIR)
+      @logger = logger
+      @events_dir = events_dir
+      @wire_client = Bosh::AzureCloud::WireClient.new(logger)
+    end
+
+    # Collect events and send them to wireserver
+    # Only one instance is allow to process the events at the same time.
+    # Once this function get the lock, the instance will be responsible to handle all
+    # existed event logs generated prior to and during the time when it handles the events;
+    # Other instances won't get the lock and quit silently, their events will be handled
+    # by the instance who got the lock.
+    #
+    def collect_and_send_events
+      mutex = FileMutex.new(CPI_LOCK_EVENT_HANDLER, @logger)
+      if mutex.lock
+        begin
+          while has_event?() do
+            last_post_timestamp = get_last_post_timestamp()
+            unless last_post_timestamp.nil?
+              duration = Time.now().round - last_post_timestamp
+              # will only send events once per minute
+              if duration >= 0 && duration < COOLDOWN
+                sleep(COOLDOWN - duration)
+              end
+            end
+
+            # sent_events
+            event_list = collect_events()
+            send_events(event_list)
+            update_last_post_timestamp(Time.now.round)
+          end
+        rescue => e
+          @logger.warn("[Telemetry] Failed to collect and send events. Error:\n#{e.inspect}\n#{e.backtrace.join("\n")}")
+        ensure
+          mutex.unlock
+        end
+      end
+    end
+
+    private
+
+    # Check if there are events to be sent
+    def has_event?()
+      event_files = Dir["#{@events_dir}/*.tld"]
+      !event_files.empty?()
+    end
+
+    # Collect telemetry events
+    #
+    # @params [Integer]  max - max event number to collect
+    # @return [TelemetryEventList]
+    #
+    def collect_events(max = 4)
+      event_list = []
+      event_files = Dir["#{@events_dir}/*.tld"]
+      event_files = event_files[0...max] if event_files.length > max
+      event_files.each do |file|
+        begin
+          hash = JSON.parse(File.read(file))
+          event_list << Bosh::AzureCloud::TelemetryEvent.parse_hash(hash)
+        rescue => e
+          @logger.warn("[Telemetry] Failed to collect event from `#{file}'. Error:\n#{e.inspect}\n#{e.backtrace.join("\n")}")
+          raise e
+        ensure
+          File.delete(file)
+        end
+      end
+      Bosh::AzureCloud::TelemetryEventList.new(event_list)
+    end
+
+    # Send the events to wireserver
+    #
+    # @params [TelemetryEventList] event_list - events to be sent
+    #
+    def send_events(event_list)
+      @wire_client.post_data(event_list.format_data_for_wire_server)
+    end
+
+    # Get the time when the last post happened
+    # Return Time or nil
+    #
+    def get_last_post_timestamp()
+      ignore_exception do
+        Time.parse(File.read(CPI_EVENT_HANDLER_LAST_POST_TIMESTAMP))
+      end
+    end
+
+    # Record the time of last post in a file
+    def update_last_post_timestamp(time)
+      File.open(CPI_EVENT_HANDLER_LAST_POST_TIMESTAMP, 'w') do |file|
+        file.write(time.to_s)
+      end
+    end
+  end
+end

--- a/src/bosh_azure_cpi/lib/cloud/azure/telemetry/telemetry_manager.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/telemetry/telemetry_manager.rb
@@ -1,0 +1,97 @@
+module Bosh::AzureCloud
+  class TelemetryManager
+    include Helpers
+
+    EVENT_ID = "1"
+    PROVIDER_ID = "69B669B9-4AF8-4C50-BDC4-6006FA76E975"
+    CPI_TELEMETRY_NAME = "BOSH-CPI"
+
+    def initialize(azure_properties, logger)
+      @azure_properties = azure_properties
+      @logger = logger
+    end
+
+    # Monitor the status of a block
+    # @param [String] operation - Operation name
+    # @param [String] id        - ID. This value can be instance_id, disk_id, and so on. Using the id to avoid the events being aggregated by Kusto.
+    # @param [Hash] extras      - Extra values passed by individual function. The values will be merged to 'message' column of the event.
+    #                             Example:  {"instance_type" => "Standard_D1"}
+    # @return - return value of the block
+    #
+    def monitor(operation, id: "", extras:  {})
+      if @azure_properties.fetch('enable_telemetry', false) == true && @azure_properties['environment'] != ENVIRONMENT_AZURESTACK
+        error_raised = false
+
+        event_param_name              = Bosh::AzureCloud::TelemetryEventParam.new("Name", CPI_TELEMETRY_NAME)
+        event_param_version           = Bosh::AzureCloud::TelemetryEventParam.new("Version", Bosh::AzureCloud::VERSION)
+        event_param_operation         = Bosh::AzureCloud::TelemetryEventParam.new("Operation", operation)
+        event_param_container_id      = Bosh::AzureCloud::TelemetryEventParam.new("ContainerId", id)
+        event_param_operation_success = Bosh::AzureCloud::TelemetryEventParam.new("OperationSuccess", true)
+        event_param_message           = Bosh::AzureCloud::TelemetryEventParam.new("Message", "")
+        event_param_duration          = Bosh::AzureCloud::TelemetryEventParam.new("Duration", 0)
+
+        message_value = {
+          "msg" => "Successed",
+          "subscription_id" => @azure_properties['subscription_id']
+        }
+        message_value.merge!(extras)
+
+        start_at = Time.now
+        begin
+          yield
+        rescue => e
+          error_raised = true
+
+          event_param_operation_success.value = false
+          msg = "#{e.inspect}\n#{e.backtrace.join("\n")}"
+          msg = msg[0...3990] + '...' if msg.length > 3993 # limit the message to less than 3.9 kB
+          message_value["msg"] = msg
+          raise e
+        ensure
+          end_at = Time.now
+          event_param_duration.value = (end_at - start_at) * 1000.0 # miliseconds
+          event_param_message.value = message_value
+
+          # No need to report event for "initialize" if it is initialized without an error
+          unless operation == "initialize" && !error_raised
+            event = Bosh::AzureCloud::TelemetryEvent.new(EVENT_ID, PROVIDER_ID)
+            event.add_param(event_param_name)
+            event.add_param(event_param_version)
+            event.add_param(event_param_operation)
+            event.add_param(event_param_container_id)
+            event.add_param(event_param_operation_success)
+            event.add_param(event_param_message)
+            event.add_param(event_param_duration)
+            report_event(event)
+          end
+        end
+      else
+        yield
+      end
+    end
+
+    private
+
+    def report_event(event)
+      begin
+        filename = "/tmp/cpi-event-#{SecureRandom.uuid}.tld"
+        File.open(filename, 'w') do |file|
+          file.write(event.to_json)
+        end
+        Dir.mkdir(CPI_EVENTS_DIR) unless File.exists?(CPI_EVENTS_DIR)
+        stdout, stderr, status = Open3.capture3("mv #{filename} #{CPI_EVENTS_DIR}")
+        if status != 0
+          @logger.warn("[Telemetry] Failed to move `#{filename}' to `#{CPI_EVENTS_DIR}', error: #{stderr}")
+        else
+          # trigger event handler to send the event in a different process
+          pid = fork {
+            Bosh::AzureCloud::TelemetryEventHandler.new(@logger).collect_and_send_events()
+          }
+          Process.detach(pid)
+        end
+      rescue => e
+        @logger.warn("[Telemetry] Failed to report event. Error:\n#{e.inspect}\n#{e.backtrace.join("\n")}")
+      end
+    end
+  end
+end

--- a/src/bosh_azure_cpi/lib/cloud/azure/telemetry/wire_client.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/telemetry/wire_client.rb
@@ -1,0 +1,139 @@
+module Bosh::AzureCloud
+  class RetriableError < Exception; end
+
+  class WireClient
+    TELEMETRY_URI_FORMAT = "http://%{endpoint}/machine?comp=telemetrydata"
+    TELEMETRY_HEADER     = {'Content-Type' => 'text/xml;charset=utf-8', 'x-ms-version' => '2012-11-30'}
+
+    RETRY_ERROR_CODES    = [408, 429, 500, 502, 503, 504]
+    SLEEP_BEFORE_RETRY   = 5
+
+    HEADER_LEASE         = "lease {"
+    HEADER_OPTION        = "option unknown-245"
+    HEADER_DNS           = "option domain-name-servers"
+    HEADER_EXPIRE        = "expire"
+    FOOTER_LEASE         = "}"
+
+    LEASE_PATHS = {
+      'Ubuntu' => '/var/lib/dhcp/dhclient.*.leases',
+      'CentOS' => '/var/lib/dhclient/dhclient-*.leases',
+    }
+
+    def initialize(logger)
+      @logger = logger
+    end
+
+    # Post data to wireserver
+    #
+    # @param [String] event_data - Data formatted as XML string
+    #
+    def post_data(event_data)
+      endpoint = get_endpoint()
+
+      unless endpoint.nil?
+        uri = URI.parse(TELEMETRY_URI_FORMAT % {:endpoint => endpoint})
+        retried = false
+        begin
+          request = Net::HTTP::Post.new(uri)
+          request.body = event_data
+          TELEMETRY_HEADER.keys.each do |key|
+            request[key] = TELEMETRY_HEADER[key]
+          end
+          res = Net::HTTP.new(uri.host, uri.port, nil).start { |http| http.request request }
+
+          status_code = res.code.to_i
+          if status_code == 200
+            @logger.debug("[Telemetry] Data posted")
+          elsif RETRY_ERROR_CODES.include?(status_code)
+            raise RetriableError, "POST response - code: #{res.code}\nbody:#{res.body}"
+          else
+            raise "Failed to POST request. Response - code: #{res.code}\nbody:#{res.body}"
+          end
+        rescue RetriableError, Net::OpenTimeout, Net::ReadTimeout, Errno::ECONNRESET => e
+          if !retried
+            retried = true
+            sleep(SLEEP_BEFORE_RETRY)
+            @logger.debug("[Telemetry] Failed to post data, retrying...")
+            retry
+          else
+            @logger.warn("[Telemetry] Failed to post data to uri `#{uri}'. Error: \n#{e.inspect}\n#{e.backtrace.join("\n")}")
+          end
+        rescue => e
+          @logger.warn("[Telemetry] Failed to post data to uri `#{uri}'. Error: \n#{e.inspect}\n#{e.backtrace.join("\n")}")
+        end
+      else
+        @logger.warn("[Telemetry] Wire server endpoint is nil, drop data")
+      end
+    end
+
+    private
+
+    # Get endpoint for different OS, only Ubuntu and CentOS are supported.
+    #
+    def get_endpoint()
+      os = nil
+      endpoint = nil
+      if File.exists?("/etc/lsb-release")
+        os = "Ubuntu" if File.read("/etc/lsb-release").include?("Ubuntu")
+      elsif File.exists?("/etc/centos-release")
+        os = "CentOS" if File.read("/etc/centos-release").include?("CentOS")
+      end
+      endpoint = get_endpoint_from_leases_path(LEASE_PATHS[os]) unless os.nil?
+      endpoint
+    end
+
+    # Try to discover and decode the wireserver endpoint in the specified dhcp leases path.
+    #
+    # @param [String] leases_path -  The path containing dhcp lease files
+    # @return [String]            -  The endpoint if available, otherwise nil
+    #
+    def get_endpoint_from_leases_path(leases_path)
+      lease_files = Dir.glob(leases_path)
+      lease_files.each do |file_name|
+        is_lease_file = false
+        endpoint = nil
+        expired  = true
+
+        file = File.open(file_name, 'r')
+        file.each_line do |line|
+          case line
+          when /#{HEADER_LEASE}/
+            is_lease_file = true
+          when /#{HEADER_OPTION}/
+            #example - option unknown-245 a8:3f:81:10;
+            endpoint = get_ip_from_lease_value(line.gsub(HEADER_OPTION, '').gsub(';', '').strip)
+          when /#{HEADER_EXPIRE}/
+            # example - expire 1 2018/01/29 04:45:46;
+            if line.include?("never")
+              expired = false
+            else
+              begin
+                ret = line.match('.*expire (\d*) (.*);')
+                expire_date = ret[2] #
+                expired = false if Time.parse(expire_date) > Time.now()
+              rescue => e
+                @logger.warn("[Telemetry] Failed to get expired data for leases of endpoint. Error:\n#{e.inspect}\n#{e.backtrace.join("\n")}")
+              end
+            end
+          when /#{FOOTER_LEASE}/
+            return endpoint if is_lease_file && !endpoint.nil? && !expired
+          end
+        end
+      end
+
+      @logger.warn("Can't find endpoint from leases_path `#{leases_path}'")
+      nil
+    end
+
+    # example: a8:3f:81:10 -> 168.63.129.16
+    def get_ip_from_lease_value(fallback_lease_value)
+      unescaped_value = fallback_lease_value.gsub('\\', '')
+      if unescaped_value.length > 4
+        unescaped_value.split(":").map{|c| c.hex}.join('.')
+      else
+        #unknown value
+        nil
+      end
+    end
+  end
+end

--- a/src/bosh_azure_cpi/lib/cloud/azure/version.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/version.rb
@@ -1,0 +1,5 @@
+module Bosh
+  module AzureCloud
+    VERSION = '35.1.0'.freeze
+  end
+end

--- a/src/bosh_azure_cpi/spec/spec_helper.rb
+++ b/src/bosh_azure_cpi/spec/spec_helper.rb
@@ -127,6 +127,12 @@ def mock_cloud(options = nil)
   Bosh::AzureCloud::Cloud.new(options || mock_cloud_options['properties'])
 end
 
+class MockTelemetryManager
+  def monitor(operation, id: "", extras: {})
+    yield
+  end
+end
+
 RSpec.configure do |config|
   config.before do
     logger = Logger.new('/dev/null')

--- a/src/bosh_azure_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
@@ -69,6 +69,7 @@ describe 'cpi.json.erb' do
             'parallel_upload_thread_num'  => 16,
             'debug_mode'                  => false,
             'keep_failed_vms'             => false,
+            'enable_telemetry'            => true,
             'use_managed_disks'           => false,
             'pip_idle_timeout_in_minutes' => 4
           },
@@ -219,6 +220,16 @@ describe 'cpi.json.erb' do
 
       it 'raises an error of missing ssh_public_key' do
         expect { subject }.to raise_error(/"ssh_public_key" is not set/)
+      end
+    end
+
+    context 'when the enable_telemetry is disabled' do
+      before do
+        manifest['properties']['azure']['enable_telemetry'] = false
+      end
+
+      it 'is able to render enable_telemetry to false' do
+        expect(subject['cloud']['properties']['azure']['enable_telemetry']).to be(false)
       end
     end
 

--- a/src/bosh_azure_cpi/spec/unit/cloud/attach_disk_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/cloud/attach_disk_spec.rb
@@ -59,6 +59,9 @@ describe Bosh::AzureCloud::Cloud do
 
       allow(vm_manager).to receive(:find).
         and_return(vm)
+
+      allow(telemetry_manager).to receive(:monitor).
+        with("attach_disk", id: instance_id).and_call_original
     end
 
     context "when use_managed_disks is true" do

--- a/src/bosh_azure_cpi/spec/unit/cloud/calculate_vm_cloud_properties_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/cloud/calculate_vm_cloud_properties_spec.rb
@@ -5,6 +5,11 @@ describe Bosh::AzureCloud::Cloud do
   include_context "shared stuff"
 
   describe '#calculate_vm_cloud_properties' do
+    before do
+      allow(telemetry_manager).to receive(:monitor).
+        with('calculate_vm_cloud_properties').and_call_original
+    end
+
     context "when the location is not specified in the global configuration" do
       it "should raise an error" do
         expect {

--- a/src/bosh_azure_cpi/spec/unit/cloud/create_disk_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/cloud/create_disk_spec.rb
@@ -20,6 +20,9 @@ describe Bosh::AzureCloud::Cloud do
         and_return(resource_group_name)
       allow(instance_id_object).to receive(:vm_name).
         and_return(vm_name)
+      allow(telemetry_manager).to receive(:monitor).
+        with("create_disk", id: instance_id, extras: {"disk_size"=>disk_size}).
+        and_call_original
     end
 
     context 'validating disk size' do
@@ -94,6 +97,9 @@ describe Bosh::AzureCloud::Cloud do
             and_return(disk_id_object)
           expect(disk_manager2).to receive(:create_disk).
             with(disk_id_object, rg_location, disk_size_in_gib, "Standard_LRS", zone)
+          expect(telemetry_manager).to receive(:monitor).
+            with("create_disk", id: "", extras: {"disk_size"=>disk_size}).
+            and_call_original
 
           expect {
             managed_cloud.create_disk(disk_size, cloud_properties, instance_id)
@@ -212,6 +218,9 @@ describe Bosh::AzureCloud::Cloud do
             and_return(disk_id_object)
           expect(disk_manager).to receive(:create_disk).
             with(disk_id_object, disk_size_in_gib)
+          expect(telemetry_manager).to receive(:monitor).
+            with("create_disk", id: "", extras: {"disk_size"=>disk_size}).
+            and_call_original
 
           expect {
             cloud.create_disk(disk_size, cloud_properties, instance_id)

--- a/src/bosh_azure_cpi/spec/unit/cloud/create_stemcell_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/cloud/create_stemcell_spec.rb
@@ -12,6 +12,10 @@ describe Bosh::AzureCloud::Cloud do
       let(:stemcell_properties) { { 'image' => 'fake-image' } }
 
       it 'should succeed' do
+        expect(telemetry_manager).to receive(:monitor).
+          with('create_stemcell', extras: {'stemcell' => 'unknown_name-unknown_version'}).
+          and_call_original
+
         expect(light_stemcell_manager).to receive(:create_stemcell).
           with(stemcell_properties).and_return(stemcell_id)
 
@@ -26,6 +30,10 @@ describe Bosh::AzureCloud::Cloud do
 
       context 'and use_managed_disks is false' do
         it 'should succeed' do
+          expect(telemetry_manager).to receive(:monitor).
+            with('create_stemcell', extras: {'stemcell' => 'unknown_name-unknown_version'}).
+            and_call_original
+
           expect(stemcell_manager).to receive(:create_stemcell).
             with(image_path, stemcell_properties).and_return(stemcell_id)
 
@@ -37,6 +45,10 @@ describe Bosh::AzureCloud::Cloud do
 
       context 'and use_managed_disks is true' do
         it 'should succeed' do
+          expect(telemetry_manager).to receive(:monitor).
+            with('create_stemcell', extras: {'stemcell' => 'unknown_name-unknown_version'}).
+            and_call_original
+
           expect(stemcell_manager2).to receive(:create_stemcell).
             with(image_path, stemcell_properties).and_return(stemcell_id)
 
@@ -44,6 +56,30 @@ describe Bosh::AzureCloud::Cloud do
             managed_cloud.create_stemcell(image_path, stemcell_properties)
           ).to eq(stemcell_id)
         end
+      end
+    end
+
+    context 'when a stcmell name ane version are specified in stemcell_properties' do
+      let(:stemcell_name) { 'fake-name' }
+      let(:stemcell_version) { 'fake-version' }
+      let(:stemcell_properties) {
+        {
+          'name' => stemcell_name,
+          'version' => stemcell_version
+        }
+      }
+
+      it 'should pass the correct stemcell info to telemetry' do
+        expect(telemetry_manager).to receive(:monitor).
+          with('create_stemcell', extras: {'stemcell' => "#{stemcell_name}-#{stemcell_version}"}).
+          and_call_original
+
+        expect(stemcell_manager).to receive(:create_stemcell).
+          with(image_path, stemcell_properties).and_return(stemcell_id)
+
+        expect(
+          cloud.create_stemcell(image_path, stemcell_properties)
+        ).to eq(stemcell_id)
       end
     end
   end

--- a/src/bosh_azure_cpi/spec/unit/cloud/create_vm_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/cloud/create_vm_spec.rb
@@ -32,6 +32,9 @@ describe Bosh::AzureCloud::Cloud do
       allow(client2).to receive(:get_virtual_network_by_name).
         with(default_resource_group_name, virtual_network_name).
         and_return(vnet)
+      allow(telemetry_manager).to receive(:monitor).
+        with('create_vm', id: agent_id, extras: {'instance_type' => 'fake-vm-size'}).
+        and_call_original
     end
 
     context 'when vnet is not found' do
@@ -223,7 +226,9 @@ describe Bosh::AzureCloud::Cloud do
 
       context 'when availability_zone is specified' do
         let(:resource_pool) {
-          { 'availability_zone' => 'fake-az' }
+          { 'availability_zone' => 'fake-az',
+            'instance_type' => 'fake-vm-size'
+          }
         }
 
         it 'should raise an error' do

--- a/src/bosh_azure_cpi/spec/unit/cloud/delete_disk_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/cloud/delete_disk_spec.rb
@@ -8,6 +8,11 @@ describe Bosh::AzureCloud::Cloud do
     let(:disk_id) { "fake-disk-id" }
     let(:disk_id_object) { instance_double(Bosh::AzureCloud::DiskId) }
 
+    before do
+      allow(telemetry_manager).to receive(:monitor).
+        with("delete_disk", id: disk_id).and_call_original
+    end
+
     context "when use_managed_disks is true" do
       before do
         allow(Bosh::AzureCloud::DiskId).to receive(:parse).

--- a/src/bosh_azure_cpi/spec/unit/cloud/delete_snapshot_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/cloud/delete_snapshot_spec.rb
@@ -5,6 +5,11 @@ describe Bosh::AzureCloud::Cloud do
   include_context "shared stuff"
 
   describe "#delete_snapshot" do
+    before do
+      allow(telemetry_manager).to receive(:monitor).
+        with("delete_snapshot", id: snapshot_id).and_call_original
+    end
+
     context "when the snapshot is a managed snapshot" do
       let(:snapshot_id) { 'fake-snapshot-id' }
       let(:snapshot_id_object) { instance_double(Bosh::AzureCloud::DiskId) }

--- a/src/bosh_azure_cpi/spec/unit/cloud/delete_stemcell_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/cloud/delete_stemcell_spec.rb
@@ -5,6 +5,11 @@ describe Bosh::AzureCloud::Cloud do
   include_context "shared stuff"
 
   describe '#delete_stemcell' do
+    before do
+      allow(telemetry_manager).to receive(:monitor).
+        with("delete_stemcell", id: stemcell_id).and_call_original
+    end
+
     context 'when a light stemcell is used' do
       let(:stemcell_id) { "bosh-light-stemcell-xxx" }
 

--- a/src/bosh_azure_cpi/spec/unit/cloud/delete_vm_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/cloud/delete_vm_spec.rb
@@ -9,6 +9,11 @@ describe Bosh::AzureCloud::Cloud do
     let(:instance_id) { "e55144a3-0c06-4240-8f15-9a7bc7b35d1f" }
     let(:instance_id_object) { instance_double(Bosh::AzureCloud::InstanceId) }
 
+    before do
+      allow(telemetry_manager).to receive(:monitor).
+        with("delete_vm", id: instance_id).and_call_original
+    end
+
     it 'should delete an instance' do
       expect(Bosh::AzureCloud::InstanceId).to receive(:parse).
         with(instance_id, azure_properties).

--- a/src/bosh_azure_cpi/spec/unit/cloud/detach_disk_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/cloud/detach_disk_spec.rb
@@ -16,6 +16,9 @@ describe Bosh::AzureCloud::Cloud do
         and_return(disk_id_object)
       allow(Bosh::AzureCloud::InstanceId).to receive(:parse).
         and_return(instance_id_object)
+
+      allow(telemetry_manager).to receive(:monitor).
+        with("detach_disk", id: instance_id).and_call_original
     end
 
     it 'detaches the disk from the vm' do

--- a/src/bosh_azure_cpi/spec/unit/cloud/get_disks_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/cloud/get_disks_spec.rb
@@ -36,6 +36,9 @@ describe Bosh::AzureCloud::Cloud do
     before do
       allow(Bosh::AzureCloud::InstanceId).to receive(:parse).
         and_return(instance_id_object)
+
+      allow(telemetry_manager).to receive(:monitor).
+        with("get_disks", id: instance_id).and_call_original
     end
 
     context 'when the instance has data disks' do

--- a/src/bosh_azure_cpi/spec/unit/cloud/has_disk_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/cloud/has_disk_spec.rb
@@ -11,6 +11,9 @@ describe Bosh::AzureCloud::Cloud do
     before do
       allow(Bosh::AzureCloud::DiskId).to receive(:parse).
         and_return(disk_id_object)
+
+      allow(telemetry_manager).to receive(:monitor).
+        with("has_disk?", id: disk_id).and_call_original
     end
 
     context "when disk name starts with DATA_DISK_PREFIX" do

--- a/src/bosh_azure_cpi/spec/unit/cloud/has_vm_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/cloud/has_vm_spec.rb
@@ -13,6 +13,9 @@ describe Bosh::AzureCloud::Cloud do
       allow(Bosh::AzureCloud::InstanceId).to receive(:parse).
         with(instance_id, azure_properties).
         and_return(instance_id_object)
+
+      allow(telemetry_manager).to receive(:monitor).
+        with("has_vm?", id: instance_id).and_call_original
     end
 
     context "when the instance exists" do

--- a/src/bosh_azure_cpi/spec/unit/cloud/info_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/cloud/info_spec.rb
@@ -5,6 +5,11 @@ describe Bosh::AzureCloud::Cloud do
   include_context "shared stuff"
 
   describe '#info' do
+    before do
+      allow(telemetry_manager).to receive(:monitor).
+        with("info").and_call_original
+    end
+
     describe 'stemcell_formats' do
       it 'supports azure-vhd' do
         expect(cloud.info['stemcell_formats']).to include('azure-vhd')

--- a/src/bosh_azure_cpi/spec/unit/cloud/reboot_vm_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/cloud/reboot_vm_spec.rb
@@ -12,6 +12,8 @@ describe Bosh::AzureCloud::Cloud do
       allow(Bosh::AzureCloud::InstanceId).to receive(:parse).
         with(instance_id, azure_properties).
         and_return(instance_id_object)
+      allow(telemetry_manager).to receive(:monitor).
+        with("reboot_vm", id: instance_id).and_call_original
     end
 
     it 'reboot an instance' do

--- a/src/bosh_azure_cpi/spec/unit/cloud/set_vm_metadata_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/cloud/set_vm_metadata_spec.rb
@@ -12,6 +12,8 @@ describe Bosh::AzureCloud::Cloud do
       allow(Bosh::AzureCloud::InstanceId).to receive(:parse).
         with(instance_id, azure_properties).
         and_return(instance_id_object)
+      allow(telemetry_manager).to receive(:monitor).
+        with("set_vm_metadata", id: instance_id).and_call_original
     end
 
     context "when the metadata is not encoded" do

--- a/src/bosh_azure_cpi/spec/unit/cloud/shared_stuff.rb
+++ b/src/bosh_azure_cpi/spec/unit/cloud/shared_stuff.rb
@@ -20,6 +20,7 @@ shared_context "shared stuff" do
   let(:light_stemcell_manager) { instance_double('Bosh::AzureCloud::LightStemcellManager') }
   let(:vm_manager) { instance_double('Bosh::AzureCloud::VMManager') }
   let(:instance_type_mapper) { instance_double('Bosh::AzureCloud::InstanceTypeMapper') }
+  let(:telemetry_manager) { MockTelemetryManager.new }
 
   before do
     allow(Bosh::AzureCloud::AzureClient2).to receive(:new).
@@ -44,5 +45,9 @@ shared_context "shared stuff" do
       and_return(vm_manager)
     allow(Bosh::AzureCloud::InstanceTypeMapper).to receive(:new).
       and_return(instance_type_mapper)
+    allow(Bosh::AzureCloud::TelemetryManager).to receive(:new).
+      and_return(telemetry_manager)
+    allow(telemetry_manager).to receive(:monitor).
+      with("initialize").and_call_original
   end
 end

--- a/src/bosh_azure_cpi/spec/unit/cloud/snapshot_disk_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/cloud/snapshot_disk_spec.rb
@@ -24,6 +24,9 @@ describe Bosh::AzureCloud::Cloud do
         and_return(resource_group_name)
       allow(disk_id_object).to receive(:caching).
         and_return(caching)
+
+      allow(telemetry_manager).to receive(:monitor).
+        with("snapshot_disk", id: disk_id).and_call_original
     end
 
     context "when the disk is a managed disk" do

--- a/src/bosh_azure_cpi/spec/unit/telemetry/telemetry_event_handler_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/telemetry/telemetry_event_handler_spec.rb
@@ -1,0 +1,277 @@
+require 'spec_helper'
+
+describe Bosh::AzureCloud::TelemetryEventHandler do
+  describe "#collect_and_send_events" do
+    let(:logger) { instance_double(Logger) }
+    let(:wire_client) { instance_double(Bosh::AzureCloud::WireClient) }
+    let(:event_handler) { Bosh::AzureCloud::TelemetryEventHandler.new(logger) }
+
+    before do
+      allow(Bosh::AzureCloud::WireClient).to receive(:new).and_return(wire_client)
+    end
+
+    context "when it gets the lock successfully" do
+      let(:mutex) { instance_double(Bosh::AzureCloud::Helpers::FileMutex) }
+
+      before do
+        allow(Bosh::AzureCloud::Helpers::FileMutex).to receive(:new).and_return(mutex)
+        allow(mutex).to receive(:lock).and_return(true)
+        allow(event_handler).to receive(:has_event?).and_return(true, false) #has_event? must return false at the end to terminate the while loop
+      end
+
+      context "when the last post happened less than 1 minutes ago" do
+        let(:now) { Time.now.round }
+        let(:last_post_timestamp) { now - 59 }
+
+        before do
+          allow(Time).to receive(:now).and_return(now)
+          allow(event_handler).to receive(:get_last_post_timestamp).and_return(last_post_timestamp)
+        end
+
+        it "will sleep and then handle the events" do
+          expect(event_handler).to receive(:sleep).with(1)
+          expect(event_handler).to receive(:collect_events).once
+          expect(event_handler).to receive(:send_events).once
+          expect(event_handler).to receive(:update_last_post_timestamp).once
+          expect(mutex).to receive(:unlock)
+          expect{
+            event_handler.collect_and_send_events
+          }.not_to raise_error
+        end
+      end
+
+      context "when the last post happened more than 1 minutes ago" do
+        let(:now) { Time.now.round }
+        let(:last_post_timestamp) { now - 61 }
+        before do
+          allow(Time).to receive(:now).and_return(now)
+          allow(event_handler).to receive(:get_last_post_timestamp).and_return(last_post_timestamp)
+        end
+
+        it "will handle the events" do
+          expect(event_handler).not_to receive(:sleep)
+          expect(event_handler).to receive(:collect_events).once
+          expect(event_handler).to receive(:send_events).once
+          expect(event_handler).to receive(:update_last_post_timestamp).once
+          expect(mutex).to receive(:unlock)
+          expect{
+            event_handler.collect_and_send_events
+          }.not_to raise_error
+        end
+      end
+
+      context "when error happens" do
+        let(:now) { Time.now.round }
+        let(:last_post_timestamp) { now - 61 }
+
+        before do
+          allow(Time).to receive(:now).and_return(now)
+          allow(event_handler).to receive(:get_last_post_timestamp).and_return(last_post_timestamp)
+          allow(event_handler).to receive(:send_events).and_raise 'unexpected error'
+        end
+
+        it "should log the error and release the lock, but not raise the error" do
+          expect(event_handler).not_to receive(:sleep)
+          expect(event_handler).to receive(:collect_events).once
+          expect(event_handler).not_to receive(:update_last_post_timestamp)
+
+          expect(logger).to receive(:warn).with(/unexpected error/)
+          expect(mutex).to receive(:unlock)
+
+          expect{
+            event_handler.collect_and_send_events
+          }.not_to raise_error
+        end
+      end
+    end
+
+    context "when it fails to get the lock" do
+      let(:mutex) { instance_double(Bosh::AzureCloud::Helpers::FileMutex) }
+
+      before do
+        allow(Bosh::AzureCloud::Helpers::FileMutex).to receive(:new).and_return(mutex)
+        allow(mutex).to receive(:lock).and_return(false)
+      end
+
+      it "will quit silently" do
+        expect(mutex).not_to receive(:unlock)
+        expect(event_handler).not_to receive(:has_event?)
+        expect{
+          event_handler.collect_and_send_events
+        }.not_to raise_error
+      end
+    end
+  end
+
+  describe "#has_event?" do
+    let(:logger) { instance_double(Logger) }
+    let(:wire_client) { instance_double(Bosh::AzureCloud::WireClient) }
+    let(:event_handler) { Bosh::AzureCloud::TelemetryEventHandler.new(logger) }
+
+    let(:cpi_events_dir) { Bosh::AzureCloud::Helpers::CPI_EVENTS_DIR }
+
+    before do
+      allow(Bosh::AzureCloud::WireClient).to receive(:new).and_return(wire_client)
+      Dir.mkdir(cpi_events_dir) unless Dir.exists?(cpi_events_dir)
+    end
+
+    after do
+      Dir.delete(cpi_events_dir) if Dir.exists?(cpi_events_dir)
+    end
+
+    context "when it has event files" do
+      let(:event_file) { "#{cpi_events_dir}/has-events-test.tld" }
+
+      before do
+        File.new(event_file, "w")
+      end
+
+      after do
+        File.delete(event_file)
+      end
+
+      it "should return true" do
+        expect(event_handler.send(:has_event?)).to be true
+      end
+    end
+  end
+
+  describe "#collect_events" do
+    let(:logger) { instance_double(Logger) }
+    let(:wire_client) { instance_double(Bosh::AzureCloud::WireClient) }
+    let(:cpi_events_dir) { '/tmp/azure_cpi_test_collect_events' }
+    let(:event_handler) { Bosh::AzureCloud::TelemetryEventHandler.new(logger, cpi_events_dir) }
+
+    let(:json) {
+      {
+        "eventId" => "fake-event-id",
+        "providerId" => "fake-provider-id",
+        "parameters" => [
+          {
+            "name" => "fake-name1",
+            "value" => "fake-value1"
+          },
+          {
+            "name" => "fake-name2",
+            "value" => "fake-value2"
+          }
+        ]
+      }.to_json
+    }
+
+    let(:event_number) { 2 }
+
+    before do
+      allow(Bosh::AzureCloud::WireClient).to receive(:new).and_return(wire_client)
+      Dir.mkdir(cpi_events_dir) unless Dir.exists?(cpi_events_dir)
+
+      (0...event_number).each do |number|
+        File.open("#{cpi_events_dir}/collect-events-test-#{number}.tld", "w") do |file|
+          file.write(json)
+        end
+      end
+    end
+
+    after do
+      Dir.delete(cpi_events_dir) if Dir.exists?(cpi_events_dir)
+    end
+
+    context "if everything is is ok" do
+      it "should collect events" do
+        expect(JSON).to receive(:parse).and_call_original.twice
+        expect(Bosh::AzureCloud::TelemetryEvent).to receive(:parse_hash).and_call_original.twice
+        expect(File).to receive(:delete).and_call_original.twice
+        expect{
+          event_handler.send(:collect_events, event_number)
+        }.not_to raise_error
+      end
+    end
+
+    context "if error happens" do
+      let(:event_number) { 1 }
+
+      it "should raise the error" do
+        expect(JSON).to receive(:parse).and_raise 'unknown error'
+        expect(Bosh::AzureCloud::TelemetryEvent).not_to receive(:parse_hash)
+        expect(File).to receive(:delete).and_call_original
+        expect(logger).to receive(:warn).with(/unknown error/)
+        expect{
+          event_handler.send(:collect_events, event_number)
+        }.to raise_error /unknown error/
+      end
+    end
+  end
+
+  describe "#send_events" do
+    let(:logger) { instance_double(Logger) }
+    let(:wire_client) { instance_double(Bosh::AzureCloud::WireClient) }
+    let(:event_handler) { Bosh::AzureCloud::TelemetryEventHandler.new(logger) }
+
+    let(:event_list) { double("event-list") }
+
+    before do
+      allow(Bosh::AzureCloud::WireClient).to receive(:new).and_return(wire_client)
+    end
+
+    it "should send the events" do
+      expect(event_list).to receive(:format_data_for_wire_server)
+      expect(wire_client).to receive(:post_data)
+      expect{
+        event_handler.send(:send_events, event_list)
+      }.not_to raise_error
+    end
+  end
+
+  describe "#get_last_post_timestamp" do
+    let(:logger) { instance_double(Logger) }
+    let(:event_handler) { Bosh::AzureCloud::TelemetryEventHandler.new(logger) }
+    let(:timestamp_file) { Bosh::AzureCloud::Helpers::CPI_EVENT_HANDLER_LAST_POST_TIMESTAMP }
+
+    let(:time) { Time.now.round }
+
+    context "when file exists" do
+      before do
+        File.open(timestamp_file, "w") do |file|
+          file.write(time)
+        end
+      end
+
+      after do
+        File.delete(timestamp_file)
+      end
+
+      it "should return correct value" do
+        expect(event_handler.send(:get_last_post_timestamp)).to eq(time)
+      end
+    end
+
+    context "when file does not exist" do
+      before do
+        File.delete(timestamp_file) if File.exist?(timestamp_file)
+      end
+
+      it "should return nil" do
+        expect(event_handler.send(:get_last_post_timestamp)).to be nil
+      end
+    end
+  end
+
+  describe "#update_last_post_timestamp" do
+    let(:logger) { instance_double(Logger) }
+    let(:event_handler) { Bosh::AzureCloud::TelemetryEventHandler.new(logger) }
+    let(:timestamp_file) { Bosh::AzureCloud::Helpers::CPI_EVENT_HANDLER_LAST_POST_TIMESTAMP }
+
+    let(:time) { Time.now.round }
+
+    after do
+      File.delete(timestamp_file)
+    end
+
+    it "should update the last post timestamp" do
+      expect_any_instance_of(File).to receive(:write).with(time.to_s)
+      expect{
+        event_handler.send(:update_last_post_timestamp, time)
+      }.not_to raise_error
+    end
+  end
+end

--- a/src/bosh_azure_cpi/spec/unit/telemetry/telemetry_event_list_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/telemetry/telemetry_event_list_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe Bosh::AzureCloud::TelemetryEventList do
+  describe "#format_data_for_wire_server" do
+    let(:parameter1) { Bosh::AzureCloud::TelemetryEventParam.new("fake-name1", "fake-value1") }
+    let(:parameter2) { Bosh::AzureCloud::TelemetryEventParam.new("fake-name2", "fake-value2") }
+    let(:event1) { Bosh::AzureCloud::TelemetryEvent.new("fake-event-id", "fake-provider-id", parameters: [parameter1, parameter2]) }
+    let(:event2) { Bosh::AzureCloud::TelemetryEvent.new("fake-event-id", "fake-provider-id", parameters: [parameter1, parameter2]) }
+
+    let(:event_list) { Bosh::AzureCloud::TelemetryEventList.new([event1, event2]) }
+
+    it "should return with right value" do
+      expect(event_list.format_data_for_wire_server).to eq("<?xml version=\"1.0\"?><TelemetryData version=\"1.0\"><Provider id=\"fake-provider-id\"><Event id=\"fake-event-id\"><![CDATA[<Param Name=\"fake-name1\" Value=\"fake-value1\" T=\"mt:wstr\" /><Param Name=\"fake-name2\" Value=\"fake-value2\" T=\"mt:wstr\" />]]></Event><Event id=\"fake-event-id\"><![CDATA[<Param Name=\"fake-name1\" Value=\"fake-value1\" T=\"mt:wstr\" /><Param Name=\"fake-name2\" Value=\"fake-value2\" T=\"mt:wstr\" />]]></Event></Provider></TelemetryData>")
+    end
+  end
+end
+

--- a/src/bosh_azure_cpi/spec/unit/telemetry/telemetry_event_param_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/telemetry/telemetry_event_param_spec.rb
@@ -1,0 +1,111 @@
+require 'spec_helper'
+
+describe Bosh::AzureCloud::TelemetryEventParam do
+  describe "#parse_hash" do
+    let(:hash) {
+      {
+        "name" => "fake-name",
+        "value" => "fake-value"
+      }
+    }
+
+    it "should parse the hash and create an instance" do
+      expect(Bosh::AzureCloud::TelemetryEventParam).to receive(:new).
+        with(hash["name"], hash["value"])
+
+      expect{
+        Bosh::AzureCloud::TelemetryEventParam.parse_hash(hash)
+      }.not_to raise_error
+    end
+  end
+
+  describe "#to_hash" do
+    let(:hash) {
+      {
+        "name" => "fake-name",
+        "value" => "fake-value"
+      }
+    }
+
+    let(:telemetry_event_param) { Bosh::AzureCloud::TelemetryEventParam.new("fake-name", "fake-value") }
+
+    it "should return with right value" do
+      expect(telemetry_event_param.to_hash).to eq(hash)
+    end
+  end
+
+  describe "#to_json" do
+    let(:json) {
+      {
+        "name" => "fake-name",
+        "value" => "fake-value"
+      }.to_json
+    }
+
+    let(:telemetry_event_param) { Bosh::AzureCloud::TelemetryEventParam.new("fake-name", "fake-value") }
+
+    it "should return with right value" do
+      expect(telemetry_event_param.to_json).to eq(json)
+    end
+  end
+
+  describe "#to_xml" do
+    context "when value is a string" do
+      let(:telemetry_event_param) { Bosh::AzureCloud::TelemetryEventParam.new("fake-name", "fake-value") }
+
+      it "should return with right value" do
+        expect(telemetry_event_param.to_xml).to eq("<Param Name=\"fake-name\" Value=\"fake-value\" T=\"mt:wstr\" />")
+      end
+    end
+
+    context "when value is a hash" do
+      let(:telemetry_event_param) { Bosh::AzureCloud::TelemetryEventParam.new("fake-name", {"fake-key" => "fake-value"}) }
+
+      it "should return with right value" do
+        expect(telemetry_event_param.to_xml).to eq("<Param Name=\"fake-name\" Value=\"{&quot;fake-key&quot;:&quot;fake-value&quot;}\" T=\"mt:wstr\" />")
+      end
+    end
+  end
+
+  describe "#type_of" do
+    let(:telemetry_event_param) { Bosh::AzureCloud::TelemetryEventParam.new("fake-name", "fake-value") }
+
+    context "when value is a string" do
+      it "should return with right value" do
+        expect(telemetry_event_param.send(:type_of, 'string')).to eq("mt:wstr")
+      end
+    end
+
+    context "when value is a integer" do
+      it "should return with right value" do
+        expect(telemetry_event_param.send(:type_of, 0)).to eq("mt:uint64")
+      end
+    end
+
+    context "when value is a float" do
+      it "should return with right value" do
+        expect(telemetry_event_param.send(:type_of, 0.1)).to eq("mt:float64")
+      end
+    end
+
+    context "when value is a bool" do
+      it "should return with right value" do
+        expect(telemetry_event_param.send(:type_of, true)).to eq("mt:bool")
+        expect(telemetry_event_param.send(:type_of, false)).to eq("mt:bool")
+      end
+    end
+
+    context "when value is a hash" do
+      it "should return with right value" do
+        expect(telemetry_event_param.send(:type_of, {})).to eq("mt:wstr")
+      end
+    end
+
+    context "when type of value is unknown" do
+      let(:obj) { double('unknown-type') }
+      it "should return with right value" do
+        expect(telemetry_event_param.send(:type_of, obj)).to eq("mt:wstr")
+      end
+    end
+  end
+end

--- a/src/bosh_azure_cpi/spec/unit/telemetry/telemetry_event_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/telemetry/telemetry_event_spec.rb
@@ -1,0 +1,117 @@
+require 'spec_helper'
+
+describe Bosh::AzureCloud::TelemetryEvent do
+  describe "#parse_hash" do
+    let(:hash) {
+      {
+        "eventId" => "fake-event-id",
+        "providerId" => "fake-provider-id",
+        "parameters" => [
+          {
+            "name" => "fake-name1",
+            "value" => "fake-value1"
+          },
+          {
+            "name" => "fake-name2",
+            "value" => "fake-value2"
+          }
+        ]
+      }
+    }
+    let(:parameter) { instance_double(Bosh::AzureCloud::TelemetryEventParam) }
+
+    before do
+      allow(Bosh::AzureCloud::TelemetryEventParam).to receive(:parse_hash).
+        and_return(parameter)
+    end
+
+    it "should parse the hash and create an instance" do
+      expect(Bosh::AzureCloud::TelemetryEvent).to receive(:new).
+        with(hash["eventId"], hash["providerId"], parameters: [parameter, parameter])
+
+      expect{
+        Bosh::AzureCloud::TelemetryEvent.parse_hash(hash)
+      }.not_to raise_error
+    end
+  end
+
+  describe "#add_param" do
+    context "when parameter is a TelemetryEventParam" do
+      let(:event) {  Bosh::AzureCloud::TelemetryEvent.new("fake-event-id", "fake-provider-id") }
+      let(:parameter) { Bosh::AzureCloud::TelemetryEventParam.new("fake-name1", "fake-value1") }
+
+      it "should add the parameter" do
+        expect(event.parameters).to receive(:push).with(parameter)
+        expect{
+          event.add_param(parameter)
+        }.not_to raise_error
+      end
+    end
+
+    context "when parameter is not a TelemetryEventParam" do
+      let(:event) {  Bosh::AzureCloud::TelemetryEvent.new("fake-event-id", "fake-provider-id") }
+      let(:parameter) { double("pamameter") }
+
+      it "should add the parameter" do
+        expect(event.parameters).not_to receive(:push).with(parameter)
+        expect{
+          event.add_param(parameter)
+        }.not_to raise_error
+      end
+    end
+  end
+
+  describe "#to_hash" do
+    let(:hash) {
+      {
+        "eventId" => "fake-event-id",
+        "providerId" => "fake-provider-id",
+        "parameters" => [
+          {
+            "name" => "fake-name1",
+            "value" => "fake-value1"
+          },
+          {
+            "name" => "fake-name2",
+            "value" => "fake-value2"
+          }
+        ]
+      }
+    }
+
+    let(:parameter1) { Bosh::AzureCloud::TelemetryEventParam.new("fake-name1", "fake-value1") }
+    let(:parameter2) { Bosh::AzureCloud::TelemetryEventParam.new("fake-name2", "fake-value2") }
+    let(:event) { Bosh::AzureCloud::TelemetryEvent.new("fake-event-id", "fake-provider-id", parameters: [parameter1, parameter2]) }
+
+    it "should return with right value" do
+      expect(event.to_hash).to eq(hash)
+    end
+  end
+
+  describe "#to_json" do
+    let(:json) {
+      {
+        "eventId" => "fake-event-id",
+        "providerId" => "fake-provider-id",
+        "parameters" => [
+          {
+            "name" => "fake-name1",
+            "value" => "fake-value1"
+          },
+          {
+            "name" => "fake-name2",
+            "value" => "fake-value2"
+          }
+        ]
+      }.to_json
+    }
+
+    let(:parameter1) { Bosh::AzureCloud::TelemetryEventParam.new("fake-name1", "fake-value1") }
+    let(:parameter2) { Bosh::AzureCloud::TelemetryEventParam.new("fake-name2", "fake-value2") }
+    let(:event) { Bosh::AzureCloud::TelemetryEvent.new("fake-event-id", "fake-provider-id", parameters: [parameter1, parameter2]) }
+
+    it "should return with right value" do
+      expect(event.to_json).to eq(json)
+    end
+  end
+end

--- a/src/bosh_azure_cpi/spec/unit/telemetry/telemetry_manager_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/telemetry/telemetry_manager_spec.rb
@@ -1,0 +1,252 @@
+require 'spec_helper'
+
+describe Bosh::AzureCloud::TelemetryManager do
+  describe '#monitor' do
+    let(:logger) { instance_double(Logger) }
+    let(:telemetry_event) { instance_double(Bosh::AzureCloud::TelemetryEvent) }
+
+    let(:id) { 'fake-id' }
+    let(:operation) { 'fake-op' }
+    let(:extras) { {'fake-key' => 'fake-value'} }
+
+    let(:event_param_name) { instance_double(Bosh::AzureCloud::TelemetryEventParam) }
+    let(:event_param_version) { instance_double(Bosh::AzureCloud::TelemetryEventParam) }
+    let(:event_param_operation) { instance_double(Bosh::AzureCloud::TelemetryEventParam) }
+    let(:event_param_container_id) { instance_double(Bosh::AzureCloud::TelemetryEventParam) }
+    let(:event_param_operation_success) { instance_double(Bosh::AzureCloud::TelemetryEventParam) }
+    let(:event_param_message) { instance_double(Bosh::AzureCloud::TelemetryEventParam) }
+    let(:event_param_duration) { instance_double(Bosh::AzureCloud::TelemetryEventParam) }
+
+    before do
+      allow(Bosh::AzureCloud::TelemetryEventParam).to receive(:new).
+        with("Name", "BOSH-CPI").
+        and_return(event_param_name)
+      allow(Bosh::AzureCloud::TelemetryEventParam).to receive(:new).
+        with("Version", Bosh::AzureCloud::VERSION).
+        and_return(event_param_version)
+      allow(Bosh::AzureCloud::TelemetryEventParam).to receive(:new).
+        with("Operation", operation).
+        and_return(event_param_operation)
+      allow(Bosh::AzureCloud::TelemetryEventParam).to receive(:new).
+        with("ContainerId", id).
+        and_return(event_param_container_id)
+      allow(Bosh::AzureCloud::TelemetryEventParam).to receive(:new).
+        with("OperationSuccess", true).
+        and_return(event_param_operation_success)
+      allow(Bosh::AzureCloud::TelemetryEventParam).to receive(:new).
+        with("Message", "").
+        and_return(event_param_message)
+      allow(Bosh::AzureCloud::TelemetryEventParam).to receive(:new).
+        with("Duration", 0).
+        and_return(event_param_duration)
+
+      allow(event_param_duration).to receive(:value=)
+      allow(event_param_message).to receive(:value=)
+
+      allow(Bosh::AzureCloud::TelemetryEvent).to receive(:new).
+        and_return(telemetry_event)
+      allow(telemetry_event).to receive(:add_param).with(event_param_name)
+      allow(telemetry_event).to receive(:add_param).with(event_param_version)
+      allow(telemetry_event).to receive(:add_param).with(event_param_operation)
+      allow(telemetry_event).to receive(:add_param).with(event_param_container_id)
+      allow(telemetry_event).to receive(:add_param).with(event_param_operation_success)
+      allow(telemetry_event).to receive(:add_param).with(event_param_message)
+      allow(telemetry_event).to receive(:add_param).with(event_param_duration)
+    end
+
+    context 'when the block is executed successfully' do
+      let(:telemetry_manager) { Bosh::AzureCloud::TelemetryManager.new(mock_azure_properties_merge({'enable_telemetry' => true}), logger) }
+      let(:result) { 'fake-result' }
+
+      context 'when operation is not initialize' do
+        it 'should return the result and report the event' do
+          expect(event_param_message).to receive(:value=).
+            with({'msg' => 'Successed',
+                  'subscription_id' => mock_azure_properties['subscription_id'],
+                  'fake-key' => 'fake-value'})
+          expect(telemetry_manager).to receive(:report_event)
+
+          expect(
+            telemetry_manager.monitor(operation, id: id, extras: extras) do
+              result
+            end
+          ).to eq(result)
+        end
+      end
+
+      context 'when operation is initialize' do
+        let(:operation) { 'initialize' }
+
+        it 'should return the result but do not report the event' do
+          expect(event_param_message).to receive(:value=).
+            with({'msg' => 'Successed',
+                  'subscription_id' => mock_azure_properties['subscription_id'],
+                  'fake-key' => 'fake-value'})
+          expect(telemetry_manager).not_to receive(:report_event)
+
+          expect(
+            telemetry_manager.monitor(operation, id: id, extras: extras) do
+              result
+            end
+          ).to eq(result)
+        end
+      end
+    end
+
+    context 'when the block raises an error' do
+      let(:telemetry_manager) { Bosh::AzureCloud::TelemetryManager.new(mock_azure_properties_merge({'enable_telemetry' => true}), logger) }
+
+      context 'when length of the message exceeds 3.9 kB' do
+        let(:error) { 'x'*3994 }
+        let(:runtime_error_prefix) { '#<RuntimeError: ' }
+        let(:error_message) { "#{runtime_error_prefix}#{error}"[0...3990] + '...' }
+
+        it 'should raise the entire error message and send the truncated message for telemetry' do
+          expect(event_param_operation_success).to receive(:value=).
+            with(false)
+          expect(event_param_message).to receive(:value=).
+            with(hash_including('msg' => error_message))
+          expect(telemetry_manager).to receive(:report_event)
+
+          expect{
+            telemetry_manager.monitor(operation, id: id, extras: extras) do
+              raise error
+            end
+          }.to raise_error error
+        end
+      end
+
+      context 'when length of the message does not exceed 3.9 kB' do
+        let(:error) { 'x' }
+        let(:runtime_error_prefix) { '#<RuntimeError: ' }
+        let(:error_message) { "#{runtime_error_prefix}#{error}" }
+
+        it 'should raise the error and report the event' do
+          expect(event_param_operation_success).to receive(:value=).
+            with(false)
+          expect(event_param_message).to receive(:value=).
+            with(hash_including('msg' => /#{error_message}/))
+          expect(telemetry_manager).to receive(:report_event)
+
+          expect{
+            telemetry_manager.monitor(operation, id: id, extras: extras) do
+              raise error
+            end
+          }.to raise_error error
+        end
+      end
+
+      context 'operation is initialize' do
+        let(:error) { 'x' }
+        let(:runtime_error_prefix) { '#<RuntimeError: ' }
+        let(:error_message) { "#{runtime_error_prefix}#{error}" }
+        let(:operationi) { 'initialize' }
+
+        it 'should raise the error and report the event' do
+          expect(event_param_operation_success).to receive(:value=).
+            with(false)
+          expect(event_param_message).to receive(:value=).
+            with(hash_including('msg' => /#{error_message}/))
+          expect(telemetry_manager).to receive(:report_event)
+
+          expect{
+            telemetry_manager.monitor(operation, id: id, extras: extras) do
+              raise error
+            end
+          }.to raise_error error
+        end
+      end
+    end
+
+    context 'when telemetry is not enabled' do
+      let(:telemetry_manager) { Bosh::AzureCloud::TelemetryManager.new(mock_azure_properties_merge({'enable_telemetry' => false}), logger) }
+      let(:result) { 'fake-result' }
+
+      it 'should return the result and does not report the event' do
+        expect(telemetry_manager).not_to receive(:report_event)
+
+        expect(
+          telemetry_manager.monitor(operation, id: id, extras: extras) do
+            result
+          end
+        ).to eq(result)
+      end
+    end
+    context 'when environment is AzureStack' do
+      let(:telemetry_manager) { Bosh::AzureCloud::TelemetryManager.new(mock_azure_properties_merge({'enable_telemetry' => true, 'environment' => 'AzureStack'}), logger) }
+      let(:result) { 'fake-result' }
+
+      it 'should return the result and does not report the event' do
+        expect(telemetry_manager).not_to receive(:report_event)
+
+        expect(
+          telemetry_manager.monitor(operation, id: id, extras: extras) do
+            result
+          end
+        ).to eq(result)
+      end
+    end
+  end
+
+  describe '#report_event' do
+    let(:logger) { instance_double(Logger) }
+    let(:telemetry_manager) { Bosh::AzureCloud::TelemetryManager.new(mock_azure_properties, logger) }
+    let(:telemetry_event) { instance_double(Bosh::AzureCloud::TelemetryEvent) }
+    let(:telemetry_event_handler) { instance_double(Bosh::AzureCloud::TelemetryEventHandler) }
+    let(:file) { double('file')}
+
+    context 'when everything is ok' do
+      before do
+        allow(Open3).to receive(:capture3).and_return(['fake-stdout', 'fake-stderr', 0])
+        allow(telemetry_event).to receive(:to_json).and_return('fake-event')
+      end
+
+      it 'should collect and sent events' do
+        expect(File).to receive(:open).and_call_original do |file|
+          expect(file).to receive(:write)
+        end
+        expect(telemetry_manager).to receive(:fork)
+        expect(Process).to receive(:detach)
+        expect {
+          telemetry_manager.send(:report_event, telemetry_event)
+        }.not_to raise_error
+      end
+    end
+
+    context 'when it fails to move event file to CPI_EVENTS_DIR' do
+      let(:err_status) { 1 }
+
+      before do
+        allow(Open3).to receive(:capture3).and_return(['fake-stdout', 'fake-stderr', err_status])
+        allow(telemetry_event).to receive(:to_json).and_return('fake-event')
+      end
+
+      it 'should log the error and drop it silently' do
+        expect(File).to receive(:open).and_call_original do |file|
+          expect(file).to receive(:write)
+        end
+        expect(logger).to receive(:warn).with(/fake-stderr/)
+        expect(Bosh::AzureCloud::TelemetryEventHandler).not_to receive(:new)
+
+        expect {
+          telemetry_manager.send(:report_event, telemetry_event)
+        }.not_to raise_error
+      end
+    end
+
+    context 'when exception is caught' do
+      before do
+        allow(File).to receive(:open).and_raise 'failed to open file'
+      end
+
+      it 'should log the error and drop the exception silently' do
+        expect(logger).to receive(:warn).with(/failed to open file/)
+        expect(Bosh::AzureCloud::TelemetryEventHandler).not_to receive(:new)
+
+        expect {
+          telemetry_manager.send(:report_event, telemetry_event)
+        }.not_to raise_error
+      end
+    end
+  end
+end

--- a/src/bosh_azure_cpi/spec/unit/telemetry/wire_client_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/telemetry/wire_client_spec.rb
@@ -1,0 +1,308 @@
+require 'spec_helper'
+require 'webmock/rspec'
+
+describe Bosh::AzureCloud::WireClient do
+  describe "post_data" do
+    let(:logger) { instance_double(Logger) }
+    let(:wire_client) { Bosh::AzureCloud::WireClient.new(logger) }
+    let(:event_data) { "fake-event-data" }
+
+    context "when it gets wire server endpoint successfully" do
+      let(:endpoint) { "fake-endpoint" }
+      let(:wire_server_uri) { "http://#{endpoint}/machine?comp=telemetrydata" }
+      let(:headers) {
+        {'Content-Type' => 'text/xml;charset=utf-8', 'x-ms-version' => '2012-11-30'}
+      }
+
+      before do
+        allow(wire_client).to receive(:get_endpoint).and_return(endpoint)
+      end
+
+      it "should post the data one time if post request returns 200" do
+        stub_request(:post, wire_server_uri).with(body: event_data, headers: headers).
+          to_return(:status => 200)
+        expect(logger).to receive(:debug).with("[Telemetry] Data posted")
+
+        expect {
+          wire_client.post_data(event_data)
+        }.not_to raise_error
+      end
+
+      it "should retry to post the data if post request returns a retryable error" do
+        stub_request(:post, wire_server_uri).with(body: event_data, headers: headers).
+          to_return(:status => 408)
+        expect(logger).to receive(:debug).with("[Telemetry] Failed to post data, retrying...")
+        expect(logger).to receive(:warn).with(/Failed to post data/)
+        expect(wire_client).to receive(:sleep)
+
+        expect {
+          wire_client.post_data(event_data)
+        }.not_to raise_error
+      end
+
+      it "should not retry to post the data if post request returns a not retryable error" do
+        stub_request(:post, wire_server_uri).with(body: event_data, headers: headers).
+          to_return(:status => 600)
+        expect(logger).to receive(:warn).with(/Failed to POST request/)
+
+        expect {
+          wire_client.post_data(event_data)
+        }.not_to raise_error
+      end
+
+      it "should retry to post the data if post request hit a timeout error" do
+        stub_request(:post, wire_server_uri).with(body: event_data, headers: headers).
+          to_raise(Net::OpenTimeout.new)
+        expect(logger).to receive(:debug).with("[Telemetry] Failed to post data, retrying...")
+        expect(logger).to receive(:warn).with(/Failed to post data/)
+        expect(wire_client).to receive(:sleep)
+
+        expect {
+          wire_client.post_data(event_data)
+        }.not_to raise_error
+      end
+    end
+
+    context "when it fails to get wire server endpoint" do
+      let(:endpoint) { nil }
+
+      before do
+        allow(wire_client).to receive(:get_endpoint).and_return(endpoint)
+      end
+
+      it "should not raise error" do
+        expect(logger).to receive(:warn).with("[Telemetry] Wire server endpoint is nil, drop data")
+
+        expect {
+          wire_client.post_data(event_data)
+        }.not_to raise_error
+      end
+    end
+
+  end
+
+  describe "get_endpoint" do
+    let(:logger) { instance_double(Logger) }
+    let(:wire_client) { Bosh::AzureCloud::WireClient.new(logger) }
+    let(:endpoint) { "fake-endpoint" }
+
+    context "when OS is Ubuntu" do
+      let(:lsb_release) { '
+DISTRIB_ID=Ubuntu
+DISTRIB_RELEASE=14.04
+DISTRIB_CODENAME=trusty
+DISTRIB_DESCRIPTION="Ubuntu 14.04.5 LTS"
+      ' }
+
+      before do
+        allow(File).to receive(:exists?).with("/etc/lsb-release").and_return(true)
+        allow(File).to receive(:exists?).with("/etc/centos-release").and_return(false)
+        allow(File).to receive(:read).with("/etc/lsb-release").and_return(lsb_release)
+      end
+
+      it "should get endpoint for Ubuntu" do
+        expect(wire_client).to receive(:get_endpoint_from_leases_path).
+          with("/var/lib/dhcp/dhclient.*.leases").
+          and_return(endpoint)
+        expect(
+          wire_client.send(:get_endpoint)
+        ).to eq(endpoint)
+      end
+    end
+
+    context "when OS is CentOS" do
+      let(:centos_release) { '
+CentOS Linux release 7.4.1708 (Core)
+      ' }
+
+      before do
+        allow(File).to receive(:exists?).with("/etc/lsb-release").and_return(false)
+        allow(File).to receive(:exists?).with("/etc/centos-release").and_return(true)
+        allow(File).to receive(:read).with("/etc/centos-release").and_return(centos_release)
+      end
+
+      it "should get endpoint for CentOS" do
+        expect(wire_client).to receive(:get_endpoint_from_leases_path).
+          with("/var/lib/dhclient/dhclient-*.leases").
+          and_return(endpoint)
+        expect(
+          wire_client.send(:get_endpoint)
+        ).to eq(endpoint)
+      end
+    end
+  end
+
+  describe "get_endpoint_from_leases_path" do
+    let(:logger) { instance_double(Logger) }
+    let(:wire_client) { Bosh::AzureCloud::WireClient.new(logger) }
+
+    let(:lease_path) { "fake-path" }
+    let(:lease_file) { "/tmp/cpi-test-fake-lease-file-name" }
+
+    context "when lease file is valid" do
+      let(:lease_content) { '
+lease {
+  interface "eth0";
+  fixed-address 172.16.3.4;
+  server-name "SG20103202064";
+  option subnet-mask 255.255.255.0;
+  option dhcp-lease-time 4294967295;
+  option routers 172.16.3.1;
+  option dhcp-message-type 5;
+  option dhcp-server-identifier 168.63.129.16;
+  option domain-name-servers 168.63.129.16;
+  option dhcp-renewal-time 4294967295;
+  option rfc3442-classless-static-routes 0,172,16,3,1,32,168,63,129,16,172,16,3,1,32,169,254,169,254,172,16,3,1;
+  option unknown-245 a8:3f:81:10;
+  option dhcp-rebinding-time 4294967295;
+  option domain-name "ta1qcq3khvnelp4p0x3q10hsjh.ix.internal.cloudapp.net";
+  renew 6 2017/11/25 01:48:29;
+  rebind 6 2017/11/25 01:48:29;
+  expire 6 2017/11/25 01:48:29;
+}
+lease {
+  interface "eth0";
+  fixed-address 172.16.3.4;
+  server-name "SG20103202064";
+  option subnet-mask 255.255.255.0;
+  option dhcp-lease-time 4294967295;
+  option routers 172.16.3.1;
+  option dhcp-message-type 5;
+  option dhcp-server-identifier 168.63.129.16;
+  option domain-name-servers 168.63.129.16;
+  option dhcp-renewal-time 4294967295;
+  option rfc3442-classless-static-routes 0,172,16,3,1,32,168,63,129,16,172,16,3,1,32,169,254,169,254,172,16,3,1;
+  option unknown-245 a8:3f:81:10;
+  option dhcp-rebinding-time 4294967295;
+  option domain-name "ta1qcq3khvnelp4p0x3q10hsjh.ix.internal.cloudapp.net";
+  renew 2 2154/01/01 08:18:55;
+  rebind 2 2154/01/01 08:18:55;
+  expire 2 2154/01/01 08:18:55;
+}
+      ' }
+
+      before do
+        allow(Dir).to receive(:glob).and_return([lease_file])
+        File.open(lease_file, 'w') do |file|
+          file.write(lease_content)
+        end
+      end
+
+      after do
+        File.delete(lease_file)
+      end
+
+      it "should get the endpoint correctly" do
+        expect(wire_client).to receive(:get_ip_from_lease_value).
+          with("a8:3f:81:10").
+          and_call_original.twice
+        expect(
+          wire_client.send(:get_endpoint_from_leases_path, lease_path)
+        ).to eq("168.63.129.16") #Note: a8:3f:81:10 is translated to 168.63.129.16
+      end
+    end
+
+    context "when lease never expires" do
+      let(:lease_content) { '
+lease {
+  interface "eth0";
+  fixed-address 172.16.3.4;
+  server-name "SG20103202064";
+  option subnet-mask 255.255.255.0;
+  option dhcp-lease-time 4294967295;
+  option routers 172.16.3.1;
+  option dhcp-message-type 5;
+  option dhcp-server-identifier 168.63.129.16;
+  option domain-name-servers 168.63.129.16;
+  option dhcp-renewal-time 4294967295;
+  option rfc3442-classless-static-routes 0,172,16,3,1,32,168,63,129,16,172,16,3,1,32,169,254,169,254,172,16,3,1;
+  option unknown-245 a8:3f:81:10;
+  option dhcp-rebinding-time 4294967295;
+  option domain-name "ta1qcq3khvnelp4p0x3q10hsjh.ix.internal.cloudapp.net";
+  renew 2 2154/01/01 08:18:55;
+  rebind 2 2154/01/01 08:18:55;
+  expire never;
+}
+      ' }
+
+      before do
+        allow(Dir).to receive(:glob).and_return([lease_file])
+        File.open(lease_file, 'w') do |file|
+          file.write(lease_content)
+        end
+      end
+
+      after do
+        File.delete(lease_file)
+      end
+
+      it "should get the endpoint correctly" do
+        expect(wire_client).to receive(:get_ip_from_lease_value).
+          with("a8:3f:81:10").
+          and_call_original
+        expect(
+          wire_client.send(:get_endpoint_from_leases_path, lease_path)
+        ).to eq("168.63.129.16") #Note: a8:3f:81:10 is translated to 168.63.129.16
+      end
+    end
+
+    context "when lease expire time invalid" do
+      let(:lease_content) { '
+lease {
+  interface "eth0";
+  fixed-address 172.16.3.4;
+  server-name "SG20103202064";
+  option subnet-mask 255.255.255.0;
+  option dhcp-lease-time 4294967295;
+  option routers 172.16.3.1;
+  option dhcp-message-type 5;
+  option dhcp-server-identifier 168.63.129.16;
+  option domain-name-servers 168.63.129.16;
+  option dhcp-renewal-time 4294967295;
+  option rfc3442-classless-static-routes 0,172,16,3,1,32,168,63,129,16,172,16,3,1,32,169,254,169,254,172,16,3,1;
+  option unknown-245 a8:3f:81:10;
+  option dhcp-rebinding-time 4294967295;
+  option domain-name "ta1qcq3khvnelp4p0x3q10hsjh.ix.internal.cloudapp.net";
+  renew 2 2154/01/01 08:18:55;
+  rebind 2 2154/01/01 08:18:55;
+  expire invalid;
+}
+      ' }
+
+      before do
+        allow(Dir).to receive(:glob).and_return([lease_file])
+        File.open(lease_file, 'w') do |file|
+          file.write(lease_content)
+        end
+      end
+
+      after do
+        File.delete(lease_file)
+      end
+
+      it "should get the endpoint correctly" do
+        expect(wire_client).to receive(:get_ip_from_lease_value).
+          with("a8:3f:81:10").
+          and_call_original
+        expect(logger).to receive(:warn).with(/Failed to get expired data for leases of endpoint/)
+        expect(logger).to receive(:warn).with(/Can't find endpoint from leases_path/)
+        expect(
+          wire_client.send(:get_endpoint_from_leases_path, lease_path)
+        ).to be_nil
+      end
+    end
+  end
+
+  describe "get_ip_from_lease_value" do
+    let(:logger) { instance_double(Logger) }
+    let(:wire_client) { Bosh::AzureCloud::WireClient.new(logger) }
+    let(:lease_value) { "a8:3f:81:10" }
+    let(:ip) { "168.63.129.16" }
+
+    it "should decode the ip correctly" do
+      expect(
+        wire_client.send(:get_ip_from_lease_value, lease_value)
+      ).to eq(ip)
+    end
+  end
+end


### PR DESCRIPTION


- [x] Please check this box and fill the data as below once you have run the unit tests.
      Code coverage before your change: `778 examples, 0 failures. 3289 / 3352 LOC (98.12%) covered.`
      Code coverage with your change:  `829 examples, 0 failures. 3580 / 3644 LOC (98.24%) covered.`

  ```
  pushd src/bosh_azure_cpi
    ./bin/test-unit
  popd
  ```

  NOTE: Please see how to setup dev environment and run unit tests in docs/development.md.

### Changelog

* Enable telemetry on CPI calls
