### PR TITLE
Enable VM boot diagnostics by default

### DIFF
--- a/jobs/azure_cpi/spec
+++ b/jobs/azure_cpi/spec
@@ -64,6 +64,9 @@ properties:
   azure.enable_telemetry:
     description: Enable telemetry on CPI calls
     default: true
+  azure.enable_vm_boot_diagnostics:
+    description: Enable VM boot diagnostics
+    default: true
   azure.azure_stack.domain:
     description: The domain for your AzureStack deployment
     default: local.azurestack.external

--- a/jobs/azure_cpi/templates/cpi.json.erb
+++ b/jobs/azure_cpi/templates/cpi.json.erb
@@ -15,7 +15,8 @@
           'use_managed_disks' => p('azure.use_managed_disks'),
           'pip_idle_timeout_in_minutes' => p('azure.pip_idle_timeout_in_minutes'),
           'keep_failed_vms' => p('azure.keep_failed_vms'),
-          'enable_telemetry' => p('azure.enable_telemetry')
+          'enable_telemetry' => p('azure.enable_telemetry'),
+          'enable_vm_boot_diagnostics' => p('azure.enable_vm_boot_diagnostics')
         },
         'registry' => {
           'user' => p('registry.username'),

--- a/src/bosh_azure_cpi/lib/cloud/azure/blob_manager.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/blob_manager.rb
@@ -282,8 +282,14 @@ module Bosh::AzureCloud
       end
     end
 
-    def prepare(storage_account_name, containers: [DISK_CONTAINER, STEMCELL_CONTAINER], is_default_storage_account: false)
-      @logger.info("prepare(#{storage_account_name}, #{containers})")
+    # Prepare containers in the storage account
+    # @param [string]  storage_account_name       - storage account name
+    # @param [Array]   containers                 - container names to be created
+    # @param [Boolean] is_default_storage_account - the storage account is the default storage account
+    # @return [void]
+    #
+    def prepare_containers(storage_account_name, containers, is_default_storage_account)
+      @logger.info("prepare_containers(#{storage_account_name}, #{containers}, #{is_default_storage_account})")
       containers.each do |container|
         @logger.debug("Creating the container `#{container}' in the storage account `#{storage_account_name}'")
         create_container(storage_account_name, container)

--- a/src/bosh_azure_cpi/lib/cloud/azure/helpers.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/helpers.rb
@@ -91,6 +91,9 @@ module Bosh::AzureCloud
     STEMCELL_STORAGE_ACCOUNT_TAGS     = AZURE_TAGS.merge({
       'type' => 'stemcell'
     })
+    DIAGNOSTICS_STORAGE_ACCOUNT_TAGS  = AZURE_TAGS.merge({
+      'type' => 'bootdiagnostics'
+    })
     DISK_CONTAINER                    = 'bosh'
     STEMCELL_CONTAINER                = 'stemcell'
     STEMCELL_TABLE                    = 'stemcells'

--- a/src/bosh_azure_cpi/lib/cloud/azure/stemcell_manager.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/stemcell_manager.rb
@@ -112,7 +112,7 @@ module Bosh::AzureCloud
           # Create containers if they are missing.
           # Background: When users create a storage account without containers in it, and use that storage account for a resource pool,
           #             CPI will try to create related containers when copying stemcell to that storage account.
-          @blob_manager.prepare(storage_account_name)
+          @blob_manager.prepare_containers(storage_account_name, [DISK_CONTAINER, STEMCELL_CONTAINER], false)
 
           @logger.info("Copying stemcell #{name} to #{storage_account_name}")
           source_blob_uri = get_stemcell_uri(@default_storage_account_name, name)

--- a/src/bosh_azure_cpi/lib/cloud/azure/vm_manager.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/vm_manager.rb
@@ -96,13 +96,9 @@ module Bosh::AzureCloud
         vm_params[:zone] = zone.to_s
       end
 
-      if is_debug_mode(@azure_properties)
-        default_storage_account = @storage_account_manager.default_storage_account
-        if default_storage_account[:location] == location
-          vm_params[:diag_storage_uri] = default_storage_account[:storage_blob_host]
-        else
-          @logger.warn("Default storage account `#{default_storage_account[:name]}' is in different region `#{default_storage_account[:location]}', ignore boot diagnostics.")
-        end
+      if @azure_properties['enable_vm_boot_diagnostics'] && (@azure_properties['environment'] != ENVIRONMENT_AZURESTACK)
+        diagnostics_storage_account = @storage_account_manager.get_or_create_diagnostics_storage_account(location)
+        vm_params[:diag_storage_uri] = diagnostics_storage_account[:storage_blob_host]
       end
 
       primary_nic_tags = AZURE_TAGS.clone

--- a/src/bosh_azure_cpi/spec/unit/blob_manager_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/blob_manager_spec.rb
@@ -652,8 +652,9 @@ describe Bosh::AzureCloud::BlobManager do
     end
   end
 
-  describe "#prepare" do
+  describe "#prepare_containers" do
     let(:another_storage_account_name) { "another-storage-account-name" }
+    let(:containers) { [container_name] }
     let(:another_storage_account) {
       {
         :id => "foo",
@@ -679,7 +680,7 @@ describe Bosh::AzureCloud::BlobManager do
         expect(blob_service).to receive(:set_container_acl).with('stemcell', 'blob', options)
 
         expect {
-          blob_manager.prepare(another_storage_account_name, containers: [container_name], is_default_storage_account: true)
+          blob_manager.prepare_containers(another_storage_account_name, containers, true)
         }.not_to raise_error
       end
     end
@@ -692,7 +693,7 @@ describe Bosh::AzureCloud::BlobManager do
         expect(blob_service).not_to receive(:set_container_acl)
 
         expect {
-          blob_manager.prepare(another_storage_account_name, containers: [container_name])
+          blob_manager.prepare_containers(another_storage_account_name, containers, false)
         }.not_to raise_error
       end
     end

--- a/src/bosh_azure_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
@@ -71,7 +71,8 @@ describe 'cpi.json.erb' do
             'keep_failed_vms'             => false,
             'enable_telemetry'            => true,
             'use_managed_disks'           => false,
-            'pip_idle_timeout_in_minutes' => 4
+            'pip_idle_timeout_in_minutes' => 4,
+            'enable_vm_boot_diagnostics'  => true
           },
           'registry'=>{
             'address'=>'registry-host.example.com',
@@ -230,6 +231,16 @@ describe 'cpi.json.erb' do
 
       it 'is able to render enable_telemetry to false' do
         expect(subject['cloud']['properties']['azure']['enable_telemetry']).to be(false)
+      end
+    end
+
+    context 'when the enable_vm_boot_diagnostics is disabled' do
+      before do
+        manifest['properties']['azure']['enable_vm_boot_diagnostics'] = false
+      end
+
+      it 'is able to render enable_vm_boot_diagnostics to false' do
+        expect(subject['cloud']['properties']['azure']['enable_vm_boot_diagnostics']).to be(false)
       end
     end
 

--- a/src/bosh_azure_cpi/spec/unit/stemcell_manager_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/stemcell_manager_spec.rb
@@ -274,8 +274,8 @@ describe Bosh::AzureCloud::StemcellManager do
           allow(table_manager).to receive(:query_entities).
             and_return(entities_query_before_insert, entities_query_after_insert)
 
-          expect(blob_manager).to receive(:prepare).
-            with(storage_account_name)
+          expect(blob_manager).to receive(:prepare_containers).
+            with(storage_account_name, ['bosh', 'stemcell'], false)
           expect(blob_manager).to receive(:copy_blob).
             with(storage_account_name, stemcell_container, "#{stemcell_name}.vhd", stemcell_blob_uri)
           expect(table_manager).to receive(:update_entity).


### PR DESCRIPTION
- [x] Please check this box and fill the data as below once you have run the unit tests.
      Code coverage before your change: `829 examples, 0 failures. 3580 / 3644 LOC (98.24%) covered.`
      Code coverage with your change:   `839 examples, 0 failures.3603 / 3667 LOC (98.25%) covered.`

  ```
  pushd src/bosh_azure_cpi
    ./bin/test-unit
  popd
  ```

  NOTE: Please see how to setup dev environment and run unit tests in docs/development.md.

### Changelog

* Enable VM boot diagnostics by default
