### PR TITLE
Support AzureChinaCloud AD as Azure Stack authentication

### DIFF
--- a/jobs/azure_cpi/spec
+++ b/jobs/azure_cpi/spec
@@ -13,7 +13,7 @@ packages:
 
 properties:
   azure.environment:
-    description: The environment for Azure Management Service. AzureCloud, AzureChinaCloud, AzureUSGovernment or AzureStack
+    description: The environment for Azure Management Service. AzureCloud, AzureChinaCloud, AzureUSGovernment, AzureGermanCloud or AzureStack
     default: AzureCloud
   azure.location:
     description: Azure region name
@@ -71,7 +71,7 @@ properties:
     description: The domain for your AzureStack deployment
     default: local.azurestack.external
   azure.azure_stack.authentication:
-    description: The authentication type for your AzureStack deployment. AzureAD or ADFS
+    description: The authentication type for your AzureStack deployment. AzureAD, AzureChinaCloudAD or ADFS
     default: AzureAD
   azure.azure_stack.resource:
     description: The token resource for your AzureStack deployment

--- a/src/bosh_azure_cpi/lib/cloud/azure/helpers.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/helpers.rb
@@ -11,7 +11,7 @@ module Bosh::AzureCloud
     ENVIRONMENT_AZURECHINACLOUD   = 'AzureChinaCloud'
     ENVIRONMENT_AZUREUSGOVERNMENT = 'AzureUSGovernment'
     ENVIRONMENT_AZURESTACK        = 'AzureStack'
-    ENVIRONMENT_AZUREGermanCloud  = 'AzureGermanCloud'
+    ENVIRONMENT_AZUREGERMANCLOUD  = 'AzureGermanCloud'
 
     AZURE_ENVIRONMENTS = {
       ENVIRONMENT_AZURECLOUD => {
@@ -56,7 +56,7 @@ module Bosh::AzureCloud
           AZURE_RESOURCE_PROVIDER_ACTIVEDIRECTORY  => '2015-06-15'
         }
       },
-      ENVIRONMENT_AZUREGermanCloud => {
+      ENVIRONMENT_AZUREGERMANCLOUD => {
         'resourceManagerEndpointUrl' => 'https://management.microsoftazure.de/',
         'activeDirectoryEndpointUrl' => 'https://login.microsoftonline.de',
         'apiVersion' => {
@@ -147,8 +147,9 @@ module Bosh::AzureCloud
     WINDOWS_VM_NAME_LENGTH        = 15
 
     # Azure Stack Authentication Type
-    AZURESTACK_AUTHENTICATION_TYPE_AZUREAD      = 'AzureAD'
-    AZURESTACK_AUTHENTICATION_TYPE_ADFS         = 'ADFS'
+    AZURESTACK_AUTHENTICATION_TYPE_AZUREAD           = 'AzureAD'
+    AZURESTACK_AUTHENTICATION_TYPE_AZURECHINACLOUDAD = 'AzureChinaCloudAD'
+    AZURESTACK_AUTHENTICATION_TYPE_ADFS              = 'ADFS'
 
     BOSH_JOBS_DIR = '/var/vcap/jobs'
     AZURESTACK_CA_CERT_RELATIVE_PATH            = 'azure_cpi/config/azure_stack_ca_cert.pem'
@@ -228,6 +229,9 @@ module Bosh::AzureCloud
         if authentication == AZURESTACK_AUTHENTICATION_TYPE_AZUREAD
           url = "#{AZURE_ENVIRONMENTS[ENVIRONMENT_AZURECLOUD]['activeDirectoryEndpointUrl']}/#{azure_properties['tenant_id']}/oauth2/token"
           api_version = AZURE_ENVIRONMENTS[ENVIRONMENT_AZURECLOUD]['apiVersion'][AZURE_RESOURCE_PROVIDER_ACTIVEDIRECTORY]
+        elsif authentication == AZURESTACK_AUTHENTICATION_TYPE_AZURECHINACLOUDAD
+          url = "#{AZURE_ENVIRONMENTS[ENVIRONMENT_AZURECHINACLOUD]['activeDirectoryEndpointUrl']}/#{azure_properties['tenant_id']}/oauth2/token"
+          api_version = AZURE_ENVIRONMENTS[ENVIRONMENT_AZURECHINACLOUD]['apiVersion'][AZURE_RESOURCE_PROVIDER_ACTIVEDIRECTORY]
         elsif authentication == AZURESTACK_AUTHENTICATION_TYPE_ADFS
           url = "https://adfs.#{domain}/adfs/oauth2/token"
         else

--- a/src/bosh_azure_cpi/spec/unit/helpers_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/helpers_spec.rb
@@ -334,6 +334,18 @@ describe Bosh::AzureCloud::Helpers do
         end
       end
 
+      context "when azure_stack.authentication is AzureChinaClouadAD" do
+        before do
+          azure_properties['azure_stack']['authentication'] = 'AzureChinaCloudAD'
+        end
+
+        it "should return Azure China Cloud authentication endpoint and api version" do
+          expect(
+            helpers_tester.get_azure_authentication_endpoint_and_api_version(azure_properties)
+          ).to eq(["https://login.chinacloudapi.cn/fake-tenant-id/oauth2/token", api_version])
+        end
+      end
+
       context "when azure_stack.authentication is ADFS" do
         before do
           azure_properties['azure_stack']['authentication'] = 'ADFS'


### PR DESCRIPTION
- [x] Please check this box and fill the data as below once you have run the unit tests.
      Code coverage before your change: `839 examples, 0 failures.3603 / 3667 LOC (98.25%) covered.`
      Code coverage with your change:   `840 examples, 0 failures. 3607 / 3671 LOC (98.26%) covered.`

### Changelog

* Support AzureChinaCloud AD as Azure Stack authentication