### PR TITLE
Fix issue: storage account in provisioning state should not be used

### DIFF
--- a/src/bosh_azure_cpi/lib/cloud/azure/stemcell_manager2.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/stemcell_manager2.rb
@@ -81,12 +81,9 @@ module Bosh::AzureCloud
       if location == default_storage_account[:location]
         storage_account_name = default_storage_account_name
       else
-        storage_account = @storage_account_manager.find_storage_account_by_tags(STEMCELL_STORAGE_ACCOUNT_TAGS, location)
-        if storage_account.nil?
-          # The storage account will only be used when preparing a stemcell in the target location for user image, ANY storage account type is ok.
-          # To make it consistent, `Standard_LRS' is used.
-          storage_account = @storage_account_manager.create_storage_account_by_tags(STEMCELL_STORAGE_ACCOUNT_TAGS, STORAGE_ACCOUNT_TYPE_STANDARD_LRS, location, [STEMCELL_CONTAINER], false)
-        end
+        # The storage account will only be used when preparing a stemcell in the target location for user image, ANY storage account type is ok.
+        # To make it consistent, `Standard_LRS' is used.
+        storage_account = @storage_account_manager.get_or_create_storage_account_by_tags(STEMCELL_STORAGE_ACCOUNT_TAGS, STORAGE_ACCOUNT_TYPE_STANDARD_LRS, location, [STEMCELL_CONTAINER], false)
         storage_account_name = storage_account[:name]
 
         mutex = FileMutex.new("#{CPI_LOCK_COPY_STEMCELL}-#{stemcell_name}-#{storage_account_name}", @logger, CPI_LOCK_COPY_STEMCELL_TIMEOUT)

--- a/src/bosh_azure_cpi/spec/unit/stemcell_manager2_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/stemcell_manager2_spec.rb
@@ -239,8 +239,7 @@ describe Bosh::AzureCloud::StemcellManager2 do
             let(:lock_copy_blob) { instance_double(Bosh::AzureCloud::Helpers::FileMutex) }
 
             before do
-              allow(storage_account_manager).to receive(:find_storage_account_by_tags).
-                with(STEMCELL_STORAGE_ACCOUNT_TAGS, location).
+              allow(storage_account_manager).to receive(:get_or_create_storage_account_by_tags).
                 and_return(storage_account)
               # The following two allows are for get_stemcell_info of stemcell_manager.rb
               allow(blob_manager).to receive(:get_blob_uri).
@@ -362,7 +361,7 @@ describe Bosh::AzureCloud::StemcellManager2 do
               context "when an error is thrown when creating the new storage account" do
                 before do
                   allow(storage_account_manager).to receive(:find_storage_account_by_tags).and_return(nil)
-                  allow(storage_account_manager).to receive(:create_storage_account_by_tags).
+                  allow(storage_account_manager).to receive(:get_or_create_storage_account_by_tags).
                     and_raise("Error when creating storage account")
                 end
 
@@ -413,7 +412,7 @@ describe Bosh::AzureCloud::StemcellManager2 do
               end
 
               it "should create a new user image and return the user image information" do
-                expect(storage_account_manager).to receive(:create_storage_account_by_tags).
+                expect(storage_account_manager).to receive(:get_or_create_storage_account_by_tags).
                   with(STEMCELL_STORAGE_ACCOUNT_TAGS, storage_account_type, location, ['stemcell'], false).
                   and_return(storage_account)
                 stemcell_info = stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location)


### PR DESCRIPTION
- [x] Please check this box and fill the data as below once you have run the unit tests.
      Code coverage before your change: `841 examples, 0 failures. 3616 / 3680 LOC (98.26%) covered.`
      Code coverage with your change: `841 examples, 0 failures. 3611 / 3675 LOC (98.26%) covered.`

  ```
  pushd src/bosh_azure_cpi
    ./bin/test-unit
  popd
  ```

  NOTE: Please see how to setup dev environment and run unit tests in docs/development.md.

### Changelog

* Fix issue the issue that storage account in provisioning state should not be used
