### PR TITLE
Move cloud property instance_type checking from vm_manager/create_vm to cloud/create_vm

### DIFF
--- a/src/bosh_azure_cpi/lib/cloud/azure/cloud.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/cloud.rb
@@ -150,6 +150,7 @@ module Bosh::AzureCloud
       # env may contain credentials so we must not log it
       @logger.info("create_vm(#{agent_id}, #{stemcell_id}, #{resource_pool}, #{networks}, #{disk_locality}, ...)")
       with_thread_name("create_vm(#{agent_id}, ...)") do
+        cloud_error("missing required cloud property `instance_type'.") if resource_pool['instance_type'].nil?
         extras = {"instance_type" => resource_pool.fetch("instance_type", 'unknown_instance_type')}
         @telemetry_manager.monitor("create_vm", id: agent_id, extras: extras) do
           # These resources should be in the same location for a VM: VM, NIC, disk(storage account or managed disk).
@@ -159,7 +160,7 @@ module Bosh::AzureCloud
           vnet = @azure_client2.get_virtual_network_by_name(network.resource_group_name, network.virtual_network_name)
           cloud_error("Cannot find the virtual network `#{network.virtual_network_name}' under resource group `#{network.resource_group_name}'") if vnet.nil?
           location = vnet[:location]
-          location_in_global_configuration = azure_properties['location'] 
+          location_in_global_configuration = azure_properties['location']
           if !location_in_global_configuration.nil? && location_in_global_configuration != location
             cloud_error("The location in the global configuration `#{location_in_global_configuration}' is different from the location of the virtual network `#{location}'")
           end

--- a/src/bosh_azure_cpi/lib/cloud/azure/helpers.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/helpers.rb
@@ -556,7 +556,7 @@ module Bosh::AzureCloud
     #     # Please note, the mutex should NOT be unlocked, because other processes will end mutex.wait and continue to use the shared resource if unlocked.
     #     # If your work is a long-running task,
     #     #   you need to call mutex.update() in do_something() to update the lock before it timeouts (60s in the example).
-    #     do_something() 
+    #     do_something()
     #     mutex.unlock
     #   else
     #     mutex.wait

--- a/src/bosh_azure_cpi/lib/cloud/azure/vm_manager.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/vm_manager.rb
@@ -19,7 +19,6 @@ module Bosh::AzureCloud
       resource_group_name = instance_id.resource_group_name()
       vm_name = instance_id.vm_name()
       vm_size = resource_pool.fetch('instance_type', nil)
-      cloud_error("missing required cloud property `instance_type'.") if vm_size.nil?
 
       # When both availability_zone and availability_set are specified, raise an error
       if !resource_pool['availability_zone'].nil? && !resource_pool['availability_set'].nil?

--- a/src/bosh_azure_cpi/spec/unit/cloud/create_vm_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/cloud/create_vm_spec.rb
@@ -37,6 +37,23 @@ describe Bosh::AzureCloud::Cloud do
         and_call_original
     end
 
+    context 'when instance_type is not provided' do
+      let(:resource_pool) { {} }
+
+      it 'should raise an error' do
+        expect {
+          cloud.create_vm(
+            agent_id,
+            stemcell_id,
+            resource_pool,
+            networks_spec,
+            disk_locality,
+            environment
+          )
+        }.to raise_error(/missing required cloud property `instance_type'./)
+      end
+    end
+
     context 'when vnet is not found' do
       before do
         allow(Bosh::AzureCloud::NetworkConfigurator).to receive(:new).

--- a/src/bosh_azure_cpi/spec/unit/vm_manager/create/invalid_option_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/vm_manager/create/invalid_option_spec.rb
@@ -5,24 +5,6 @@ describe Bosh::AzureCloud::VMManager do
   include_context "shared stuff for vm manager"
 
   describe "#create" do
-    context "when instance_type is not provided" do
-      let(:resource_pool) { {} }
-
-      it "should raise an error" do
-        expect(client2).not_to receive(:delete_virtual_machine)
-        expect(client2).not_to receive(:delete_network_interface)
-        expect(client2).to receive(:list_network_interfaces_by_keyword).with(resource_group_name, vm_name).and_return([])
-        expect(client2).to receive(:get_public_ip_by_name).
-          with(resource_group_name, vm_name).
-          and_return({ :ip_address => "public-ip" })
-        expect(client2).to receive(:delete_public_ip).with(resource_group_name, vm_name)
-
-        expect {
-          vm_manager.create(instance_id, location, stemcell_info, resource_pool, network_configurator, env)
-        }.to raise_error /missing required cloud property `instance_type'/
-      end
-    end
-
     context "when both availability_zone and availability_set are specified" do
       let(:resource_pool) {
         {
@@ -68,27 +50,6 @@ describe Bosh::AzureCloud::VMManager do
         expect {
           vm_manager.create(instance_id, location, stemcell_info, resource_pool, network_configurator, env)
         }.to raise_error /`#{zone}' is not a valid zone/
-      end
-    end
-
-    context "when an error is thrown during cleanup" do
-      let(:resource_pool) { {} } # missing required cloud property `instance_type' causes a cleanup
-
-      before do
-        allow(client2).to receive(:get_public_ip_by_name).
-          with(resource_group_name, vm_name).
-          and_return({ :ip_address => "public-ip" })
-        allow(client2).to receive(:delete_public_ip).with(resource_group_name, vm_name).and_raise("Error during cleanup")
-      end
-
-      it "should raise an error" do
-        expect(client2).not_to receive(:delete_virtual_machine)
-        expect(client2).not_to receive(:delete_network_interface)
-        expect(client2).to receive(:list_network_interfaces_by_keyword).with(resource_group_name, vm_name).and_return([])
-
-        expect {
-          vm_manager.create(instance_id, location, stemcell_info, resource_pool, network_configurator, env)
-        }.to raise_error /Error during cleanup/
       end
     end
 


### PR DESCRIPTION
--------------------MESSAGE FROM ADMIN, DELETE BEFORE SUBMITTING----------------------

Thanks for submitting a pull request!

All pull request submitters and commit authors must have a Contributor License Agreement (CLA) on-file with us. Please sign the appropriate CLA ([individual](http://cloudfoundry.org/pdfs/CFF_Individual_CLA.pdf) or [corporate](http://cloudfoundry.org/pdfs/CFF_Corporate_CLA.pdf)).

When sending signed CLA please provide your github username in case of individual CLA or the list of github usernames that can make pull requests on behalf of your organization.

If you are confident that you're covered under a Corporate CLA, please make sure you've publicized your membership in the appropriate Github Org, per [these instructions](https://help.github.com/articles/publicizing-or-concealing-organization-membership/).

--------------------MESSAGE FROM ADMIN, DELETE BEFORE SUBMITTING----------------------

- [x] Please check this box and fill the data as below once you have run the unit tests.
      Code coverage before your change: 3619 / 3683 LOC (98.26%) covered.
      Code coverage with your change:     3619 / 3683 LOC (98.26%) covered.

  ```
  pushd src/bosh_azure_cpi
    ./bin/test-unit
  popd
  ```

  NOTE: Please see how to setup dev environment and run unit tests in docs/development.md.

### Changelog

* Move cloud property `instance_type` checking from vm_manager/create_vm to cloud/create_vm.