### PR TITLE
Add EOFError as one of the retryable network errors

### DIFF
--- a/src/bosh_azure_cpi/lib/cloud/azure/azure_client2.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/azure_client2.rb
@@ -2104,7 +2104,7 @@ module Bosh::AzureCloud
           @logger.debug("get_token - request body:\n#{redact_credentials_in_request_body(request_body)}")
 
           response = http(uri).request(request)
-        rescue Net::OpenTimeout, Net::ReadTimeout, Errno::ECONNRESET => e
+        rescue Net::OpenTimeout, Net::ReadTimeout, Errno::ECONNRESET, EOFError => e
           if retry_count < AZURE_MAX_RETRY_COUNT
             @logger.warn("get_token - Fail for an error #{e.class.name}. Will retry after #{retry_after} seconds.")
             retry_count += 1

--- a/src/bosh_azure_cpi/lib/cloud/azure/azure_client2.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/azure_client2.rb
@@ -2215,7 +2215,7 @@ module Bosh::AzureCloud
           retry
         end
         raise e
-      rescue AzureInternalError, Net::OpenTimeout, Net::ReadTimeout, Errno::ECONNRESET => e
+      rescue AzureInternalError, Net::OpenTimeout, Net::ReadTimeout, Errno::ECONNRESET, EOFError => e
         if retry_count < AZURE_MAX_RETRY_COUNT
           @logger.warn("http_get_response - Fail for an error #{e.class.name}. Will retry after #{retry_after} seconds.")
           retry_count += 1


### PR DESCRIPTION
- [x] Please check this box and fill the data as below once you have run the unit tests.
      Code coverage before your change: 3619 / 3683 LOC (98.26%) covered.
      Code coverage with your change:   3619 / 3683 LOC (98.26%) covered.

  ```
  pushd src/bosh_azure_cpi
    ./bin/test-unit
  popd
  ```

  NOTE: Please see how to setup dev environment and run unit tests in docs/development.md.

### Changelog

*  Add EOFError as one of the retryable network errors
