### PR TITLE
Fix the issue that CPI takes more time to create the first VM than others in a deployment

### DIFF
--- a/src/bosh_azure_cpi/lib/cloud/azure/cloud.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/cloud.rb
@@ -25,7 +25,7 @@ module Bosh::AzureCloud
       @use_managed_disks = azure_properties['use_managed_disks']
 
       init_cpi_lock_dir
-      @telemetry_manager = Bosh::AzureCloud::TelemetryManager.new(azure_properties, @logger)
+      @telemetry_manager = Bosh::AzureCloud::TelemetryManager.new(azure_properties)
       @telemetry_manager.monitor("initialize") do
         init_registry
         init_azure

--- a/src/bosh_azure_cpi/lib/cloud/azure/helpers.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/helpers.rb
@@ -155,10 +155,13 @@ module Bosh::AzureCloud
     AZURESTACK_CA_CERT_RELATIVE_PATH            = 'azure_cpi/config/azure_stack_ca_cert.pem'
     SERVICE_PRINCIPAL_CERTIFICATE_RELATIVE_PATH = 'azure_cpi/config/service_principal_certificate.pem'
 
+    # Availability Zones
     AVAILABILITY_ZONES = ['1', '2', '3']
 
+    # Telemetry
     CPI_EVENTS_DIR                        = "/tmp/azure_cpi_events"
     CPI_EVENT_HANDLER_LAST_POST_TIMESTAMP = "/tmp/azure_cpi_events_last_update"
+    CPI_TELEMETRY_LOG_FILE                = "/tmp/azure_cpi_telemetry.log"
 
     ##
     # Raises CloudError exception

--- a/src/bosh_azure_cpi/lib/cloud/azure/telemetry/telemetry_event.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/telemetry/telemetry_event.rb
@@ -133,6 +133,7 @@ module Bosh::AzureCloud
     EVENTS_WITH_PROVIDER_FORMAT = "<Provider id=\"%{provider_id}\">%{event_xml_without_provider}</Provider>"
 
     def initialize(event_list)
+      raise "event_list must be an Array, but it is a #{event_list.class}" unless event_list.is_a?(Array)
       @event_list = event_list
     end
 
@@ -140,6 +141,10 @@ module Bosh::AzureCloud
     # <?xml version="1.0"?><TelemetryData version="1.0"><Provider id="69B669B9-4AF8-4C50-BDC4-6006FA76E975"><Event id="1"><![CDATA[<Param Name="Name" Value="BOSH-CPI" T="mt:wstr" /><Param Name="Version" Value="" T="mt:wstr" /><Param Name="Operation" Value="create_vm" T="mt:wstr" /><Param Name="OperationSuccess" Value="True" T="mt:bool" /><Param Name="Message" Value='{"msg":"Successed"}' T="mt:wstr" /><Param Name="Duration" Value="510.046195" T="mt:float64" /><Param Name="OSVersion" Value="Linux:ubuntu-14.04-trusty:4.4.0-53-generic" T="mt:wstr" /><Param Name="GAVersion" Value="WALinuxAgent-2.1.3" T="mt:wstr" /><Param Name="RAM" Value="6958" T="mt:uint64" /><Param Name="Processors" Value="2" T="mt:uint64" /><Param Name="VMName" Value="_b9c3354c-3275-4049-680f-3748ad0af496" T="mt:wstr" /><Param Name="TenantName" Value="8c1b2d76-a666-4958-a7ec-6ef464422ad1" T="mt:wstr" /><Param Name="RoleName" Value="_b9c3354c-3275-4049-680f-3748ad0af496" T="mt:wstr" /><Param Name="RoleInstanceName" Value="8c1b2d76-a666-4958-a7ec-6ef464422ad1._b9c3354c-3275-4049-680f-3748ad0af496" T="mt:wstr" /><Param Name="ContainerId" Value="edf9b1e3-90dd-4da5-9c23-6c9a2f419ddc" T="mt:wstr" />]]></Event></Provider></TelemetryData>
     def format_data_for_wire_server
       TELEMETRY_XML_FORMAT % {:events_string => to_xml}
+    end
+
+    def length
+      @event_list.length
     end
 
     private

--- a/src/bosh_azure_cpi/lib/cloud/azure/telemetry/wire_client.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/telemetry/wire_client.rb
@@ -25,9 +25,9 @@ module Bosh::AzureCloud
 
     # Post data to wireserver
     #
-    # @param [String] event_data - Data formatted as XML string
+    # @param [TelemetryEventList] event_list - events to be sent
     #
-    def post_data(event_data)
+    def post_data(event_list)
       endpoint = get_endpoint()
 
       unless endpoint.nil?
@@ -35,7 +35,7 @@ module Bosh::AzureCloud
         retried = false
         begin
           request = Net::HTTP::Post.new(uri)
-          request.body = event_data
+          request.body = event_list.format_data_for_wire_server
           TELEMETRY_HEADER.keys.each do |key|
             request[key] = TELEMETRY_HEADER[key]
           end
@@ -43,7 +43,7 @@ module Bosh::AzureCloud
 
           status_code = res.code.to_i
           if status_code == 200
-            @logger.debug("[Telemetry] Data posted")
+            @logger.debug("[Telemetry] Data posted: #{event_list.length} event(s)")
           elsif RETRY_ERROR_CODES.include?(status_code)
             raise RetriableError, "POST response - code: #{res.code}\nbody:#{res.body}"
           else

--- a/src/bosh_azure_cpi/spec/spec_helper.rb
+++ b/src/bosh_azure_cpi/spec/spec_helper.rb
@@ -10,6 +10,7 @@ require 'json'
 require 'net/http'
 require 'stringio'
 require 'fileutils'
+require 'bosh/cpi'
 
 MOCK_AZURE_SUBSCRIPTION_ID        = 'aa643f05-5b67-4d58-b433-54c2e9131a59'
 MOCK_DEFAULT_STORAGE_ACCOUNT_NAME = '8853f441db154b438550a853'

--- a/src/bosh_azure_cpi/spec/unit/telemetry/telemetry_event_handler_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/telemetry/telemetry_event_handler_spec.rb
@@ -33,6 +33,7 @@ describe Bosh::AzureCloud::TelemetryEventHandler do
           expect(event_handler).to receive(:collect_events).once
           expect(event_handler).to receive(:send_events).once
           expect(event_handler).to receive(:update_last_post_timestamp).once
+          expect(mutex).to receive(:update)
           expect(mutex).to receive(:unlock)
           expect{
             event_handler.collect_and_send_events
@@ -53,6 +54,7 @@ describe Bosh::AzureCloud::TelemetryEventHandler do
           expect(event_handler).to receive(:collect_events).once
           expect(event_handler).to receive(:send_events).once
           expect(event_handler).to receive(:update_last_post_timestamp).once
+          expect(mutex).to receive(:update)
           expect(mutex).to receive(:unlock)
           expect{
             event_handler.collect_and_send_events
@@ -76,6 +78,7 @@ describe Bosh::AzureCloud::TelemetryEventHandler do
           expect(event_handler).not_to receive(:update_last_post_timestamp)
 
           expect(logger).to receive(:warn).with(/unexpected error/)
+          expect(mutex).to receive(:update)
           expect(mutex).to receive(:unlock)
 
           expect{
@@ -214,8 +217,7 @@ describe Bosh::AzureCloud::TelemetryEventHandler do
     end
 
     it "should send the events" do
-      expect(event_list).to receive(:format_data_for_wire_server)
-      expect(wire_client).to receive(:post_data)
+      expect(wire_client).to receive(:post_data).with(event_list)
       expect{
         event_handler.send(:send_events, event_list)
       }.not_to raise_error

--- a/src/bosh_azure_cpi/spec/unit/telemetry/telemetry_event_list_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/telemetry/telemetry_event_list_spec.rb
@@ -1,6 +1,39 @@
 require 'spec_helper'
 
 describe Bosh::AzureCloud::TelemetryEventList do
+  describe "#initialize" do
+    context "when event_list is an Array" do
+      let(:param) { [] }
+      it "should not raise an error" do
+        expect{
+          Bosh::AzureCloud::TelemetryEventList.new(param)
+        }.not_to raise_error
+      end
+    end
+
+    context "when event_list is not an Array" do
+      let(:param) { nil }
+      it "should raise an error" do
+        expect{
+          Bosh::AzureCloud::TelemetryEventList.new(param)
+        }.to raise_error /event_list must be an Array/
+      end
+    end
+  end
+
+  describe "#length" do
+    let(:parameter1) { Bosh::AzureCloud::TelemetryEventParam.new("fake-name1", "fake-value1") }
+    let(:parameter2) { Bosh::AzureCloud::TelemetryEventParam.new("fake-name2", "fake-value2") }
+    let(:event1) { Bosh::AzureCloud::TelemetryEvent.new("fake-event-id", "fake-provider-id", parameters: [parameter1, parameter2]) }
+    let(:event2) { Bosh::AzureCloud::TelemetryEvent.new("fake-event-id", "fake-provider-id", parameters: [parameter1, parameter2]) }
+
+    let(:event_list) { Bosh::AzureCloud::TelemetryEventList.new([event1, event2]) }
+
+    it "should return with right value" do
+      expect(event_list.length).to eq(2)
+    end
+  end
+
   describe "#format_data_for_wire_server" do
     let(:parameter1) { Bosh::AzureCloud::TelemetryEventParam.new("fake-name1", "fake-value1") }
     let(:parameter2) { Bosh::AzureCloud::TelemetryEventParam.new("fake-name2", "fake-value2") }

--- a/src/bosh_azure_cpi/spec/unit/telemetry/wire_client_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/telemetry/wire_client_spec.rb
@@ -6,6 +6,13 @@ describe Bosh::AzureCloud::WireClient do
     let(:logger) { instance_double(Logger) }
     let(:wire_client) { Bosh::AzureCloud::WireClient.new(logger) }
     let(:event_data) { "fake-event-data" }
+    let(:event_list) { instance_double(Bosh::AzureCloud::TelemetryEventList) }
+    let(:event_length) { 1 }
+
+    before do
+      allow(event_list).to receive(:format_data_for_wire_server).and_return(event_data)
+      allow(event_list).to receive(:length).and_return(event_length)
+    end
 
     context "when it gets wire server endpoint successfully" do
       let(:endpoint) { "fake-endpoint" }
@@ -21,10 +28,10 @@ describe Bosh::AzureCloud::WireClient do
       it "should post the data one time if post request returns 200" do
         stub_request(:post, wire_server_uri).with(body: event_data, headers: headers).
           to_return(:status => 200)
-        expect(logger).to receive(:debug).with("[Telemetry] Data posted")
+        expect(logger).to receive(:debug).with("[Telemetry] Data posted: #{event_length} event(s)")
 
         expect {
-          wire_client.post_data(event_data)
+          wire_client.post_data(event_list)
         }.not_to raise_error
       end
 
@@ -36,7 +43,7 @@ describe Bosh::AzureCloud::WireClient do
         expect(wire_client).to receive(:sleep)
 
         expect {
-          wire_client.post_data(event_data)
+          wire_client.post_data(event_list)
         }.not_to raise_error
       end
 
@@ -46,7 +53,7 @@ describe Bosh::AzureCloud::WireClient do
         expect(logger).to receive(:warn).with(/Failed to POST request/)
 
         expect {
-          wire_client.post_data(event_data)
+          wire_client.post_data(event_list)
         }.not_to raise_error
       end
 
@@ -58,7 +65,7 @@ describe Bosh::AzureCloud::WireClient do
         expect(wire_client).to receive(:sleep)
 
         expect {
-          wire_client.post_data(event_data)
+          wire_client.post_data(event_list)
         }.not_to raise_error
       end
     end
@@ -74,7 +81,7 @@ describe Bosh::AzureCloud::WireClient do
         expect(logger).to receive(:warn).with("[Telemetry] Wire server endpoint is nil, drop data")
 
         expect {
-          wire_client.post_data(event_data)
+          wire_client.post_data(event_list)
         }.not_to raise_error
       end
     end


### PR DESCRIPTION
- [x] Please check this box and fill the data as below once you have run the unit tests.
      Code coverage before your change: `850 examples, 0 failures. 3619 / 3683 LOC (98.26%) covered.`
      Code coverage with your change: `853 examples, 0 failures. 3624 / 3693 LOC (98.13%) covered.` simplecov is not picking up coverage of code during fork, that is why code coverage declined.

  ```
  pushd src/bosh_azure_cpi
    ./bin/test-unit
  popd
  ```

  NOTE: Please see how to setup dev environment and run unit tests in docs/development.md.

### Changelog

* CPI should not wait for telemetry to complete
