### PR TITLE
Raise error if get_blob_properties can't find the storage account

### DIFF
--- a/src/bosh_azure_cpi/lib/cloud/azure/blob_manager.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/blob_manager.rb
@@ -409,6 +409,7 @@ module Bosh::AzureCloud
       @blob_client_mutex.synchronize do
         unless @storage_accounts.has_key?(storage_account_name)
           storage_account = @azure_client2.get_storage_account_by_name(storage_account_name)
+          cloud_error("initialize_blob_client: Storage account `#{storage_account_name}' not found") if storage_account.nil?
           keys = @azure_client2.get_storage_account_keys_by_name(storage_account_name)
           storage_account[:key] = keys[0]
           @storage_accounts[storage_account_name] = storage_account

--- a/src/bosh_azure_cpi/spec/unit/blob_manager_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/blob_manager_spec.rb
@@ -242,6 +242,20 @@ describe Bosh::AzureCloud::BlobManager do
   end
 
   describe "#get_blob_properties" do
+    context "when storage account does not exist" do
+      before do
+        allow(azure_client2).to receive(:get_storage_account_by_name).
+          with(MOCK_DEFAULT_STORAGE_ACCOUNT_NAME).
+          and_return(nil)
+      end
+
+      it "should raise error" do
+        expect {
+          blob_manager.get_blob_properties(MOCK_DEFAULT_STORAGE_ACCOUNT_NAME, container_name, blob_name)
+        }.to raise_error("initialize_blob_client: Storage account `#{MOCK_DEFAULT_STORAGE_ACCOUNT_NAME}' not found")
+      end
+    end
+
     context "when blob exists" do
       let(:blob) { instance_double(Azure::Storage::Blob::Blob) }
       let(:properties) { { "foo" => "bar" } }


### PR DESCRIPTION
--------------------MESSAGE FROM ADMIN, DELETE BEFORE SUBMITTING----------------------

Thanks for submitting a pull request!

All pull request submitters and commit authors must have a Contributor License Agreement (CLA) on-file with us. Please sign the appropriate CLA ([individual](http://cloudfoundry.org/pdfs/CFF_Individual_CLA.pdf) or [corporate](http://cloudfoundry.org/pdfs/CFF_Corporate_CLA.pdf)).

When sending signed CLA please provide your github username in case of individual CLA or the list of github usernames that can make pull requests on behalf of your organization.

If you are confident that you're covered under a Corporate CLA, please make sure you've publicized your membership in the appropriate Github Org, per [these instructions](https://help.github.com/articles/publicizing-or-concealing-organization-membership/).

--------------------MESSAGE FROM ADMIN, DELETE BEFORE SUBMITTING----------------------

- [x] Please check this box and fill the data as below once you have run the unit tests.
      Code coverage before your change: 854 examples, 0 failures. 3624 / 3693 LOC (98.13%) covered.
      Code coverage with your change:   855 examples, 0 failures. 3625 / 3694 LOC (98.13%) covered.

  ```
  pushd src/bosh_azure_cpi
    ./bin/test-unit
  popd
  ```

  NOTE: Please see how to setup dev environment and run unit tests in docs/development.md.

### Changelog

* Raise error if get_blob_properties can't find the storage account
