### PR TITLE
[DO NOT MERGE] Add how to use Azure Stack storage blobstore

### DIFF
--- a/docs/advanced/azure-stack/use-azure-stack-storage-blobstore.yml
+++ b/docs/advanced/azure-stack/use-azure-stack-storage-blobstore.yml
@@ -1,0 +1,192 @@
+---
+- type: remove
+  path: /instance_groups/name=singleton-blobstore
+
+- type: remove
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/buildpacks
+- type: remove
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/droplets
+- type: remove
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/packages
+- type: remove
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/resource_pool
+
+- type: remove
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/buildpacks
+- type: remove
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/droplets
+- type: remove
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/packages
+- type: remove
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/resource_pool
+
+- type: remove
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/buildpacks
+- type: remove
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/droplets
+- type: remove
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/packages
+- type: remove
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/resource_pool
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/buildpacks?/fog_connection?
+  value: &blobstore-properties
+    provider: AzureRM
+    environment: ((environment))
+    azure_storage_account_name: ((blobstore_storage_account_name))
+    azure_storage_access_key: ((blobstore_storage_access_key))
+    azure_storage_dns_suffix: ((blobstore_storage_dns_suffix))
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/droplets?/fog_connection?
+  value: *blobstore-properties
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/packages?/fog_connection?
+  value: *blobstore-properties
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/resource_pool?/fog_connection?
+  value: *blobstore-properties
+
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/buildpacks?/fog_connection?
+  value: *blobstore-properties
+
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/droplets?/fog_connection?
+  value: *blobstore-properties
+
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/packages?/fog_connection?
+  value: *blobstore-properties
+
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/resource_pool?/fog_connection?
+  value: *blobstore-properties
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/buildpacks?/fog_connection?
+  value: *blobstore-properties
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/droplets?/fog_connection?
+  value: *blobstore-properties
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/packages?/fog_connection?
+  value: *blobstore-properties
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/resource_pool?/fog_connection?
+  value: *blobstore-properties
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/buildpacks/webdav_config?
+  value: &webdav_config
+    public_endpoint: blobstore.((system_domain))
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/droplets/webdav_config?
+  value: *webdav_config
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/packages/webdav_config?
+  value: *webdav_config
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/resource_pool/webdav_config?
+  value: *webdav_config
+
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/buildpacks/webdav_config?
+  value: *webdav_config
+
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/droplets/webdav_config?
+  value: *webdav_config
+
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/packages/webdav_config?
+  value: *webdav_config
+
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/resource_pool/webdav_config?
+  value: *webdav_config
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/buildpacks/webdav_config?
+  value: *webdav_config
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/droplets/webdav_config?
+  value: *webdav_config
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/packages/webdav_config?
+  value: *webdav_config
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/resource_pool/webdav_config?
+  value: *webdav_config
+
+# replace Azure Storage container names
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/buildpacks/buildpack_directory_key?
+  value: ((buildpack_directory_key))
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/droplets/droplet_directory_key?
+  value: ((droplet_directory_key))
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/packages/app_package_directory_key?
+  value: ((app_package_directory_key))
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/resource_pool/resource_directory_key?
+  value: ((resource_directory_key))
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/buildpacks/buildpack_directory_key?
+  value: ((buildpack_directory_key))
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/droplets/droplet_directory_key?
+  value: ((droplet_directory_key))
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/packages/app_package_directory_key?
+  value: ((app_package_directory_key))
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/resource_pool/resource_directory_key?
+  value: ((resource_directory_key))
+
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/buildpacks/buildpack_directory_key?
+  value: ((buildpack_directory_key))
+
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/droplets/droplet_directory_key?
+  value: ((droplet_directory_key))
+
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/packages/app_package_directory_key?
+  value: ((app_package_directory_key))
+
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/resource_pool/resource_directory_key?
+  value: ((resource_directory_key))
+
+# remove unnecessary variables for internal blobstore
+
+- type: remove
+  path: /variables/name=blobstore_admin_users_password
+
+- type: remove
+  path: /variables/name=blobstore_secure_link_secret
+
+- type: remove
+  path: /variables/name=blobstore_tls


### PR DESCRIPTION
No need to run unit tests.

This PR needs to be merged after:
* [x] https://github.com/fog/fog-azure-rm/pull/386 is merged
* [ ] Use the branch `fog-arm-cf` of `fog-azure-rm` in [cloud_controller_ng gem](https://github.com/cloudfoundry/cloud_controller_ng/blob/565510a6d930835caf2b50509c261180716cbaf8/Gemfile#L52)
* [ ] Bump cloud_controller_ng in capi-release

### Changelog

* Add how to use Azure Stack storage blobstore
