### PR TITLE
Turn off diagnostics metrics and boot diagnostics by default

### DIFF
--- a/jobs/azure_cpi/spec
+++ b/jobs/azure_cpi/spec
@@ -63,10 +63,10 @@ properties:
     default: false
   azure.enable_telemetry:
     description: Enable telemetry on CPI calls
-    default: true
+    default: false
   azure.enable_vm_boot_diagnostics:
     description: Enable VM boot diagnostics
-    default: true
+    default: false
   azure.azure_stack.domain:
     description: The domain for your AzureStack deployment
     default: local.azurestack.external

--- a/src/bosh_azure_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
@@ -69,10 +69,10 @@ describe 'cpi.json.erb' do
             'parallel_upload_thread_num'  => 16,
             'debug_mode'                  => false,
             'keep_failed_vms'             => false,
-            'enable_telemetry'            => true,
+            'enable_telemetry'            => false,
             'use_managed_disks'           => false,
             'pip_idle_timeout_in_minutes' => 4,
-            'enable_vm_boot_diagnostics'  => true
+            'enable_vm_boot_diagnostics'  => false
           },
           'registry'=>{
             'address'=>'registry-host.example.com',
@@ -234,6 +234,16 @@ describe 'cpi.json.erb' do
       end
     end
 
+    context 'when the enable_telemetry is enabled' do
+      before do
+        manifest['properties']['azure']['enable_telemetry'] = true
+      end
+
+      it 'is able to render enable_telemetry to true' do
+        expect(subject['cloud']['properties']['azure']['enable_telemetry']).to be(true)
+      end
+    end
+
     context 'when the enable_vm_boot_diagnostics is disabled' do
       before do
         manifest['properties']['azure']['enable_vm_boot_diagnostics'] = false
@@ -241,6 +251,16 @@ describe 'cpi.json.erb' do
 
       it 'is able to render enable_vm_boot_diagnostics to false' do
         expect(subject['cloud']['properties']['azure']['enable_vm_boot_diagnostics']).to be(false)
+      end
+    end
+
+    context 'when the enable_vm_boot_diagnostics is enabled' do
+      before do
+        manifest['properties']['azure']['enable_vm_boot_diagnostics'] = true
+      end
+
+      it 'is able to render enable_vm_boot_diagnostics to true' do
+        expect(subject['cloud']['properties']['azure']['enable_vm_boot_diagnostics']).to be(true)
       end
     end
 


### PR DESCRIPTION
- [x] Please check this box and fill the data as below once you have run the unit tests.
      Code coverage before your change: `854 examples, 0 failures. 3624 / 3693 LOC (98.13%) covered.`
      Code coverage with your change: `856 examples, 0 failures. 3624 / 3693 LOC (98.13%) covered.`

  ```
  pushd src/bosh_azure_cpi
    ./bin/test-unit
  popd
  ```

  NOTE: Please see how to setup dev environment and run unit tests in docs/development.md.

### Changelog

* Turn off diagnostics metrics and boot diagnostics by default, as discussed in #399.
