### PR TITLE
Increase timeout of creating storage account

### DIFF
--- a/src/bosh_azure_cpi/lib/cloud/azure/helpers.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/helpers.rb
@@ -123,15 +123,16 @@ module Bosh::AzureCloud
     MINIMUM_REQUIRED_OS_DISK_SIZE_IN_GB_WINDOWS = 128
 
     # Lock
-    CPI_LOCK_DIR                         = "/tmp/azure_cpi"
-    CPI_LOCK_PREFIX                      = "bosh-lock"
-    CPI_LOCK_CREATE_STORAGE_ACCOUNT      = "#{CPI_LOCK_PREFIX}-create-storage-account"
-    CPI_LOCK_COPY_STEMCELL               = "#{CPI_LOCK_PREFIX}-copy-stemcell"
-    CPI_LOCK_COPY_STEMCELL_TIMEOUT       = 180 # seconds
-    CPI_LOCK_CREATE_USER_IMAGE           = "#{CPI_LOCK_PREFIX}-create-user-image"
-    CPI_LOCK_PREFIX_AVAILABILITY_SET     = "#{CPI_LOCK_PREFIX}-availability-set"
-    CPI_LOCK_DELETE                      = "#{CPI_LOCK_DIR}/DELETING-LOCKS"
-    CPI_LOCK_EVENT_HANDLER               = "#{CPI_LOCK_PREFIX}-event-handler"
+    CPI_LOCK_DIR                            = "/tmp/azure_cpi"
+    CPI_LOCK_PREFIX                         = "bosh-lock"
+    CPI_LOCK_CREATE_STORAGE_ACCOUNT         = "#{CPI_LOCK_PREFIX}-create-storage-account"
+    CPI_LOCK_CREATE_STORAGE_ACCOUNT_TIMEOUT = 300 # seconds
+    CPI_LOCK_COPY_STEMCELL                  = "#{CPI_LOCK_PREFIX}-copy-stemcell"
+    CPI_LOCK_COPY_STEMCELL_TIMEOUT          = 180 # seconds
+    CPI_LOCK_CREATE_USER_IMAGE              = "#{CPI_LOCK_PREFIX}-create-user-image"
+    CPI_LOCK_PREFIX_AVAILABILITY_SET        = "#{CPI_LOCK_PREFIX}-availability-set"
+    CPI_LOCK_DELETE                         = "#{CPI_LOCK_DIR}/DELETING-LOCKS"
+    CPI_LOCK_EVENT_HANDLER                  = "#{CPI_LOCK_PREFIX}-event-handler"
     class LockError < Bosh::Clouds::CloudError; end
     class LockTimeoutError < LockError; end
     class LockNotFoundError < LockError; end

--- a/src/bosh_azure_cpi/lib/cloud/azure/storage_account_manager.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/storage_account_manager.rb
@@ -39,7 +39,7 @@ module Bosh::AzureCloud
     def get_or_create_storage_account(name, tags, type, location, containers, is_default_storage_account)
       @logger.debug("get_or_create_storage_account(#{name}, #{tags}, #{type}, #{location}, #{containers}, #{is_default_storage_account})")
       lock_file = "#{CPI_LOCK_CREATE_STORAGE_ACCOUNT}-#{name}"
-      mutex = FileMutex.new(lock_file, @logger)
+      mutex = FileMutex.new(lock_file, @logger, CPI_LOCK_CREATE_STORAGE_ACCOUNT_TIMEOUT)
       begin
         if mutex.lock
           storage_account = find_storage_account_by_name(name) # make sure the storage account is not yet created by other process
@@ -101,7 +101,7 @@ module Bosh::AzureCloud
     def get_or_create_storage_account_by_tags(tags, type, location, containers, is_default_storage_account)
       @logger.debug("get_or_create_storage_account_by_tags(#{tags}, #{type}, #{location}, #{containers}, #{is_default_storage_account})")
       lock_file = "#{CPI_LOCK_CREATE_STORAGE_ACCOUNT}-#{location}-#{Digest::MD5.hexdigest(tags.to_s)}"
-      mutex = FileMutex.new(lock_file, @logger)
+      mutex = FileMutex.new(lock_file, @logger, CPI_LOCK_CREATE_STORAGE_ACCOUNT_TIMEOUT)
       begin
         if mutex.lock
           storage_account = find_storage_account_by_tags(tags, location) # make sure the storage account is not yet created by other process

--- a/src/bosh_azure_cpi/spec/spec_helper.rb
+++ b/src/bosh_azure_cpi/spec/spec_helper.rb
@@ -44,6 +44,8 @@ STEMCELL_STORAGE_ACCOUNT_TAGS   = {
   'type' => 'stemcell'
 }
 
+CPI_LOCK_CREATE_STORAGE_ACCOUNT_TIMEOUT = 300
+
 def mock_cloud_options
   {
     'plugin'     => 'azure',

--- a/src/bosh_azure_cpi/spec/unit/storage_account_manager_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/storage_account_manager_spec.rb
@@ -65,9 +65,12 @@ describe Bosh::AzureCloud::StorageAccountManager do
 
     let(:storage_account) { double('storage-account') }
     let(:lock_creating_storage_account) { instance_double(Bosh::AzureCloud::Helpers::FileMutex) }
+    let(:lock_file) { "bosh-lock-create-storage-account-#{name}" }
 
     before do
-      allow(Bosh::AzureCloud::Helpers::FileMutex).to receive(:new).and_return(lock_creating_storage_account)
+      allow(Bosh::AzureCloud::Helpers::FileMutex).to receive(:new).
+        with(lock_file, anything, CPI_LOCK_CREATE_STORAGE_ACCOUNT_TIMEOUT).
+        and_return(lock_creating_storage_account)
     end
 
     context 'when lock is not acquired' do
@@ -267,7 +270,7 @@ describe Bosh::AzureCloud::StorageAccountManager do
 
     before do
       allow(Bosh::AzureCloud::Helpers::FileMutex).to receive(:new).
-        with(lock_file, anything).
+        with(lock_file, anything, CPI_LOCK_CREATE_STORAGE_ACCOUNT_TIMEOUT).
         and_return(lock)
     end
 


### PR DESCRIPTION
- [x] Please check this box and fill the data as below once you have run the unit tests.
      Code coverage before your change: `857 examples, 0 failures. 3626 / 3695 LOC (98.13%) covered.`
      Code coverage with your change: `857 examples, 0 failures. 3626 / 3695 LOC (98.13%) covered.`

  ```
  pushd src/bosh_azure_cpi
    ./bin/test-unit
  popd
  ```

  NOTE: Please see how to setup dev environment and run unit tests in docs/development.md.

### Changelog

* Increase timeout of creating storage account
