### PR TITLE
Raise an error if the default storage account is specified but it does not exist

### DIFF
--- a/src/bosh_azure_cpi/lib/cloud/azure/storage_account_manager.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/storage_account_manager.rb
@@ -221,6 +221,7 @@ module Bosh::AzureCloud
         storage_account_name = @azure_properties['storage_account_name']
         @logger.debug("The default storage account is `#{storage_account_name}'")
         @default_storage_account = @azure_client2.get_storage_account_by_name(storage_account_name)
+        cloud_error("The default storage account `#{storage_account_name}' is specified in Global Configuration, but it does not exist.") if @default_storage_account.nil?
         if @use_managed_disks && !is_stemcell_storage_account?(@default_storage_account[:tags])
           @azure_client2.update_tags_of_storage_account(storage_account_name, STEMCELL_STORAGE_ACCOUNT_TAGS)
         end

--- a/src/bosh_azure_cpi/spec/unit/storage_account_manager_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/storage_account_manager_spec.rb
@@ -759,6 +759,18 @@ describe Bosh::AzureCloud::StorageAccountManager do
     end
 
     context 'When the global configurations contain storage_account_name' do
+      context 'when the storage account does not exist' do
+        before do
+          allow(client2).to receive(:get_storage_account_by_name).with(MOCK_DEFAULT_STORAGE_ACCOUNT_NAME).and_return(nil)
+        end
+
+        it 'should raise an error' do
+          expect{
+            storage_account_manager.default_storage_account
+          }.to raise_error /The default storage account `#{MOCK_DEFAULT_STORAGE_ACCOUNT_NAME}' is specified in Global Configuration, but it does not exist./
+        end
+      end
+
       context 'When use_managed_disks is false' do
         it 'should return the default storage account, and do not set the tags' do
           expect(client2).not_to receive(:update_tags_of_storage_account)


### PR DESCRIPTION
- [x] Please check this box and fill the data as below once you have run the unit tests.
      Code coverage before your change: `857 examples, 0 failures. 3626 / 3695 LOC (98.13%) covered.`
      Code coverage with your change: `858 examples, 0 failures. 3627 / 3696 LOC (98.13%) covered.`

  ```
  pushd src/bosh_azure_cpi
    ./bin/test-unit
  popd
  ```

  NOTE: Please see how to setup dev environment and run unit tests in docs/development.md.

### Changelog

* Raise an error if the default storage account is specified but it does not exist
