### PR TITLE
 Bump to ruby 2.4.4

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,3 +1,3 @@
 export RELEASE_DIR=$PWD
 export SRC_DIR=$PWD/src/bosh_azure_cpi
-export PROJECT_RUBY_VERSION=2.4.2
+export PROJECT_RUBY_VERSION=2.4.4

--- a/.final_builds/packages/ruby-2.4-r4/index.yml
+++ b/.final_builds/packages/ruby-2.4-r4/index.yml
@@ -1,0 +1,6 @@
+builds:
+  0cdc60ed7fdb326e605479e9275346200af30a25:
+    version: 0cdc60ed7fdb326e605479e9275346200af30a25
+    blobstore_id: 0e6aa794-528b-4500-68fc-c291d700786a
+    sha1: 3f1809b9d7e326d8a701de516fb51ea4245913c6
+format-version: "2"

--- a/ci/docker/boshcpi.azure-cpi-release/Dockerfile
+++ b/ci/docker/boshcpi.azure-cpi-release/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:15.04
+FROM ubuntu:16.04
 
 RUN apt-get update; apt-get -y upgrade; apt-get clean
 
@@ -8,11 +8,10 @@ RUN apt-get install -y git curl tar make jq; apt-get clean
 RUN apt-get install -y build-essential zlibc zlib1g-dev ruby ruby-dev openssl libxslt-dev libxml2-dev libssl-dev libreadline6 libreadline6-dev libyaml-dev libsqlite3-dev sqlite3; apt-get clean
 
 # azure-cli
-RUN echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ wheezy main" | \
-    tee /etc/apt/sources.list.d/azure-cli.list
-RUN apt-key adv --keyserver packages.microsoft.com --recv-keys 417A0893
+RUN echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ xenial main" | tee /etc/apt/sources.list.d/azure-cli.list
+RUN curl -L https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
 RUN apt-get install -y apt-transport-https
-RUN apt-get update; apt-get install -y azure-cli=2.0.18-1; apt-get clean; az -v
+RUN apt-get update; apt-get install -y azure-cli=2.0.41-1~xenial; apt-get clean; az -v
 
 # chruby
 RUN /bin/bash -l -c " \

--- a/ci/docker/boshcpi.azure-cpi-release/Dockerfile
+++ b/ci/docker/boshcpi.azure-cpi-release/Dockerfile
@@ -33,7 +33,7 @@ RUN /bin/bash -l -c " \
 "
 
 # ruby
-ENV RUBY_VERSION 2.4.2
+ENV RUBY_VERSION 2.4.4
 RUN ruby-install ruby ${RUBY_VERSION}
 
 # Bundler

--- a/docs/development.md
+++ b/docs/development.md
@@ -27,9 +27,9 @@
     sudo tar -C /usr/local -xzf go1.9.3.linux-amd64.tar.gz
     rm go1.9.3.linux-amd64.tar.gz
     mkdir ~/go
-    echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.bashrc
-    echo 'export GOPATH=$HOME/go' >> ~/.bashrc
-    exec $SHELL
+    echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.profile
+    echo 'export GOPATH=$HOME/go' >> ~/.profile
+    source ~/.profile
     ```
 
 1. Install direnv
@@ -43,13 +43,13 @@
       make
       sudo make install
     popd
-    echo 'eval "$(direnv hook bash)"' >> ~/.bashrc
-    exec $SHELL
+    echo 'eval "$(direnv hook bash)"' >> ~/.profile
+    source ~/.profile
     ```
 
 1. Install ruby
 
-    Please make sure you have installed ruby `2.4.2` before you start.
+    Please make sure you have installed ruby `2.4.4` before you start.
 
     ```bash
     cd ~/workspace
@@ -57,9 +57,9 @@
     tar -xzvf chruby-0.3.9.tar.gz
     pushd chruby-0.3.9/
       sudo make install
-      echo 'source /usr/local/share/chruby/chruby.sh' >> ~/.bashrc
+      echo 'source /usr/local/share/chruby/chruby.sh' >> ~/.profile
     popd
-    exec $SHELL
+    source ~/.profile
 
     wget -O ruby-install-0.6.1.tar.gz https://github.com/postmodern/ruby-install/archive/v0.6.1.tar.gz
     tar -xzvf ruby-install-0.6.1.tar.gz
@@ -67,9 +67,9 @@
       sudo make install
     popd
 
-    ruby-install ruby 2.4.2
-    echo 'chruby 2.4.2' >> ~/.bashrc
-    exec $SHELL
+    ruby-install ruby 2.4.4
+    echo 'chruby 2.4.4' >> ~/.profile
+    source ~/.profile
     ruby -v
     ```
 
@@ -142,7 +142,7 @@ You can use `bosh_azure_console` to test your code changes quickly.
   gem install pg --version 0.20.0 --no-ri --no-rdoc
 
   # Workaround for the issue https://github.com/cloudfoundry/bosh/issues/1621
-  sed -i -e '23s/^/#/' ~/.gem/ruby/2.4.2/gems/bosh-registry-1.3262.24.0/lib/bosh/registry.rb
+  sed -i -e '23s/^/#/' ~/.gem/ruby/2.4.4/gems/bosh-registry-1.3262.24.0/lib/bosh/registry.rb
 
   cat > ~/workspace/registry.cfg <<EOS
   ---

--- a/jobs/azure_cpi/spec
+++ b/jobs/azure_cpi/spec
@@ -8,7 +8,7 @@ templates:
   service_principal_certificate.pem.erb: config/service_principal_certificate.pem
 
 packages:
-- ruby-2.4-r3
+- ruby-2.4-r4
 - bosh_azure_cpi
 
 properties:

--- a/jobs/azure_cpi/templates/cpi.erb
+++ b/jobs/azure_cpi/templates/cpi.erb
@@ -2,6 +2,11 @@
 
 set -e
 
+BOSH_PACKAGES_DIR=${BOSH_PACKAGES_DIR:-/var/vcap/packages}
+source ${BOSH_PACKAGES_DIR}/ruby-2.4-r4/bosh/runtime.env
+BOSH_JOBS_DIR=${BOSH_JOBS_DIR:-/var/vcap/jobs}
+export HOME=~
+
 <% if_p('env.http_proxy') do |http_proxy| %>
 export HTTP_PROXY="<%= http_proxy %>"
 export http_proxy="<%= http_proxy %>"
@@ -17,16 +22,7 @@ export NO_PROXY="<%= no_proxy %>"
 export no_proxy="<%= no_proxy %>"
 <% end %>
 
-BOSH_PACKAGES_DIR=${BOSH_PACKAGES_DIR:-/var/vcap/packages}
-BOSH_JOBS_DIR=${BOSH_JOBS_DIR:-/var/vcap/jobs}
-export HOME=~
-
-PATH=$BOSH_PACKAGES_DIR/ruby-2.4-r3/bin:$PATH
-export PATH
-
 export BUNDLE_GEMFILE=$BOSH_PACKAGES_DIR/bosh_azure_cpi/Gemfile
 
-bundle_cmd="$BOSH_PACKAGES_DIR/ruby-2.4-r3/bin/bundle"
-
-exec $bundle_cmd exec $BOSH_PACKAGES_DIR/bosh_azure_cpi/bin/azure_cpi \
+exec bundle exec $BOSH_PACKAGES_DIR/bosh_azure_cpi/bin/azure_cpi \
   $BOSH_JOBS_DIR/azure_cpi/config/cpi.json

--- a/packages/bosh_azure_cpi/packaging
+++ b/packages/bosh_azure_cpi/packaging
@@ -4,15 +4,16 @@ set -e -x
 
 BOSH_PACKAGES_DIR=${BOSH_PACKAGES_DIR:-/var/vcap/packages}
 
+source ${BOSH_PACKAGES_DIR}/ruby-2.4-r4/bosh/compile.env
+
 cp -a bosh_azure_cpi/* ${BOSH_INSTALL_TARGET}
 
 export BUNDLE_CACHE_PATH="vendor/package"
 export BUNDLE_WITHOUT="development:test"
-bundle_cmd="$BOSH_PACKAGES_DIR/ruby-2.4-r3/bin/bundle"
 
 cd ${BOSH_INSTALL_TARGET}
 
-$bundle_cmd install \
-  --local           \
-  --no-prune        \
+bundle install \
+  --local      \
+  --no-prune   \
   --deployment

--- a/packages/bosh_azure_cpi/spec
+++ b/packages/bosh_azure_cpi/spec
@@ -1,7 +1,7 @@
 ---
 name: bosh_azure_cpi
 dependencies:
-- ruby-2.4-r3
+- ruby-2.4-r4
 files:
 - bosh_azure_cpi/Gemfile
 - bosh_azure_cpi/Gemfile.lock

--- a/packages/ruby-2.4-r3/spec.lock
+++ b/packages/ruby-2.4-r3/spec.lock
@@ -1,2 +1,0 @@
-name: ruby-2.4-r3
-fingerprint: 8471dec5da9ecc321686b8990a5ad2cc84529254

--- a/packages/ruby-2.4-r4/spec.lock
+++ b/packages/ruby-2.4-r4/spec.lock
@@ -1,0 +1,2 @@
+name: ruby-2.4-r4
+fingerprint: 0cdc60ed7fdb326e605479e9275346200af30a25

--- a/src/bosh_azure_cpi/.rubocop.yml
+++ b/src/bosh_azure_cpi/.rubocop.yml
@@ -1,4 +1,4 @@
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 2.4.2
+  TargetRubyVersion: 2.4.4


### PR DESCRIPTION
- [x] Please check this box and fill the data as below once you have run the unit tests.
      Code coverage before your change: `858 examples, 0 failures. 3587 / 3650 LOC (98.27%) covered.`
      Code coverage with your change:   `858 examples, 0 failures. 3587 / 3650 LOC (98.27%) covered.`

  ```
  pushd src/bosh_azure_cpi
    ./bin/test-unit
  popd
  ```

  NOTE: Please see how to setup dev environment and run unit tests in docs/development.md.

### Changelog

* Bump to ruby 2.4.4
  * See https://github.com/cloudfoundry-incubator/bosh-aws-cpi-release/commit/80ac9242984103b205817d08bc6b6dcbf259c259 and https://github.com/cloudfoundry-incubator/bosh-vsphere-cpi-release/commit/e29f08303e4184f508e7e58efeb8e965f85e4eb2
* Use the latest signing key to install Azure CLI
