### PR TITLE
Accelerated Networking support

### DIFF
--- a/docs/advanced/accelerated-networking/README.md
+++ b/docs/advanced/accelerated-networking/README.md
@@ -1,0 +1,50 @@
+# Use Azure Accelerated Networking
+
+[Accelerated networking (AN)](https://docs.microsoft.com/en-us/azure/virtual-network/create-vm-accelerated-networking-cli) enables single root I/O virtualization (SR-IOV) to a VM, greatly improving its networking performance. This high-performance path bypasses the host from the datapath, reducing latency, jitter, and CPU utilization, for use with the most demanding network workloads on supported VM types. 
+
+## Requirements
+
+* Azure CPI v35.4.0+ is required.
+
+* You need to review the supported VM instances and regions in [Limitations and Constraints](https://docs.microsoft.com/en-us/azure/virtual-network/create-vm-accelerated-networking-cli#limitations-and-constraints) before you continue.
+
+* The stemcell [ubuntu-xenial v81+](http://bosh.io/stemcells/bosh-azure-hyperv-ubuntu-xenial-go_agent) is required because AN needs [Ubuntu 16.04](https://docs.microsoft.com/en-us/azure/virtual-network/create-vm-accelerated-networking-cli#supported-operating-systems) and [linux-generic-hwe-16.04-edge 4.15.0.23.45](https://github.com/cloudfoundry/bosh-linux-stemcell-builder/issues/47).
+
+## Steps
+
+1. Upload your stemcell [ubuntu-xenial v81+](http://bosh.io/stemcells/bosh-azure-hyperv-ubuntu-xenial-go_agent).
+
+1. Select supported VM size according to [Limitations and Constraints](https://docs.microsoft.com/en-us/azure/virtual-network/create-vm-accelerated-networking-cli#limitations-and-constraints). Otherwise, you will hit the error `VMSizeIsNotPermittedToEnableAcceleratedNetworking`.
+
+1. In your cloud config, set `accelerated_networking: true` in [network configuration](http://bosh.io/docs/azure-cpi/#dynamic-network-or-manual-network) or [VM Types/VM Extensions](http://bosh.io/docs/azure-cpi/#resource-pools). Then, run `bosh update-cloud-config`.
+
+1. Use the xenial stemcell to deploy Cloud Foundry.
+
+    You can refer to the [ops file](https://github.com/cloudfoundry/cf-deployment/blob/master/operations/experimental/use-xenial-stemcell.yml) and update it with your stemcell version.
+
+    ```
+    bosh -d cf deploy cf-deployment.yml \
+    ...
+    -o use-xenial-stemcell.yml \
+    ...
+    ```
+
+    * For a new deployment, all the VMs are newly created using the ubuntu-xenial stemcell.
+
+    * For an existing deployment, all the VMs are re-created and updated because a new stemcell is used.
+
+        If you hits the following error, you need to check the SKU of your load balancer.
+
+            ```
+            Error message: {
+              "error": {
+                "details": [],
+                "code": "ExistingAvailabilitySetWasNotDeployedOnAcceleratedNetworkingEnabledCluster",
+                "message": "Cannot add Virtual Machine with accelerated networking-enabled nics (/subscriptions/<subscription-id>/resourceGroups/<resource-group-name>/providers/Microsoft.Compute/virtualMachines/<vm-name>) on an existing non-accelerated networking AvailabilitySet (/subscriptions/<subscription-id>/resourceGroups/<resource-group-name>/providers/Microsoft.Compute/availabilitySets/<availability-set-name>)."
+              }
+            }>
+            ```
+
+        * If the load balancer SKU is `Standard`, you can fix the error by changing the availability set name to a new one in your [VM Types/VM Extensions](http://bosh.io/docs/azure-cpi/#resource-pools).
+
+        * If the load balancer SKU is `Basic`, you have to delete the failed VMs and its availability set, and recreate them. There's downtime in this progress.

--- a/docs/guidance.md
+++ b/docs/guidance.md
@@ -57,6 +57,7 @@ In this step, you will install Cloud Foundry Command Line Interface and push you
   * [Deploy Cloud Foundry on Azure Stack](./advanced/azure-stack/)
   * [Use service principal with certificate](./advanced/use-service-principal-with-certificate/)
   * [Calculate correct VM cloud properties based on `vm_resources`](./advanced/calculate-vm-cloud-properties/)
+  * [Use Azure Accelerated Networking](./advanced/accelerated-networking/)
 * Cloud Foundry Scenarios
   * [Configure Cloud Foundry external databases using Azure MySQL/Postgres Service](./advanced/configure-cf-external-databases-using-azure-mysql-postgres-service)
   * [Integrating Application Gateway](./advanced/application-gateway/)

--- a/src/bosh_azure_cpi/.rubocop_todo.yml
+++ b/src/bosh_azure_cpi/.rubocop_todo.yml
@@ -78,7 +78,7 @@ Metrics/AbcSize:
 # Offense count: 625
 # Configuration parameters: CountComments, ExcludedMethods.
 Metrics/BlockLength:
-  Max: 2132
+  Max: 10000
 
 # Offense count: 12
 # Configuration parameters: CountBlocks.

--- a/src/bosh_azure_cpi/lib/cloud/azure/azure_client2.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/azure_client2.rb
@@ -1290,19 +1290,20 @@ module Bosh::AzureCloud
     #  ==== Params
     #
     # Accepted key/value pairs are:
-    # * +:name+                       - String. Name of network interface.
-    # * +:location+                   - String. The location where the network interface will be created.
-    # * +:tags                        - Hash. The tags of the network interface.
-    # * +:enable_ip_forwarding        - Boolean. Indicates whether IP forwarding is enabled on this network interface.
-    # * +:ipconfig_name+              - String. The name of ipConfigurations for the network interface.
-    # * +:private_ip                  - String. Private IP address which the network interface will use.
-    # * +:public_ip                   - Hash. The public IP which the network interface is bound to.
-    # * +:subnet                      - Hash. The subnet which the network interface is bound to.
-    # * +:dns_servers                 - Array. DNS servers.
-    # * +:network_security_group      - Hash. The network security group which the network interface is bound to.
-    # * +:application_security_groups - Array. The application security groups which the network interface is bound to.
-    # * +:load_balancer               - Hash. The load balancer which the network interface is bound to.
-    # * +:application_gateway         - Hash. The application gateway which the network interface is bound to.
+    # * +:name+                         - String. Name of network interface.
+    # * +:location+                     - String. The location where the network interface will be created.
+    # * +:tags                          - Hash. The tags of the network interface.
+    # * +:enable_ip_forwarding          - Boolean. Indicates whether IP forwarding is enabled on this network interface.
+    # * +:enable_accelerated_networking - Boolean. Indicates whether accelerated networking is enabled on this network interface.
+    # * +:ipconfig_name+                - String. The name of ipConfigurations for the network interface.
+    # * +:private_ip                    - String. Private IP address which the network interface will use.
+    # * +:public_ip                     - Hash. The public IP which the network interface is bound to.
+    # * +:subnet                        - Hash. The subnet which the network interface is bound to.
+    # * +:dns_servers                   - Array. DNS servers.
+    # * +:network_security_group        - Hash. The network security group which the network interface is bound to.
+    # * +:application_security_groups   - Array. The application security groups which the network interface is bound to.
+    # * +:load_balancer                 - Hash. The load balancer which the network interface is bound to.
+    # * +:application_gateway           - Hash. The application gateway which the network interface is bound to.
     #
     # @return [Boolean]
     #
@@ -1318,6 +1319,7 @@ module Bosh::AzureCloud
         'properties' => {
           'networkSecurityGroup' => nic_params[:network_security_group].nil? ? nil : { 'id' => nic_params[:network_security_group][:id] },
           'enableIPForwarding' => nic_params[:enable_ip_forwarding],
+          'enableAcceleratedNetworking' => nic_params[:enable_accelerated_networking],
           'ipConfigurations' => [
             {
               'name'        => nic_params[:ipconfig_name],
@@ -1901,6 +1903,8 @@ module Bosh::AzureCloud
         interface[:provisioning_state] = properties['provisioningState']
 
         interface[:enable_ip_forwarding] = properties['enableIPForwarding'] unless properties['enableIPForwarding'].nil?
+
+        interface[:enable_accelerated_networking] = properties['enableAcceleratedNetworking'] unless properties['enableAcceleratedNetworking'].nil?
 
         unless properties['networkSecurityGroup'].nil?
           interface[:network_security_group] = if recursive

--- a/src/bosh_azure_cpi/lib/cloud/azure/cloud.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/cloud.rb
@@ -94,7 +94,8 @@ module Bosh::AzureCloud
     #        "resource_group_name"         => "rg1",
     #        "security_group"              => "nsg-bosh",
     #        "application_security_groups" => ["asg1", "asg2"],
-    #        "ip_forwarding"               => true
+    #        "ip_forwarding"               => true,
+    #        "accelerated_networking"      => true
     #      }
     #    }
     #  }
@@ -125,7 +126,8 @@ module Bosh::AzureCloud
     #    "assign_dynamic_public_ip" => true,
     #    "security_group" => "nsg-bosh",
     #    "application_security_groups" => ["asg1", "asg2"],
-    #    "ip_forwarding" => true
+    #    "ip_forwarding" => true,
+    #    "accelerated_networking" => true
     #  }
     #
     # Sample env config:

--- a/src/bosh_azure_cpi/lib/cloud/azure/dynamic_network.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/dynamic_network.rb
@@ -4,7 +4,7 @@ module Bosh::AzureCloud
   class DynamicNetwork < Network
     include Helpers
 
-    attr_reader :virtual_network_name, :subnet_name, :security_group, :application_security_groups, :ip_forwarding
+    attr_reader :virtual_network_name, :subnet_name, :security_group, :application_security_groups, :ip_forwarding, :accelerated_networking
 
     # create dynamic network
     # @param [String] name Network name
@@ -16,11 +16,12 @@ module Bosh::AzureCloud
     #     "dns"     => ["168.63.129.16"],
     #     "type"    => "dynamic",
     #     "cloud_properties" => {
-    #       "virtual_network_name" => "boshvnet",
-    #       "subnet_name"          => "Bosh",
-    #       "resource_group_name"  => "rg-name",
-    #       "ip_forwarding"        => false,
-    #       "security_group"       => "nsg-bosh",
+    #       "virtual_network_name"   => "boshvnet",
+    #       "subnet_name"            => "Bosh",
+    #       "resource_group_name"    => "rg-name",
+    #       "ip_forwarding"          => false,
+    #       "accelerated_networking" => false,
+    #       "security_group"         => "nsg-bosh",
     #       "application_security_groups" => []
     #     }
     #   }
@@ -47,6 +48,8 @@ module Bosh::AzureCloud
       @application_security_groups = @cloud_properties.fetch('application_security_groups', [])
 
       @ip_forwarding = @cloud_properties.fetch('ip_forwarding', false)
+
+      @accelerated_networking = @cloud_properties.fetch('accelerated_networking', false)
     end
 
     def dns

--- a/src/bosh_azure_cpi/lib/cloud/azure/manual_network.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/manual_network.rb
@@ -4,7 +4,7 @@ module Bosh::AzureCloud
   class ManualNetwork < Network
     include Helpers
 
-    attr_reader :virtual_network_name, :subnet_name, :security_group, :application_security_groups, :ip_forwarding
+    attr_reader :virtual_network_name, :subnet_name, :security_group, :application_security_groups, :ip_forwarding, :accelerated_networking
 
     # create manual network
     # @param [String] name Network name
@@ -18,11 +18,12 @@ module Bosh::AzureCloud
     #     "dns"     => ["168.63.129.16"],
     #     "default" => ["dns", "gateway"],
     #     "cloud_properties" => {
-    #       "virtual_network_name" => "boshvnet",
-    #       "subnet_name"          => "Bosh",
-    #       "resource_group_name"  => "rg-name",
-    #       "ip_forwarding"        => false,
-    #       "security_group"       => "nsg-bosh",
+    #       "virtual_network_name"   => "boshvnet",
+    #       "subnet_name"            => "Bosh",
+    #       "resource_group_name"    => "rg-name",
+    #       "ip_forwarding"          => false,
+    #       "accelerated_networking" => false,
+    #       "security_group"         => "nsg-bosh",
     #       "application_security_groups" => []
     #     }
     #   }
@@ -51,6 +52,8 @@ module Bosh::AzureCloud
       @application_security_groups = @cloud_properties.fetch('application_security_groups', [])
 
       @ip_forwarding = @cloud_properties.fetch('ip_forwarding', false)
+
+      @accelerated_networking = @cloud_properties.fetch('accelerated_networking', false)
     end
 
     def private_ip

--- a/src/bosh_azure_cpi/lib/cloud/azure/vm_manager.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/vm_manager.rb
@@ -369,6 +369,13 @@ module Bosh::AzureCloud
       ip_forwarding
     end
 
+    def get_accelerated_networking(resource_pool, network)
+      accelerated_networking = false
+      # accelerated_networking can be specified in resource_pool and networks (ordered by priority)
+      accelerated_networking = resource_pool.fetch('accelerated_networking', network.accelerated_networking)
+      accelerated_networking
+    end
+
     def get_public_ip(vip_network)
       public_ip = nil
       unless vip_network.nil?
@@ -421,6 +428,7 @@ module Bosh::AzureCloud
         network_security_group = get_network_security_group(resource_pool, network)
         application_security_groups = get_application_security_groups(resource_pool, network)
         ip_forwarding = get_ip_forwarding(resource_pool, network)
+        accelerated_networking = get_accelerated_networking(resource_pool, network)
         nic_name = "#{vm_name}-#{index}"
         nic_params = {
           name: nic_name,
@@ -429,7 +437,8 @@ module Bosh::AzureCloud
           network_security_group: network_security_group,
           application_security_groups: application_security_groups,
           ipconfig_name: "ipconfig#{index}",
-          enable_ip_forwarding: ip_forwarding
+          enable_ip_forwarding: ip_forwarding,
+          enable_accelerated_networking: accelerated_networking
         }
         nic_params[:subnet] = get_network_subnet(network)
         if index.zero?

--- a/src/bosh_azure_cpi/spec/unit/azure_client2/create_network_interface_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client2/create_network_interface_spec.rb
@@ -49,6 +49,7 @@ describe Bosh::AzureCloud::AzureClient2 do
             subnet: { id: subnet[:id] },
             tags: {},
             enable_ip_forwarding: false,
+            enable_accelerated_networking: false,
             private_ip: '10.0.0.100',
             dns_servers: ['168.63.129.16'],
             public_ip: { id: 'fake-public-id' },
@@ -68,6 +69,7 @@ describe Bosh::AzureCloud::AzureClient2 do
                 id: nic_params[:network_security_group][:id]
               },
               enableIPForwarding: false,
+              enableAcceleratedNetworking: false,
               ipConfigurations: [{
                 name: nic_params[:ipconfig_name],
                 properties: {
@@ -125,6 +127,7 @@ describe Bosh::AzureCloud::AzureClient2 do
             subnet: { id: subnet[:id] },
             tags: {},
             enable_ip_forwarding: false,
+            enable_accelerated_networking: false,
             network_security_group: { id: nsg_id },
             application_security_groups: [],
             load_balancer: nil,
@@ -141,6 +144,7 @@ describe Bosh::AzureCloud::AzureClient2 do
                 id: nic_params[:network_security_group][:id]
               },
               enableIPForwarding: false,
+              enableAcceleratedNetworking: false,
               ipConfigurations: [{
                 name: nic_params[:ipconfig_name],
                 properties: {
@@ -198,6 +202,7 @@ describe Bosh::AzureCloud::AzureClient2 do
             subnet: { id: subnet[:id] },
             tags: {},
             enable_ip_forwarding: false,
+            enable_accelerated_networking: false,
             private_ip: '10.0.0.100',
             dns_servers: ['168.63.129.16'],
             public_ip: { id: 'fake-public-id' },
@@ -215,6 +220,7 @@ describe Bosh::AzureCloud::AzureClient2 do
             properties: {
               networkSecurityGroup: nil,
               enableIPForwarding: false,
+              enableAcceleratedNetworking: false,
               ipConfigurations: [{
                 name: nic_params[:ipconfig_name],
                 properties: {
@@ -272,6 +278,7 @@ describe Bosh::AzureCloud::AzureClient2 do
             subnet: { id: subnet[:id] },
             tags: {},
             enable_ip_forwarding: false,
+            enable_accelerated_networking: false,
             private_ip: '10.0.0.100',
             dns_servers: ['168.63.129.16'],
             public_ip: { id: 'fake-public-id' },
@@ -303,6 +310,7 @@ describe Bosh::AzureCloud::AzureClient2 do
                 id: nic_params[:network_security_group][:id]
               },
               enableIPForwarding: false,
+              enableAcceleratedNetworking: false,
               ipConfigurations: [{
                 name: nic_params[:ipconfig_name],
                 properties: {
@@ -366,6 +374,7 @@ describe Bosh::AzureCloud::AzureClient2 do
             subnet: { id: subnet[:id] },
             tags: {},
             enable_ip_forwarding: false,
+            enable_accelerated_networking: false,
             private_ip: '10.0.0.100',
             dns_servers: ['168.63.129.16'],
             public_ip: { id: 'fake-public-id' },
@@ -385,6 +394,7 @@ describe Bosh::AzureCloud::AzureClient2 do
                 id: nic_params[:network_security_group][:id]
               },
               enableIPForwarding: false,
+              enableAcceleratedNetworking: false,
               ipConfigurations: [{
                 name: nic_params[:ipconfig_name],
                 properties: {
@@ -450,6 +460,7 @@ describe Bosh::AzureCloud::AzureClient2 do
             subnet: { id: subnet[:id] },
             tags: {},
             enable_ip_forwarding: false,
+            enable_accelerated_networking: false,
             private_ip: '10.0.0.100',
             dns_servers: ['168.63.129.16'],
             public_ip: { id: 'fake-public-id' },
@@ -475,6 +486,7 @@ describe Bosh::AzureCloud::AzureClient2 do
                 id: nic_params[:network_security_group][:id]
               },
               enableIPForwarding: false,
+              enableAcceleratedNetworking: false,
               ipConfigurations: [{
                 name: nic_params[:ipconfig_name],
                 properties: {

--- a/src/bosh_azure_cpi/spec/unit/azure_client2/get_operation_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client2/get_operation_spec.rb
@@ -846,6 +846,57 @@ describe Bosh::AzureCloud::AzureClient2 do
         end
       end
 
+      context 'when the accelerated networking is enabled' do
+        let(:nic_response_body) do
+          {
+            'id' => 'fake-id',
+            'name' => 'fake-name',
+            'location' => 'fake-location',
+            'tags' => 'fake-tags',
+            'properties' => {
+              'provisioningState' => 'fake-state',
+              'enableAcceleratedNetworking' => true,
+              'dnsSettings' => {
+                'dnsServers' => ['168.63.129.16']
+              },
+              'ipConfigurations' => [
+                {
+                  'id' => 'fake-id',
+                  'properties' => {
+                    'privateIPAddress' => '10.0.0.100',
+                    'privateIPAllocationMethod' => 'Dynamic'
+                  }
+                }
+              ]
+            }
+          }.to_json
+        end
+        let(:fake_nic) do
+          {
+            id: 'fake-id',
+            name: 'fake-name',
+            location: 'fake-location',
+            tags: 'fake-tags',
+            provisioning_state: 'fake-state',
+            enable_accelerated_networking: true,
+            dns_settings: ['168.63.129.16'],
+            ip_configuration_id: 'fake-id',
+            private_ip: '10.0.0.100',
+            private_ip_allocation_method: 'Dynamic'
+          }
+        end
+        it 'should return the network interface with accelerated networking enabled' do
+          stub_request(:get, nic_uri).to_return(
+            status: 200,
+            body: nic_response_body,
+            headers: {}
+          )
+          expect(
+            azure_client2.get_network_interface_by_name(resource_group_name, nic_name)
+          ).to eq(fake_nic)
+        end
+      end
+
       context 'when the network interface is bound to network security group' do
         let(:nic_response_body) do
           {

--- a/src/bosh_azure_cpi/spec/unit/dynamic_network_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/dynamic_network_spec.rb
@@ -22,7 +22,8 @@ describe Bosh::AzureCloud::DynamicNetwork do
           'resource_group_name'         => rg_name,
           'security_group'              => nsg_name,
           'application_security_groups' => asg_names,
-          'ip_forwarding'               => true
+          'ip_forwarding'               => true,
+          'accelerated_networking'      => true
         }
       }
     end
@@ -35,6 +36,7 @@ describe Bosh::AzureCloud::DynamicNetwork do
       expect(network.security_group).to eq(nsg_name)
       expect(network.application_security_groups).to eq(asg_names)
       expect(network.ip_forwarding).to eq(true)
+      expect(network.accelerated_networking).to eq(true)
       expect(network.dns).to eq(dns)
       expect(network.has_default_dns?).to be true
       expect(network.has_default_gateway?).to be true
@@ -140,6 +142,7 @@ describe Bosh::AzureCloud::DynamicNetwork do
       expect(network.security_group).to be_nil
       expect(network.application_security_groups).to eq([])
       expect(network.ip_forwarding).to be false
+      expect(network.accelerated_networking).to be false
       expect(network.resource_group_name).to eq(azure_properties['resource_group_name'])
       expect(network.dns).to be_nil
       expect(network.has_default_dns?).to be false

--- a/src/bosh_azure_cpi/spec/unit/manual_network_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/manual_network_spec.rb
@@ -24,7 +24,8 @@ describe Bosh::AzureCloud::ManualNetwork do
           'resource_group_name'         => rg_name,
           'security_group'              => nsg_name,
           'application_security_groups' => asg_names,
-          'ip_forwarding'               => true
+          'ip_forwarding'               => true,
+          'accelerated_networking'      => true
         }
       }
     end
@@ -38,6 +39,7 @@ describe Bosh::AzureCloud::ManualNetwork do
       expect(network.security_group).to eq(nsg_name)
       expect(network.application_security_groups).to eq(asg_names)
       expect(network.ip_forwarding).to eq(true)
+      expect(network.accelerated_networking).to eq(true)
       expect(network.dns).to eq(dns)
       expect(network.has_default_dns?).to be true
       expect(network.has_default_gateway?).to be true
@@ -181,6 +183,7 @@ describe Bosh::AzureCloud::ManualNetwork do
       expect(network.security_group).to be_nil
       expect(network.application_security_groups).to eq([])
       expect(network.ip_forwarding).to be false
+      expect(network.accelerated_networking).to be false
       expect(network.resource_group_name).to eq(azure_properties['resource_group_name'])
       expect(network.dns).to be_nil
       expect(network.has_default_dns?).to be false

--- a/src/bosh_azure_cpi/spec/unit/vm_manager/create/shared_stuff.rb
+++ b/src/bosh_azure_cpi/spec/unit/vm_manager/create/shared_stuff.rb
@@ -143,6 +143,8 @@ shared_context 'shared stuff for vm manager' do
       .and_return([])
     allow(manual_network).to receive(:ip_forwarding)
       .and_return(false)
+    allow(manual_network).to receive(:accelerated_networking)
+      .and_return(false)
 
     allow(dynamic_network).to receive(:resource_group_name)
       .and_return(MOCK_RESOURCE_GROUP_NAME)
@@ -155,6 +157,8 @@ shared_context 'shared stuff for vm manager' do
     allow(dynamic_network).to receive(:application_security_groups)
       .and_return([])
     allow(dynamic_network).to receive(:ip_forwarding)
+      .and_return(false)
+    allow(dynamic_network).to receive(:accelerated_networking)
       .and_return(false)
   end
 

--- a/src/bosh_azure_cpi/spec/unit/vm_manager/create/vm_is_created_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/vm_manager/create/vm_is_created_spec.rb
@@ -612,6 +612,129 @@ describe Bosh::AzureCloud::VMManager do
         end
       end
 
+      # Accelerated Networking
+      context '#accelerated_networking' do
+        context 'when accelerated networking is disbaled in network specs' do
+          before do
+            allow(manual_network).to receive(:accelerated_networking).and_return(false)
+            allow(dynamic_network).to receive(:accelerated_networking).and_return(false)
+          end
+
+          context 'when accelerated networking is not specified in resource_pool' do
+            let(:resource_pool) do
+              {
+                'instance_type' => 'Standard_D1'
+              }
+            end
+            it 'should disable accelerated networking on the network interface' do
+              expect(client2).not_to receive(:delete_virtual_machine)
+              expect(client2).not_to receive(:delete_network_interface)
+              expect(client2).to receive(:create_network_interface)
+                .with(resource_group_name, hash_including(enable_accelerated_networking: false), any_args).twice
+              expect do
+                vm_manager.create(instance_id, location, stemcell_info, resource_pool, network_configurator, env)
+              end.not_to raise_error
+            end
+          end
+
+          context 'when accelerated networking is disabled in resource_pool' do
+            let(:resource_pool) do
+              {
+                'instance_type' => 'Standard_D1',
+                'accelerated_networking' => false
+              }
+            end
+            it 'should disable accelerated networking on the network interface' do
+              expect(client2).not_to receive(:delete_virtual_machine)
+              expect(client2).not_to receive(:delete_network_interface)
+              expect(client2).to receive(:create_network_interface)
+                .with(resource_group_name, hash_including(enable_accelerated_networking: false), any_args).twice
+              expect do
+                vm_manager.create(instance_id, location, stemcell_info, resource_pool, network_configurator, env)
+              end.not_to raise_error
+            end
+          end
+
+          context 'when accelerated networking is enabled in resource_pool' do
+            let(:resource_pool) do
+              {
+                'instance_type' => 'Standard_D1',
+                'accelerated_networking' => true
+              }
+            end
+            it 'should enable accelerated networking on the network interface' do
+              expect(client2).not_to receive(:delete_virtual_machine)
+              expect(client2).not_to receive(:delete_network_interface)
+              expect(client2).to receive(:create_network_interface)
+                .with(resource_group_name, hash_including(enable_accelerated_networking: true), any_args).twice
+              expect do
+                vm_manager.create(instance_id, location, stemcell_info, resource_pool, network_configurator, env)
+              end.not_to raise_error
+            end
+          end
+        end
+
+        context 'when accelerated networking is enabled in network specs' do
+          before do
+            allow(manual_network).to receive(:accelerated_networking).and_return(true)
+            allow(dynamic_network).to receive(:accelerated_networking).and_return(true)
+          end
+
+          context 'when accelerated networking is not specified in resource_pool' do
+            let(:resource_pool) do
+              {
+                'instance_type' => 'Standard_D1'
+              }
+            end
+            it 'should enable accelerated networking on the network interface' do
+              expect(client2).not_to receive(:delete_virtual_machine)
+              expect(client2).not_to receive(:delete_network_interface)
+              expect(client2).to receive(:create_network_interface)
+                .with(resource_group_name, hash_including(enable_accelerated_networking: true), any_args).twice
+              expect do
+                vm_manager.create(instance_id, location, stemcell_info, resource_pool, network_configurator, env)
+              end.not_to raise_error
+            end
+          end
+
+          context 'when accelerated networking is disabled in resource_pool' do
+            let(:resource_pool) do
+              {
+                'instance_type' => 'Standard_D1',
+                'accelerated_networking' => false
+              }
+            end
+            it 'should disable accelerated networking on the network interface' do
+              expect(client2).not_to receive(:delete_virtual_machine)
+              expect(client2).not_to receive(:delete_network_interface)
+              expect(client2).to receive(:create_network_interface)
+                .with(resource_group_name, hash_including(enable_accelerated_networking: false), any_args).twice
+              expect do
+                vm_manager.create(instance_id, location, stemcell_info, resource_pool, network_configurator, env)
+              end.not_to raise_error
+            end
+          end
+
+          context 'when accelerated networking is enabled in resource_pool' do
+            let(:resource_pool) do
+              {
+                'instance_type' => 'Standard_D1',
+                'accelerated_networking' => true
+              }
+            end
+            it 'should enable accelerated networking on the network interface' do
+              expect(client2).not_to receive(:delete_virtual_machine)
+              expect(client2).not_to receive(:delete_network_interface)
+              expect(client2).to receive(:create_network_interface)
+                .with(resource_group_name, hash_including(enable_accelerated_networking: true), any_args).twice
+              expect do
+                vm_manager.create(instance_id, location, stemcell_info, resource_pool, network_configurator, env)
+              end.not_to raise_error
+            end
+          end
+        end
+      end
+
       # Stemcell
       context '#stemcell' do
         context 'when a heavy stemcell is used' do


### PR DESCRIPTION
- [x] Please check this box and fill the data as below once you have run the unit tests.
      Code coverage before your change: `858 examples, 0 failures. 3587 / 3650 LOC (98.27%) covered.`
      Code coverage with your change:   `865 examples, 0 failures. 3595 / 3658 LOC (98.28%) covered.`

  NOTE: Please see how to setup dev environment and run unit tests in docs/development.md.

### Changelog

* Supports enabling accelerated networking
  By default, accelerated networking is disabled. To enable it, you can set accelerated_networking in VM type/extension or network configuration to true. The accelerated_networking in VM type/extension can override the equivalent option in the network configuration.
  It only supports Xenial Stemcell.
* Add a doc for accelerated networking