### PR TITLE
Refine file locks for inter process communication

### DIFF
--- a/src/bosh_azure_cpi/lib/cloud/azure.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure.rb
@@ -36,6 +36,7 @@ require 'common/thread_pool'
 require 'common/thread_formatter'
 require 'common/common'
 
+require 'bosh/cpi'
 require 'bosh/cpi/registry_client'
 
 require 'cloud'

--- a/src/bosh_azure_cpi/lib/cloud/azure.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure.rb
@@ -20,6 +20,7 @@ require 'open3'
 require 'etc'
 require 'fcntl'
 require 'jwt'
+require 'fileutils'
 # Use resolv-replace.rb to replace the libc resolver
 # Reference:
 #  https://makandracards.com/ninjaconcept/30815-fixing-socketerror-getaddrinfo-name-or-service-not-known-with-ruby-s-resolv-replace-rb

--- a/src/bosh_azure_cpi/lib/cloud/azure/blob_manager.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/blob_manager.rb
@@ -227,7 +227,6 @@ module Bosh::AzureCloud
 
           copy_status_description = ''
           while copy_status == 'pending'
-            yield if block_given?
             options = merge_storage_common_options
             @logger.info("copy_blob: Calling get_blob_properties(#{container_name}, #{blob_name}, #{options})")
             blob = @blob_service_client.get_blob_properties(container_name, blob_name, options)

--- a/src/bosh_azure_cpi/lib/cloud/azure/cloud.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/cloud.rb
@@ -695,16 +695,7 @@ module Bosh::AzureCloud
 
     def init_cpi_lock_dir
       @logger.info('init_cpi_lock_dir: Initializing the CPI lock directory')
-      if !Dir.exist?(CPI_LOCK_DIR)
-        ignore_exception(Errno::EEXIST) { Dir.mkdir(CPI_LOCK_DIR) }
-      elsif needs_deleting_locks?
-        @logger.info('init_cpi_lock_dir: Cleaning up the locks')
-        Dir.glob("#{CPI_LOCK_DIR}/#{CPI_LOCK_PREFIX}*") do |file_name|
-          @logger.debug("init_cpi_lock_dir: Deleting the lock `#{file_name}'")
-          ignore_exception(Errno::ENOENT) { File.delete(file_name) }
-        end
-        ignore_exception(Errno::ENOENT) { remove_deleting_mark }
-      end
+      ignore_exception(Errno::EEXIST) { Dir.mkdir(CPI_LOCK_DIR) } unless Dir.exist?(CPI_LOCK_DIR)
     end
 
     # Generates initial agent settings. These settings will be read by agent

--- a/src/bosh_azure_cpi/lib/cloud/azure/cloud.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/cloud.rb
@@ -695,7 +695,7 @@ module Bosh::AzureCloud
 
     def init_cpi_lock_dir
       @logger.info('init_cpi_lock_dir: Initializing the CPI lock directory')
-      ignore_exception(Errno::EEXIST) { Dir.mkdir(CPI_LOCK_DIR) } unless Dir.exist?(CPI_LOCK_DIR)
+      FileUtils.mkdir_p(CPI_LOCK_DIR)
     end
 
     # Generates initial agent settings. These settings will be read by agent

--- a/src/bosh_azure_cpi/lib/cloud/azure/telemetry/telemetry_manager.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/telemetry/telemetry_manager.rb
@@ -79,7 +79,7 @@ module Bosh::AzureCloud
       File.open(filename, 'w') do |file|
         file.write(event.to_json)
       end
-      Dir.mkdir(CPI_EVENTS_DIR) unless File.exist?(CPI_EVENTS_DIR)
+      FileUtils.mkdir_p(CPI_EVENTS_DIR)
       stdout, stderr, status = Open3.capture3("mv #{filename} #{CPI_EVENTS_DIR}")
       if status != 0
         @logger.warn("[Telemetry] Failed to move `#{filename}' to `#{CPI_EVENTS_DIR}', error: #{stderr}")

--- a/src/bosh_azure_cpi/spec/unit/cloud/cloud_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/cloud/cloud_spec.rb
@@ -15,48 +15,10 @@ describe Bosh::AzureCloud::Cloud do
       end
 
       it 'raises an exception with a user friendly message' do
+        expect(FileUtils).to receive(:mkdir_p).with(CPI_LOCK_DIR).and_call_original
         expect do
           cloud
         end.to raise_error(Bosh::Clouds::CloudError, 'Please make sure the CPI has proper network access to Azure. #<Net::OpenTimeout: execution expired>')
-      end
-    end
-
-    context 'when the lock dir exists' do
-      before do
-        allow(Dir).to receive(:exist?)
-          .with(cpi_lock_dir)
-          .and_return(true)
-      end
-
-      it 'should not create the cpi lock dir' do
-        expect(Dir).not_to receive(:mkdir)
-        expect do
-          cloud
-        end.not_to raise_error
-      end
-    end
-
-    context "when the lock dir doesn't exist" do
-      before do
-        allow(Dir).to receive(:exist?)
-          .with(cpi_lock_dir)
-          .and_return(false)
-      end
-
-      it 'should create the cpi lock dir' do
-        expect(Dir).to receive(:mkdir).with(cpi_lock_dir)
-        expect do
-          cloud
-        end.not_to raise_error
-      end
-
-      context 'when the lock dir is created by other processes' do
-        it 'should create the lock dir and ignore the error of exising directory' do
-          expect(Dir).to receive(:mkdir).with(cpi_lock_dir).and_return(Errno::EEXIST)
-          expect do
-            cloud
-          end.not_to raise_error
-        end
       end
     end
   end

--- a/src/bosh_azure_cpi/spec/unit/cloud/cloud_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/cloud/cloud_spec.rb
@@ -8,7 +8,6 @@ describe Bosh::AzureCloud::Cloud do
 
   describe '#initialize' do
     let(:cpi_lock_dir) { Bosh::AzureCloud::Helpers::CPI_LOCK_DIR }
-    let(:cpi_lock_delete) { Bosh::AzureCloud::Helpers::CPI_LOCK_DELETE }
 
     context 'when there is no proper network access to Azure' do
       before do
@@ -24,65 +23,24 @@ describe Bosh::AzureCloud::Cloud do
 
     context 'when the lock dir exists' do
       before do
-        Dir.mkdir(cpi_lock_dir) unless Dir.exist?(cpi_lock_dir)
+        allow(Dir).to receive(:exist?)
+          .with(cpi_lock_dir)
+          .and_return(true)
       end
 
-      after do
-        Dir.delete(cpi_lock_dir) if Dir.exist?(cpi_lock_dir)
-      end
-
-      context "when CPI doesn't need to cleanup locks" do
-        before do
-          allow(File).to receive(:exist?).with(cpi_lock_delete).and_return(false)
-        end
-
-        it 'should not create the cpi lock dir and cleanup the locks' do
-          expect(Dir).not_to receive(:mkdir)
-          expect(Dir).not_to receive(:glob)
-          expect do
-            cloud
-          end.not_to raise_error
-        end
-      end
-
-      context 'when CPI needs to cleanup locks' do
-        before do
-          allow(File).to receive(:exist?).with(cpi_lock_delete).and_return(true)
-        end
-
-        it 'should not create the cpi lock dir, but should cleanup the locks and the deleting mark' do
-          expect(Dir).not_to receive(:mkdir)
-          expect(Dir).to receive(:glob)
-            .and_yield("#{Bosh::AzureCloud::Helpers::CPI_LOCK_PREFIX}-fake-lock-1")
-            .and_yield("#{Bosh::AzureCloud::Helpers::CPI_LOCK_PREFIX}-fake-lock-2")
-          expect(File).to receive(:delete).with("#{Bosh::AzureCloud::Helpers::CPI_LOCK_PREFIX}-fake-lock-1").once
-          expect(File).to receive(:delete).with("#{Bosh::AzureCloud::Helpers::CPI_LOCK_PREFIX}-fake-lock-2").once
-          expect(File).to receive(:delete).with(cpi_lock_delete).once
-          expect do
-            cloud
-          end.not_to raise_error
-        end
-
-        context 'when the locks have been deleted by other processes' do
-          it 'should not create the cpi lock dir, but should cleanup the locks and the deleting mark, and ignore the errors of non-existent locks' do
-            expect(Dir).not_to receive(:mkdir)
-            expect(Dir).to receive(:glob)
-              .and_yield("#{Bosh::AzureCloud::Helpers::CPI_LOCK_PREFIX}-fake-lock-1")
-              .and_yield("#{Bosh::AzureCloud::Helpers::CPI_LOCK_PREFIX}-fake-lock-2")
-            expect(File).to receive(:delete).with("#{Bosh::AzureCloud::Helpers::CPI_LOCK_PREFIX}-fake-lock-1").once.and_raise(Errno::ENOENT)
-            expect(File).to receive(:delete).with("#{Bosh::AzureCloud::Helpers::CPI_LOCK_PREFIX}-fake-lock-2").once.and_raise(Errno::ENOENT)
-            expect(File).to receive(:delete).with(cpi_lock_delete).and_raise(Errno::ENOENT)
-            expect do
-              cloud
-            end.not_to raise_error
-          end
-        end
+      it 'should not create the cpi lock dir' do
+        expect(Dir).not_to receive(:mkdir)
+        expect do
+          cloud
+        end.not_to raise_error
       end
     end
 
     context "when the lock dir doesn't exist" do
       before do
-        Dir.delete(cpi_lock_dir) if Dir.exist?(cpi_lock_dir)
+        allow(Dir).to receive(:exist?)
+          .with(cpi_lock_dir)
+          .and_return(false)
       end
 
       it 'should create the cpi lock dir' do
@@ -93,9 +51,8 @@ describe Bosh::AzureCloud::Cloud do
       end
 
       context 'when the lock dir is created by other processes' do
-        it 'should create the lock dir and ignore the error of exising directory, but not clean the locks' do
+        it 'should create the lock dir and ignore the error of exising directory' do
           expect(Dir).to receive(:mkdir).with(cpi_lock_dir).and_return(Errno::EEXIST)
-          expect(Dir).not_to receive(:glob)
           expect do
             cloud
           end.not_to raise_error

--- a/src/bosh_azure_cpi/spec/unit/telemetry/telemetry_event_handler_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/telemetry/telemetry_event_handler_spec.rb
@@ -82,7 +82,7 @@ describe Bosh::AzureCloud::TelemetryEventHandler do
 
     before do
       allow(Bosh::AzureCloud::WireClient).to receive(:new).and_return(wire_client)
-      Dir.mkdir(cpi_events_dir) unless Dir.exist?(cpi_events_dir)
+      FileUtils.mkdir_p(cpi_events_dir)
     end
 
     after do
@@ -133,7 +133,7 @@ describe Bosh::AzureCloud::TelemetryEventHandler do
 
     before do
       allow(Bosh::AzureCloud::WireClient).to receive(:new).and_return(wire_client)
-      Dir.mkdir(cpi_events_dir) unless Dir.exist?(cpi_events_dir)
+      FileUtils.mkdir_p(cpi_events_dir)
 
       (0...event_number).each do |number|
         File.open("#{cpi_events_dir}/collect-events-test-#{number}.tld", 'w') do |file|


### PR DESCRIPTION
- [x] Please check this box and fill the data as below once you have run the unit tests.
      Code coverage before your change: `865 examples, 0 failures. 3595 / 3658 LOC (98.28%) covered.`
      Code coverage with your change: `839 examples, 0 failures. 3445 / 3501 LOC (98.4%) covered.`

  ```
  pushd src/bosh_azure_cpi
    ./bin/test-unit
  popd
  ```

  NOTE: Please see how to setup dev environment and run unit tests in docs/development.md.

### Changelog

* Refine file locks for inter process communication, and fix the issue that the empty availability set may not be deleted due to lock issue
