### PR TITLE
Use different locks in unit tests of flock

### DIFF
--- a/src/bosh_azure_cpi/spec/unit/helpers_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/helpers_spec.rb
@@ -917,6 +917,7 @@ describe Bosh::AzureCloud::Helpers do
       context 'with exclusive lock' do
         let(:mode) { File::LOCK_EX }
         let(:accuracy) { 0.05 }
+        let(:lock_name) { 'fake-exclusive-lock' }
 
         it 'the processes should get the lock sequentially and then call the block' do
           # process 1 - child process
@@ -945,6 +946,7 @@ describe Bosh::AzureCloud::Helpers do
       context 'with share lock' do
         let(:mode) { File::LOCK_SH }
         let(:accuracy) { 0.05 }
+        let(:lock_name) { 'fake-share-lock' }
 
         it 'the processes should get the lock in parallel and then call the block' do
           # process 1 - child process
@@ -972,6 +974,7 @@ describe Bosh::AzureCloud::Helpers do
       context 'with exclusive but no block lock' do
         let(:mode) { File::LOCK_EX | File::LOCK_NB }
         let(:accuracy) { 0.05 }
+        let(:lock_name) { 'fake-exclusive-nb-lock' }
 
         it 'only the process gets the lock and calls the block, the other process should return directly' do
           # process 1 - child process


### PR DESCRIPTION
- [x] Please check this box and fill the data as below once you have run the unit tests.
      Code coverage before your change: `833 examples, 0 failures. 3438 / 3492 LOC (98.45%) covered.`
      Code coverage with your change: `833 examples, 0 failures. 3438 / 3492 LOC (98.45%) covered.`

  ```
  pushd src/bosh_azure_cpi
    ./bin/test-unit
  popd
  ```

  NOTE: Please see how to setup dev environment and run unit tests in docs/development.md.

### Changelog

* Use different locks in unit tests of flock
