### PR TITLE
Allow partners to configure ISV tracking GUID

### DIFF
--- a/jobs/azure_cpi/spec
+++ b/jobs/azure_cpi/spec
@@ -84,6 +84,8 @@ properties:
       -----BEGIN CERTIFICATE-----
       MII...
       -----END CERTIFICATE-----
+  azure.isv_tracking_guid:
+    description: ISV tracking GUID for usage association
 
   registry.username:
     description: User to access the Registry

--- a/jobs/azure_cpi/templates/cpi.json.erb
+++ b/jobs/azure_cpi/templates/cpi.json.erb
@@ -75,6 +75,10 @@
     params['cloud']['properties']['azure']['azure_stack']['endpoint_prefix'] = p('azure.azure_stack.endpoint_prefix')
   end
 
+  if_p('azure.isv_tracking_guid') do |isv_tracking_guid|
+    params['cloud']['properties']['azure']['isv_tracking_guid'] = isv_tracking_guid
+  end
+
   if_p('registry.endpoint') do |endpoint|
     params['cloud']['properties']['registry']['endpoint'] = endpoint
   end.else do

--- a/jobs/azure_cpi/templates/cpi.json.erb
+++ b/jobs/azure_cpi/templates/cpi.json.erb
@@ -76,6 +76,7 @@
   end
 
   if_p('azure.isv_tracking_guid') do |isv_tracking_guid|
+    raise 'Invalide "isv_tracking_guid", length of guid must be 36.' if isv_tracking_guid.length != 36
     params['cloud']['properties']['azure']['isv_tracking_guid'] = isv_tracking_guid
   end
 

--- a/jobs/azure_cpi/templates/cpi.json.erb
+++ b/jobs/azure_cpi/templates/cpi.json.erb
@@ -76,7 +76,7 @@
   end
 
   if_p('azure.isv_tracking_guid') do |isv_tracking_guid|
-    raise 'Invalide "isv_tracking_guid", length of guid must be 36.' if isv_tracking_guid.length != 36
+    raise 'Invalid "isv_tracking_guid", length of guid must be 36.' if isv_tracking_guid.length != 36
     params['cloud']['properties']['azure']['isv_tracking_guid'] = isv_tracking_guid
   end
 

--- a/src/bosh_azure_cpi/lib/cloud/azure/azure_client2.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/azure_client2.rb
@@ -2417,7 +2417,10 @@ module Bosh::AzureCloud
     end
 
     def merge_http_common_headers(request)
-      request['User-Agent'] = USER_AGENT_FOR_REST
+      user_agents = ["#{USER_AGENT_FOR_REST}/#{Bosh::AzureCloud::VERSION}"]
+      isv_tracking_guid = @azure_properties['isv_tracking_guid'].nil? ? DEFAULT_ISV_TRACKING_GUID : @azure_properties['isv_tracking_guid']
+      user_agents.push("pid-#{isv_tracking_guid}")
+      request['User-Agent'] = user_agents.join(' ')
       # https://msdn.microsoft.com/en-us/library/mt766820.aspx
       # Caller-specified request ID, in the form of a GUID with no decoration such as curly braces.
       # If specified, this will be included in response information as a way to map the request.

--- a/src/bosh_azure_cpi/lib/cloud/azure/azure_client2.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/azure_client2.rb
@@ -2418,7 +2418,7 @@ module Bosh::AzureCloud
 
     def merge_http_common_headers(request)
       user_agents = ["#{USER_AGENT_FOR_REST}/#{Bosh::AzureCloud::VERSION}"]
-      isv_tracking_guid = @azure_properties['isv_tracking_guid'].nil? ? DEFAULT_ISV_TRACKING_GUID : @azure_properties['isv_tracking_guid']
+      isv_tracking_guid = @azure_properties.fetch('isv_tracking_guid', DEFAULT_ISV_TRACKING_GUID)
       user_agents.push("pid-#{isv_tracking_guid}")
       request['User-Agent'] = user_agents.join(' ')
       # https://msdn.microsoft.com/en-us/library/mt766820.aspx

--- a/src/bosh_azure_cpi/lib/cloud/azure/helpers.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/helpers.rb
@@ -84,7 +84,7 @@ module Bosh::AzureCloud
       'user-agent' => USER_AGENT_FOR_AZURE_RESOURCE
     }.freeze
     # ISV Tracking
-    DEFAULT_ISV_TRACKING_GUID = "563bbbca-7944-4791-b9c6-8af0928114ac"
+    DEFAULT_ISV_TRACKING_GUID = '563bbbca-7944-4791-b9c6-8af0928114ac'
 
     AZURE_MAX_RETRY_COUNT = 10
 

--- a/src/bosh_azure_cpi/lib/cloud/azure/helpers.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/helpers.rb
@@ -83,6 +83,8 @@ module Bosh::AzureCloud
     AZURE_TAGS                    = {
       'user-agent' => USER_AGENT_FOR_AZURE_RESOURCE
     }.freeze
+    # ISV Tracking
+    DEFAULT_ISV_TRACKING_GUID = "563bbbca-7944-4791-b9c6-8af0928114ac"
 
     AZURE_MAX_RETRY_COUNT = 10
 

--- a/src/bosh_azure_cpi/spec/unit/azure_client2/request_headers_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client2/request_headers_spec.rb
@@ -25,7 +25,7 @@ describe Bosh::AzureCloud::AzureClient2 do
     allow(azure_client2).to receive(:sleep)
   end
 
-  describe '#create_virtual_machine' do  # Use function create_virtual_machine to validate user agent
+  describe '#create_virtual_machine' do # Use function create_virtual_machine to validate user agent
     let(:vm_uri) { "https://management.azure.com//subscriptions/#{subscription_id}/resourceGroups/#{resource_group}/providers/Microsoft.Compute/virtualMachines/#{vm_name}?api-version=#{api_version_compute}&validating=true" }
 
     let(:vm_params) do
@@ -83,12 +83,12 @@ describe Bosh::AzureCloud::AzureClient2 do
             headers: {}
           )
           stub_request(:put, vm_uri)
-            .with{ |request|
+            .with do |request|
               headers = request.headers
               expect(headers['Content-Type']).to eq('application/json')
               expect(headers['User-Agent']).to include("BOSH-AZURE-CPI/#{Bosh::AzureCloud::VERSION}")
               expect(headers['User-Agent']).to include(default_isv_tracking_guid)
-            }
+            end
             .to_return(
               status: 200,
               body: '',
@@ -128,12 +128,12 @@ describe Bosh::AzureCloud::AzureClient2 do
             headers: {}
           )
           stub_request(:put, vm_uri)
-            .with{ |request|
+            .with do |request|
               headers = request.headers
               expect(headers['Content-Type']).to eq('application/json')
               expect(headers['User-Agent']).to include("BOSH-AZURE-CPI/#{Bosh::AzureCloud::VERSION}")
               expect(headers['User-Agent']).to include("pid-#{isv_tracking_guid}")
-            }
+            end
             .to_return(
               status: 200,
               body: '',

--- a/src/bosh_azure_cpi/spec/unit/azure_client2/request_headers_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client2/request_headers_spec.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'webmock/rspec'
+
+WebMock.disable_net_connect!(allow_localhost: true)
+
+describe Bosh::AzureCloud::AzureClient2 do
+  let(:subscription_id) { mock_azure_properties['subscription_id'] }
+  let(:tenant_id) { mock_azure_properties['tenant_id'] }
+  let(:api_version) { AZURE_API_VERSION }
+  let(:api_version_compute) { AZURE_RESOURCE_PROVIDER_COMPUTE }
+  let(:resource_group) { 'fake-resource-group-name' }
+  let(:request_id) { 'fake-request-id' }
+
+  let(:token_uri) { "https://login.microsoftonline.com/#{tenant_id}/oauth2/token?api-version=#{api_version}" }
+  let(:operation_status_link) { "https://management.azure.com/subscriptions/#{subscription_id}/operations/#{request_id}" }
+
+  let(:vm_name) { 'fake-vm-name' }
+  let(:valid_access_token) { 'valid-access-token' }
+
+  let(:expires_on) { (Time.now + 1800).to_i.to_s }
+
+  before do
+    allow(azure_client2).to receive(:sleep)
+  end
+
+  describe '#create_virtual_machine' do  # Use function create_virtual_machine to validate user agent
+    let(:vm_uri) { "https://management.azure.com//subscriptions/#{subscription_id}/resourceGroups/#{resource_group}/providers/Microsoft.Compute/virtualMachines/#{vm_name}?api-version=#{api_version_compute}&validating=true" }
+
+    let(:vm_params) do
+      {
+        name: vm_name,
+        location: 'b',
+        tags: { 'foo' => 'bar' },
+        vm_size: 'c',
+        ssh_username: 'd',
+        ssh_cert_data: 'e',
+        custom_data: 'f',
+        image_uri: 'g',
+        os_disk: {
+          disk_name: 'h',
+          disk_uri: 'i',
+          disk_caching: 'j',
+          disk_size: 'k'
+        },
+        ephemeral_disk: {
+          disk_name: 'l',
+          disk_uri: 'm',
+          disk_caching: 'n',
+          disk_size: 'o'
+        },
+        os_type: 'linux',
+        managed: false
+      }
+    end
+
+    let(:network_interfaces) do
+      [
+        { id: 'a' },
+        { id: 'b' }
+      ]
+    end
+
+    context 'parse http headers' do
+      context 'when isv_tracking_guid is not provided' do
+        let(:logger) { Bosh::Clouds::Config.logger }
+        let(:azure_client2) do
+          Bosh::AzureCloud::AzureClient2.new(
+            mock_cloud_options['properties']['azure'],
+            logger
+          )
+        end
+        let(:default_isv_tracking_guid) { 'pid-563bbbca-7944-4791-b9c6-8af0928114ac' }
+
+        it 'should set the default guid in user agent' do
+          stub_request(:post, token_uri).to_return(
+            status: 200,
+            body: {
+              'access_token' => valid_access_token,
+              'expires_on' => expires_on
+            }.to_json,
+            headers: {}
+          )
+          stub_request(:put, vm_uri)
+            .with{ |request|
+              headers = request.headers
+              expect(headers['Content-Type']).to eq('application/json')
+              expect(headers['User-Agent']).to include("BOSH-AZURE-CPI/#{Bosh::AzureCloud::VERSION}")
+              expect(headers['User-Agent']).to include(default_isv_tracking_guid)
+            }
+            .to_return(
+              status: 200,
+              body: '',
+              headers: {
+                'azure-asyncoperation' => operation_status_link
+              }
+            )
+          stub_request(:get, operation_status_link).to_return(
+            status: 200,
+            body: '{"status":"Succeeded"}',
+            headers: {}
+          )
+
+          expect do
+            azure_client2.create_virtual_machine(resource_group, vm_params, network_interfaces)
+          end.not_to raise_error
+        end
+      end
+
+      context 'when isv_tracking_guid is provided' do
+        let(:logger) { Bosh::Clouds::Config.logger }
+        let(:isv_tracking_guid) { 'fake-isv-tracking-guid' }
+        let(:azure_client2) do
+          Bosh::AzureCloud::AzureClient2.new(
+            mock_azure_properties_merge('isv_tracking_guid' => isv_tracking_guid),
+            logger
+          )
+        end
+
+        it 'should set the guid in user agent' do
+          stub_request(:post, token_uri).to_return(
+            status: 200,
+            body: {
+              'access_token' => valid_access_token,
+              'expires_on' => expires_on
+            }.to_json,
+            headers: {}
+          )
+          stub_request(:put, vm_uri)
+            .with{ |request|
+              headers = request.headers
+              expect(headers['Content-Type']).to eq('application/json')
+              expect(headers['User-Agent']).to include("BOSH-AZURE-CPI/#{Bosh::AzureCloud::VERSION}")
+              expect(headers['User-Agent']).to include("pid-#{isv_tracking_guid}")
+            }
+            .to_return(
+              status: 200,
+              body: '',
+              headers: {
+                'azure-asyncoperation' => operation_status_link
+              }
+            )
+          stub_request(:get, operation_status_link).to_return(
+            status: 200,
+            body: '{"status":"Succeeded"}',
+            headers: {}
+          )
+
+          expect do
+            azure_client2.create_virtual_machine(resource_group, vm_params, network_interfaces)
+          end.not_to raise_error
+        end
+      end
+    end
+  end
+end

--- a/src/bosh_azure_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
@@ -334,12 +334,24 @@ describe 'cpi.json.erb' do
     end
 
     context 'when isv_tracking_guid is provided' do
-      before do
-        manifest['properties']['azure']['isv_tracking_guid'] = 'fake-tracking-guid'
+      context 'when guid is invalid' do
+        before do
+          manifest['properties']['azure']['isv_tracking_guid'] = 'fake-tracking-guid'
+        end
+
+        it 'raise an error' do
+          expect { subject }.to raise_error('Invalide "isv_tracking_guid", length of guid must be 36.')
+        end
       end
 
-      it 'is able to render isv_tracking_guid' do
-        expect(subject['cloud']['properties']['azure']['isv_tracking_guid']).to eq('fake-tracking-guid')
+      context 'when guid is valid' do
+        before do
+          manifest['properties']['azure']['isv_tracking_guid'] = 'cd237ace-be2a-425c-a30f-dd91d5e93d96'
+        end
+
+        it 'is able to render isv_tracking_guid' do
+          expect(subject['cloud']['properties']['azure']['isv_tracking_guid']).to eq('cd237ace-be2a-425c-a30f-dd91d5e93d96')
+        end
       end
     end
   end

--- a/src/bosh_azure_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
@@ -332,6 +332,16 @@ describe 'cpi.json.erb' do
         end
       end
     end
+
+    context 'when isv_tracking_guid is provided' do
+      before do
+        manifest['properties']['azure']['isv_tracking_guid'] = 'fake-tracking-guid'
+      end
+
+      it 'is able to render isv_tracking_guid' do
+        expect(subject['cloud']['properties']['azure']['isv_tracking_guid']).to eq('fake-tracking-guid')
+      end
+    end
   end
 
   context 'when parsing the registry property' do

--- a/src/bosh_azure_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
@@ -340,7 +340,7 @@ describe 'cpi.json.erb' do
         end
 
         it 'raise an error' do
-          expect { subject }.to raise_error('Invalide "isv_tracking_guid", length of guid must be 36.')
+          expect { subject }.to raise_error('Invalid "isv_tracking_guid", length of guid must be 36.')
         end
       end
 


### PR DESCRIPTION
- [x] Please check this box and fill the data as below once you have run the unit tests.
      Code coverage before your change: `865 examples, 0 failures. 3440 / 3493 LOC (98.48%) covered.`
      Code coverage with your change:   `868 examples, 0 failures. 3444 / 3497 LOC (98.48%) covered.`

  ```
  pushd src/bosh_azure_cpi
    ./bin/test-unit
  popd
  ```

  NOTE: Please see how to setup dev environment and run unit tests in docs/development.md.

### Changelog

* Allow partners to configure ISV tracking GUID

