### PR TITLE
Use WAIT_STEMCELL_COPY_INTERVAL instead of @wait_stemcell_copy_interval

### DIFF
--- a/src/bosh_azure_cpi/lib/cloud/azure/stemcell_manager.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/stemcell_manager.rb
@@ -5,12 +5,10 @@ module Bosh::AzureCloud
     STEMCELL_STATUS_PENDING       = 'pending'
     STEMCELL_STATUS_SUCCESS       = 'success'
     DEFAULT_COPY_STEMCELL_TIMEOUT = 20 * 60 # seconds
+    WAIT_STEMCELL_COPY_INTERVAL   = 3 # seconds
 
     include Bosh::Exec
     include Helpers
-
-    @wait_stemcell_copy_interval = 3 # seconds
-    attr_writer :wait_stemcell_copy_interval
 
     def initialize(blob_manager, table_manager, storage_account_manager)
       @blob_manager  = blob_manager
@@ -153,7 +151,7 @@ module Bosh::AzureCloud
           @blob_manager.delete_blob(storage_account_name, STEMCELL_CONTAINER, "#{name}.vhd")
           cloud_error("The operation of copying the stemcell #{name} to the storage account #{storage_account_name} timeouts")
         end
-        sleep(@wait_stemcell_copy_interval)
+        sleep(WAIT_STEMCELL_COPY_INTERVAL)
       end
     end
   end


### PR DESCRIPTION
- [x] Please check this box and fill the data as below once you have run the unit tests.
      Code coverage before your change: `869 examples, 0 failures. 3446 / 3499 LOC (98.49%) covered.`
      Code coverage with your change:   `869 examples, 0 failures. 3445 / 3498 LOC (98.48%) covered.`

The coverage drop is expected because we remove one line in stemcell_manager.rb.

### Changelog

* Use WAIT_STEMCELL_COPY_INTERVAL instead of @wait_stemcell_copy_interval
* Refine test cases in stemcell_manager_spec.rb
