### PR TITLE
Code relocated

### DIFF
--- a/src/bosh_azure_cpi/.rubocop_todo.yml
+++ b/src/bosh_azure_cpi/.rubocop_todo.yml
@@ -108,6 +108,8 @@ Metrics/ModuleLength:
 # Configuration parameters: CountKeywordArgs.
 Metrics/ParameterLists:
   Max: 7
+  Exclude:
+    - 'lib/cloud/azure/vm_manager.rb'
 
 # Offense count: 28
 Metrics/PerceivedComplexity:

--- a/src/bosh_azure_cpi/lib/cloud/azure/cloud.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/cloud.rb
@@ -168,39 +168,16 @@ module Bosh::AzureCloud
 
           if @use_managed_disks
             instance_id = InstanceId.create(resource_group_name, agent_id)
-
-            storage_account_type = vm_properties['storage_account_type']
-            storage_account_type = get_storage_account_type_by_instance_type(vm_properties['instance_type']) if storage_account_type.nil?
-
-            if is_light_stemcell_id?(stemcell_id)
-              raise Bosh::Clouds::VMCreationFailed.new(false), "Given stemcell '#{stemcell_id}' does not exist" unless @light_stemcell_manager.has_stemcell?(location, stemcell_id)
-              stemcell_info = @light_stemcell_manager.get_stemcell_info(stemcell_id)
-            else
-              begin
-                # Treat user_image_info as stemcell_info
-                stemcell_info = @stemcell_manager2.get_user_image_info(stemcell_id, storage_account_type, location)
-              rescue StandardError => e
-                raise Bosh::Clouds::VMCreationFailed.new(false), "Failed to get the user image information for the stemcell '#{stemcell_id}': #{e.inspect}\n#{e.backtrace.join("\n")}"
-              end
-            end
           else
             cloud_error('Virtual Machines deployed to an Availability Zone must use managed disks') unless vm_properties['availability_zone'].nil?
             storage_account = @storage_account_manager.get_storage_account_from_vm_properties(vm_properties, location)
             instance_id = InstanceId.create(resource_group_name, agent_id, storage_account[:name])
-
-            if is_light_stemcell_id?(stemcell_id)
-              raise Bosh::Clouds::VMCreationFailed.new(false), "Given stemcell '#{stemcell_id}' does not exist" unless @light_stemcell_manager.has_stemcell?(location, stemcell_id)
-              stemcell_info = @light_stemcell_manager.get_stemcell_info(stemcell_id)
-            else
-              raise Bosh::Clouds::VMCreationFailed.new(false), "Given stemcell '#{stemcell_id}' does not exist" unless @stemcell_manager.has_stemcell?(storage_account[:name], stemcell_id)
-              stemcell_info = @stemcell_manager.get_stemcell_info(storage_account[:name], stemcell_id)
-            end
           end
 
           vm_params = @vm_manager.create(
             instance_id,
             location,
-            stemcell_info,
+            stemcell_id,
             vm_properties,
             network_configurator,
             env
@@ -687,7 +664,7 @@ module Bosh::AzureCloud
       @disk_manager2           = Bosh::AzureCloud::DiskManager2.new(@azure_client)
       @stemcell_manager2       = Bosh::AzureCloud::StemcellManager2.new(@blob_manager, @table_manager, @storage_account_manager, @azure_client)
       @light_stemcell_manager  = Bosh::AzureCloud::LightStemcellManager.new(@blob_manager, @storage_account_manager, @azure_client)
-      @vm_manager              = Bosh::AzureCloud::VMManager.new(azure_config, @registry.endpoint, @disk_manager, @disk_manager2, @azure_client, @storage_account_manager)
+      @vm_manager              = Bosh::AzureCloud::VMManager.new(azure_config, @registry.endpoint, @disk_manager, @disk_manager2, @azure_client, @storage_account_manager, @stemcell_manager, @stemcell_manager2, @light_stemcell_manager)
       @instance_type_mapper    = Bosh::AzureCloud::InstanceTypeMapper.new
     rescue Net::OpenTimeout => e
       cloud_error("Please make sure the CPI has proper network access to Azure. #{e.inspect}") # TODO: Will it throw the error when initializing the client and manager

--- a/src/bosh_azure_cpi/spec/unit/vm_manager/attach_disk_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/vm_manager/attach_disk_spec.rb
@@ -10,7 +10,10 @@ describe Bosh::AzureCloud::VMManager do
     let(:client2) { instance_double(Bosh::AzureCloud::AzureClient) }
     let(:storage_account_manager) { instance_double(Bosh::AzureCloud::StorageAccountManager) }
     let(:azure_config) { mock_azure_config }
-    let(:vm_manager) { Bosh::AzureCloud::VMManager.new(azure_config, registry_endpoint, disk_manager, disk_manager2, client2, storage_account_manager) }
+    let(:stemcell_manager) { instance_double(Bosh::AzureCloud::StemcellManager) }
+    let(:stemcell_manager2) { instance_double(Bosh::AzureCloud::StemcellManager2) }
+    let(:light_stemcell_manager) { instance_double(Bosh::AzureCloud::LightStemcellManager) }
+    let(:vm_manager) { Bosh::AzureCloud::VMManager.new(azure_config, registry_endpoint, disk_manager, disk_manager2, client2, storage_account_manager, stemcell_manager, stemcell_manager2, light_stemcell_manager) }
 
     let(:caching) { 'fake-caching' }
     let(:lun) { 1 }

--- a/src/bosh_azure_cpi/spec/unit/vm_manager/create/accelerated_networking_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/vm_manager/create/accelerated_networking_spec.rb
@@ -10,6 +10,10 @@ describe Bosh::AzureCloud::VMManager do
   #   - resource_group_name
   #   - default_security_group
   describe '#create' do
+    before do
+      allow(vm_manager).to receive(:get_stemcell_info).and_return(stemcell_info)
+    end
+
     context 'when VM is created' do
       before do
         allow(client2).to receive(:create_virtual_machine)
@@ -35,7 +39,7 @@ describe Bosh::AzureCloud::VMManager do
               expect(client2).to receive(:create_network_interface)
                 .with(resource_group_name, hash_including(enable_accelerated_networking: false), any_args).twice
               expect do
-                vm_manager.create(instance_id, location, stemcell_info, vm_properties, network_configurator, env)
+                vm_manager.create(instance_id, location, stemcell_id, vm_properties, network_configurator, env)
               end.not_to raise_error
             end
           end
@@ -53,7 +57,7 @@ describe Bosh::AzureCloud::VMManager do
               expect(client2).to receive(:create_network_interface)
                 .with(resource_group_name, hash_including(enable_accelerated_networking: false), any_args).twice
               expect do
-                vm_manager.create(instance_id, location, stemcell_info, vm_properties, network_configurator, env)
+                vm_manager.create(instance_id, location, stemcell_id, vm_properties, network_configurator, env)
               end.not_to raise_error
             end
           end
@@ -71,7 +75,7 @@ describe Bosh::AzureCloud::VMManager do
               expect(client2).to receive(:create_network_interface)
                 .with(resource_group_name, hash_including(enable_accelerated_networking: true), any_args).twice
               expect do
-                vm_manager.create(instance_id, location, stemcell_info, vm_properties, network_configurator, env)
+                vm_manager.create(instance_id, location, stemcell_id, vm_properties, network_configurator, env)
               end.not_to raise_error
             end
           end
@@ -95,7 +99,7 @@ describe Bosh::AzureCloud::VMManager do
               expect(client2).to receive(:create_network_interface)
                 .with(resource_group_name, hash_including(enable_accelerated_networking: true), any_args).twice
               expect do
-                vm_manager.create(instance_id, location, stemcell_info, vm_properties, network_configurator, env)
+                vm_manager.create(instance_id, location, stemcell_id, vm_properties, network_configurator, env)
               end.not_to raise_error
             end
           end
@@ -113,7 +117,7 @@ describe Bosh::AzureCloud::VMManager do
               expect(client2).to receive(:create_network_interface)
                 .with(resource_group_name, hash_including(enable_accelerated_networking: false), any_args).twice
               expect do
-                vm_manager.create(instance_id, location, stemcell_info, vm_properties, network_configurator, env)
+                vm_manager.create(instance_id, location, stemcell_id, vm_properties, network_configurator, env)
               end.not_to raise_error
             end
           end
@@ -131,7 +135,7 @@ describe Bosh::AzureCloud::VMManager do
               expect(client2).to receive(:create_network_interface)
                 .with(resource_group_name, hash_including(enable_accelerated_networking: true), any_args).twice
               expect do
-                vm_manager.create(instance_id, location, stemcell_info, vm_properties, network_configurator, env)
+                vm_manager.create(instance_id, location, stemcell_id, vm_properties, network_configurator, env)
               end.not_to raise_error
             end
           end

--- a/src/bosh_azure_cpi/spec/unit/vm_manager/create/application_security_group_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/vm_manager/create/application_security_group_spec.rb
@@ -13,6 +13,8 @@ describe Bosh::AzureCloud::VMManager do
     context 'when VM is created' do
       before do
         allow(client2).to receive(:create_virtual_machine)
+        allow(vm_manager).to receive(:get_stemcell_info).and_return(stemcell_info)
+        allow(vm_manager2).to receive(:get_stemcell_info).and_return(stemcell_info)
       end
 
       # Resource group
@@ -28,7 +30,7 @@ describe Bosh::AzureCloud::VMManager do
           expect(client2).to receive(:create_resource_group)
             .with(resource_group_name, location)
 
-          vm_params = vm_manager.create(instance_id, location, stemcell_info, vm_properties, network_configurator, env)
+          vm_params = vm_manager.create(instance_id, location, stemcell_id, vm_properties, network_configurator, env)
           expect(vm_params[:name]).to eq(vm_name)
         end
       end
@@ -74,7 +76,7 @@ describe Bosh::AzureCloud::VMManager do
             expect(client2).to receive(:create_network_interface)
               .with(resource_group_name, hash_including(application_security_groups: asgs_in_network_spec), any_args).twice
             expect do
-              vm_manager.create(instance_id, location, stemcell_info, vm_properties, network_configurator, env)
+              vm_manager.create(instance_id, location, stemcell_id, vm_properties, network_configurator, env)
             end.not_to raise_error
           end
 
@@ -125,7 +127,7 @@ describe Bosh::AzureCloud::VMManager do
               expect(client2).not_to receive(:create_network_interface)
                 .with(resource_group_name, hash_including(application_security_groups: asgs_in_network_spec), any_args)
               expect do
-                vm_manager.create(instance_id, location, stemcell_info, vm_properties, network_configurator, env)
+                vm_manager.create(instance_id, location, stemcell_id, vm_properties, network_configurator, env)
               end.not_to raise_error
             end
           end
@@ -176,7 +178,7 @@ describe Bosh::AzureCloud::VMManager do
               expect(client2).to receive(:create_network_interface)
                 .with(resource_group_name, hash_including(application_security_groups: asgs), any_args).twice
               expect do
-                vm_manager.create(instance_id, location, stemcell_info, vm_properties, network_configurator, env)
+                vm_manager.create(instance_id, location, stemcell_id, vm_properties, network_configurator, env)
               end.not_to raise_error
             end
           end
@@ -210,7 +212,7 @@ describe Bosh::AzureCloud::VMManager do
                 expect(client2).to receive(:create_network_interface)
                   .with(rg_name_for_asg, hash_including(application_security_groups: asgs), any_args).twice
                 expect do
-                  vm_manager.create(instance_id, location, stemcell_info, vm_properties, network_configurator, env)
+                  vm_manager.create(instance_id, location, stemcell_id, vm_properties, network_configurator, env)
                 end.not_to raise_error
               end
             end
@@ -228,7 +230,7 @@ describe Bosh::AzureCloud::VMManager do
                 expect(client2).to receive(:create_network_interface)
                   .with(resource_group_name, hash_including(application_security_groups: asgs), any_args).twice
                 expect do
-                  vm_manager.create(instance_id, location, stemcell_info, vm_properties, network_configurator, env)
+                  vm_manager.create(instance_id, location, stemcell_id, vm_properties, network_configurator, env)
                 end.not_to raise_error
               end
             end
@@ -247,7 +249,7 @@ describe Bosh::AzureCloud::VMManager do
                 expect(client2).to receive(:list_network_interfaces_by_keyword).and_return([])
                 expect(client2).not_to receive(:delete_network_interface)
                 expect do
-                  vm_manager.create(instance_id, location, stemcell_info, vm_properties, network_configurator, env)
+                  vm_manager.create(instance_id, location, stemcell_id, vm_properties, network_configurator, env)
                 end.to raise_error /Cannot find the application security group '#{asg_name}'/
               end
             end
@@ -275,7 +277,7 @@ describe Bosh::AzureCloud::VMManager do
               expect(client2).to receive(:create_network_interface)
                 .with(resource_group_name, hash_including(enable_ip_forwarding: false), any_args).twice
               expect do
-                vm_manager.create(instance_id, location, stemcell_info, vm_properties, network_configurator, env)
+                vm_manager.create(instance_id, location, stemcell_id, vm_properties, network_configurator, env)
               end.not_to raise_error
             end
           end
@@ -293,7 +295,7 @@ describe Bosh::AzureCloud::VMManager do
               expect(client2).to receive(:create_network_interface)
                 .with(resource_group_name, hash_including(enable_ip_forwarding: false), any_args).twice
               expect do
-                vm_manager.create(instance_id, location, stemcell_info, vm_properties, network_configurator, env)
+                vm_manager.create(instance_id, location, stemcell_id, vm_properties, network_configurator, env)
               end.not_to raise_error
             end
           end
@@ -311,7 +313,7 @@ describe Bosh::AzureCloud::VMManager do
               expect(client2).to receive(:create_network_interface)
                 .with(resource_group_name, hash_including(enable_ip_forwarding: true), any_args).twice
               expect do
-                vm_manager.create(instance_id, location, stemcell_info, vm_properties, network_configurator, env)
+                vm_manager.create(instance_id, location, stemcell_id, vm_properties, network_configurator, env)
               end.not_to raise_error
             end
           end
@@ -335,7 +337,7 @@ describe Bosh::AzureCloud::VMManager do
               expect(client2).to receive(:create_network_interface)
                 .with(resource_group_name, hash_including(enable_ip_forwarding: true), any_args).twice
               expect do
-                vm_manager.create(instance_id, location, stemcell_info, vm_properties, network_configurator, env)
+                vm_manager.create(instance_id, location, stemcell_id, vm_properties, network_configurator, env)
               end.not_to raise_error
             end
           end
@@ -353,7 +355,7 @@ describe Bosh::AzureCloud::VMManager do
               expect(client2).to receive(:create_network_interface)
                 .with(resource_group_name, hash_including(enable_ip_forwarding: false), any_args).twice
               expect do
-                vm_manager.create(instance_id, location, stemcell_info, vm_properties, network_configurator, env)
+                vm_manager.create(instance_id, location, stemcell_id, vm_properties, network_configurator, env)
               end.not_to raise_error
             end
           end
@@ -371,7 +373,7 @@ describe Bosh::AzureCloud::VMManager do
               expect(client2).to receive(:create_network_interface)
                 .with(resource_group_name, hash_including(enable_ip_forwarding: true), any_args).twice
               expect do
-                vm_manager.create(instance_id, location, stemcell_info, vm_properties, network_configurator, env)
+                vm_manager.create(instance_id, location, stemcell_id, vm_properties, network_configurator, env)
               end.not_to raise_error
             end
           end
@@ -398,7 +400,7 @@ describe Bosh::AzureCloud::VMManager do
               expect(client2).to receive(:create_network_interface)
                 .with(resource_group_name, hash_including(enable_accelerated_networking: false), any_args).twice
               expect do
-                vm_manager.create(instance_id, location, stemcell_info, vm_properties, network_configurator, env)
+                vm_manager.create(instance_id, location, stemcell_id, vm_properties, network_configurator, env)
               end.not_to raise_error
             end
           end
@@ -416,7 +418,7 @@ describe Bosh::AzureCloud::VMManager do
               expect(client2).to receive(:create_network_interface)
                 .with(resource_group_name, hash_including(enable_accelerated_networking: false), any_args).twice
               expect do
-                vm_manager.create(instance_id, location, stemcell_info, vm_properties, network_configurator, env)
+                vm_manager.create(instance_id, location, stemcell_id, vm_properties, network_configurator, env)
               end.not_to raise_error
             end
           end
@@ -434,7 +436,7 @@ describe Bosh::AzureCloud::VMManager do
               expect(client2).to receive(:create_network_interface)
                 .with(resource_group_name, hash_including(enable_accelerated_networking: true), any_args).twice
               expect do
-                vm_manager.create(instance_id, location, stemcell_info, vm_properties, network_configurator, env)
+                vm_manager.create(instance_id, location, stemcell_id, vm_properties, network_configurator, env)
               end.not_to raise_error
             end
           end
@@ -458,7 +460,7 @@ describe Bosh::AzureCloud::VMManager do
               expect(client2).to receive(:create_network_interface)
                 .with(resource_group_name, hash_including(enable_accelerated_networking: true), any_args).twice
               expect do
-                vm_manager.create(instance_id, location, stemcell_info, vm_properties, network_configurator, env)
+                vm_manager.create(instance_id, location, stemcell_id, vm_properties, network_configurator, env)
               end.not_to raise_error
             end
           end
@@ -476,7 +478,7 @@ describe Bosh::AzureCloud::VMManager do
               expect(client2).to receive(:create_network_interface)
                 .with(resource_group_name, hash_including(enable_accelerated_networking: false), any_args).twice
               expect do
-                vm_manager.create(instance_id, location, stemcell_info, vm_properties, network_configurator, env)
+                vm_manager.create(instance_id, location, stemcell_id, vm_properties, network_configurator, env)
               end.not_to raise_error
             end
           end
@@ -494,7 +496,7 @@ describe Bosh::AzureCloud::VMManager do
               expect(client2).to receive(:create_network_interface)
                 .with(resource_group_name, hash_including(enable_accelerated_networking: true), any_args).twice
               expect do
-                vm_manager.create(instance_id, location, stemcell_info, vm_properties, network_configurator, env)
+                vm_manager.create(instance_id, location, stemcell_id, vm_properties, network_configurator, env)
               end.not_to raise_error
             end
           end
@@ -509,7 +511,7 @@ describe Bosh::AzureCloud::VMManager do
             expect(client2).not_to receive(:delete_network_interface)
 
             expect(client2).to receive(:create_network_interface).exactly(2).times
-            vm_params = vm_manager.create(instance_id, location, stemcell_info, vm_properties, network_configurator, env)
+            vm_params = vm_manager.create(instance_id, location, stemcell_id, vm_properties, network_configurator, env)
             expect(vm_params[:name]).to eq(vm_name)
             expect(vm_params[:image_uri]).to eq(stemcell_uri)
             expect(vm_params[:os_type]).to eq(os_type)
@@ -538,7 +540,7 @@ describe Bosh::AzureCloud::VMManager do
             expect(client2).not_to receive(:delete_network_interface)
 
             expect(client2).to receive(:create_network_interface).twice
-            vm_params = vm_manager.create(instance_id, location, stemcell_info, vm_properties, network_configurator, env)
+            vm_params = vm_manager.create(instance_id, location, stemcell_id, vm_properties, network_configurator, env)
             expect(vm_params[:name]).to eq(vm_name)
             expect(vm_params[:os_type]).to eq(os_type)
           end
@@ -564,7 +566,7 @@ describe Bosh::AzureCloud::VMManager do
             Bosh::AzureCloud::VMManager.new(
               mock_azure_config_merge(
                 'pip_idle_timeout_in_minutes' => idle_timeout
-              ), registry_endpoint, disk_manager, disk_manager2, client2, storage_account_manager
+              ), registry_endpoint, disk_manager, disk_manager2, client2, storage_account_manager, stemcell_manager, stemcell_manager2, light_stemcell_manager
             )
           end
           let(:public_ip_params) do
@@ -574,6 +576,10 @@ describe Bosh::AzureCloud::VMManager do
               is_static: false,
               idle_timeout_in_minutes: idle_timeout
             }
+          end
+
+          before do
+            allow(vm_manager_for_pip).to receive(:get_stemcell_info).and_return(stemcell_info)
           end
 
           it 'creates a public IP and assigns it to the primary NIC' do
@@ -589,7 +595,7 @@ describe Bosh::AzureCloud::VMManager do
                                            application_gateway: application_gateway
                                          )).once
 
-            vm_params = vm_manager_for_pip.create(instance_id, location, stemcell_info, vm_properties, network_configurator, env)
+            vm_params = vm_manager_for_pip.create(instance_id, location, stemcell_id, vm_properties, network_configurator, env)
             expect(vm_params[:name]).to eq(vm_name)
           end
         end
@@ -617,7 +623,7 @@ describe Bosh::AzureCloud::VMManager do
                                            application_gateway: application_gateway
                                          ))
 
-            vm_params = vm_manager.create(instance_id, location, stemcell_info, vm_properties, network_configurator, env)
+            vm_params = vm_manager.create(instance_id, location, stemcell_id, vm_properties, network_configurator, env)
             expect(vm_params[:name]).to eq(vm_name)
           end
         end
@@ -667,7 +673,7 @@ describe Bosh::AzureCloud::VMManager do
             expect(client2).not_to receive(:delete_network_interface)
             expect(client2).to receive(:create_virtual_machine)
               .with(resource_group_name, vm_params, network_interfaces, nil)
-            result = vm_manager2.create(instance_id, location, stemcell_info, vm_properties, network_configurator, env)
+            result = vm_manager2.create(instance_id, location, stemcell_id, vm_properties, network_configurator, env)
             expect(result[:name]).to eq(vm_name)
           end
         end
@@ -713,7 +719,7 @@ describe Bosh::AzureCloud::VMManager do
               .with(resource_group_name, vm_params, network_interfaces, nil)
             expect(SecureRandom).to receive(:uuid).exactly(3).times
             expect do
-              vm_manager2.create(instance_id, location, stemcell_info, vm_properties, network_configurator, env)
+              vm_manager2.create(instance_id, location, stemcell_id, vm_properties, network_configurator, env)
             end.not_to raise_error
           end
         end
@@ -740,7 +746,7 @@ describe Bosh::AzureCloud::VMManager do
             expect(client2).not_to receive(:delete_network_interface)
 
             expect do
-              vm_manager.create(instance_id, location, stemcell_info, vm_properties, network_configurator, env)
+              vm_manager.create(instance_id, location, stemcell_id, vm_properties, network_configurator, env)
             end.not_to raise_error
           end
         end
@@ -763,7 +769,7 @@ describe Bosh::AzureCloud::VMManager do
             expect(client2).not_to receive(:delete_network_interface)
 
             expect do
-              vm_manager2.create(instance_id, location, stemcell_info, vm_properties, network_configurator, env)
+              vm_manager2.create(instance_id, location, stemcell_id, vm_properties, network_configurator, env)
             end.not_to raise_error
           end
         end
@@ -777,7 +783,7 @@ describe Bosh::AzureCloud::VMManager do
               'enable_vm_boot_diagnostics' => true
             )
           end
-          let(:vm_manager) { Bosh::AzureCloud::VMManager.new(azure_config_debug, registry_endpoint, disk_manager, disk_manager2, client2, storage_account_manager) }
+          let(:vm_manager) { Bosh::AzureCloud::VMManager.new(azure_config_debug, registry_endpoint, disk_manager, disk_manager2, client2, storage_account_manager, stemcell_manager, stemcell_manager2, light_stemcell_manager) }
 
           let(:vm_location) { location }
           let(:diag_storage_uri) { 'fake-diag-storage-uri' }
@@ -804,7 +810,7 @@ describe Bosh::AzureCloud::VMManager do
               'environment' => 'AzureStack'
             )
           end
-          let(:vm_manager) { Bosh::AzureCloud::VMManager.new(azure_config_debug, registry_endpoint, disk_manager, disk_manager2, client2, storage_account_manager) }
+          let(:vm_manager) { Bosh::AzureCloud::VMManager.new(azure_config_debug, registry_endpoint, disk_manager, disk_manager2, client2, storage_account_manager, stemcell_manager, stemcell_manager2, light_stemcell_manager) }
 
           let(:vm_location) { location }
 
@@ -846,7 +852,7 @@ describe Bosh::AzureCloud::VMManager do
                     anything,
                     nil)             # Availability set must be nil when availability is specified
 
-            vm_params = vm_manager.create(instance_id, location, stemcell_info, vm_properties, network_configurator, env)
+            vm_params = vm_manager.create(instance_id, location, stemcell_id, vm_properties, network_configurator, env)
             expect(vm_params[:zone]).to eq(availability_zone)
           end
         end
@@ -859,7 +865,7 @@ describe Bosh::AzureCloud::VMManager do
                     anything,
                     nil)             # Availability set must be nil when availability is specified
 
-            vm_params = vm_manager.create(instance_id, location, stemcell_info, vm_properties, network_configurator, env)
+            vm_params = vm_manager.create(instance_id, location, stemcell_id, vm_properties, network_configurator, env)
             expect(vm_params[:zone]).to eq(availability_zone)
           end
         end
@@ -876,7 +882,7 @@ describe Bosh::AzureCloud::VMManager do
                     anything,
                     nil)             # Availability set must be nil when availability is specified
 
-            vm_params = vm_manager.create(instance_id, location, stemcell_info, vm_properties, network_configurator, env)
+            vm_params = vm_manager.create(instance_id, location, stemcell_id, vm_properties, network_configurator, env)
             expect(vm_params[:zone]).to eq('1')
           end
         end

--- a/src/bosh_azure_cpi/spec/unit/vm_manager/create/availability_zone_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/vm_manager/create/availability_zone_spec.rb
@@ -13,6 +13,7 @@ describe Bosh::AzureCloud::VMManager do
     context 'when VM is created' do
       before do
         allow(client2).to receive(:create_virtual_machine)
+        allow(vm_manager).to receive(:get_stemcell_info).and_return(stemcell_info)
       end
 
       # Availability Zones
@@ -46,7 +47,7 @@ describe Bosh::AzureCloud::VMManager do
                     anything,
                     nil)             # Availability set must be nil when availability is specified
 
-            vm_params = vm_manager.create(instance_id, location, stemcell_info, vm_properties, network_configurator, env)
+            vm_params = vm_manager.create(instance_id, location, stemcell_id, vm_properties, network_configurator, env)
             expect(vm_params[:zone]).to eq(availability_zone)
           end
         end
@@ -59,7 +60,7 @@ describe Bosh::AzureCloud::VMManager do
                     anything,
                     nil)             # Availability set must be nil when availability is specified
 
-            vm_params = vm_manager.create(instance_id, location, stemcell_info, vm_properties, network_configurator, env)
+            vm_params = vm_manager.create(instance_id, location, stemcell_id, vm_properties, network_configurator, env)
             expect(vm_params[:zone]).to eq(availability_zone)
           end
         end
@@ -76,7 +77,7 @@ describe Bosh::AzureCloud::VMManager do
                     anything,
                     nil)             # Availability set must be nil when availability is specified
 
-            vm_params = vm_manager.create(instance_id, location, stemcell_info, vm_properties, network_configurator, env)
+            vm_params = vm_manager.create(instance_id, location, stemcell_id, vm_properties, network_configurator, env)
             expect(vm_params[:zone]).to eq('1')
           end
         end

--- a/src/bosh_azure_cpi/spec/unit/vm_manager/create/dynamic_public_ip_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/vm_manager/create/dynamic_public_ip_spec.rb
@@ -13,6 +13,8 @@ describe Bosh::AzureCloud::VMManager do
     context 'when VM is created' do
       before do
         allow(client2).to receive(:create_virtual_machine)
+        allow(vm_manager).to receive(:get_stemcell_info).and_return(stemcell_info)
+        allow(vm_manager2).to receive(:get_stemcell_info).and_return(stemcell_info)
       end
 
       # Dynamic Public IP
@@ -34,7 +36,7 @@ describe Bosh::AzureCloud::VMManager do
             Bosh::AzureCloud::VMManager.new(
               mock_azure_config_merge(
                 'pip_idle_timeout_in_minutes' => idle_timeout
-              ), registry_endpoint, disk_manager, disk_manager2, client2, storage_account_manager
+              ), registry_endpoint, disk_manager, disk_manager2, client2, storage_account_manager, stemcell_manager, stemcell_manager2, light_stemcell_manager
             )
           end
           let(:public_ip_params) do
@@ -44,6 +46,10 @@ describe Bosh::AzureCloud::VMManager do
               is_static: false,
               idle_timeout_in_minutes: idle_timeout
             }
+          end
+
+          before do
+            allow(vm_manager_for_pip).to receive(:get_stemcell_info).and_return(stemcell_info)
           end
 
           it 'creates a public IP and assigns it to the primary NIC' do
@@ -59,7 +65,7 @@ describe Bosh::AzureCloud::VMManager do
                                            application_gateway: application_gateway
                                          )).once
 
-            vm_params = vm_manager_for_pip.create(instance_id, location, stemcell_info, vm_properties, network_configurator, env)
+            vm_params = vm_manager_for_pip.create(instance_id, location, stemcell_id, vm_properties, network_configurator, env)
             expect(vm_params[:name]).to eq(vm_name)
           end
         end
@@ -87,7 +93,7 @@ describe Bosh::AzureCloud::VMManager do
                                            application_gateway: application_gateway
                                          ))
 
-            vm_params = vm_manager.create(instance_id, location, stemcell_info, vm_properties, network_configurator, env)
+            vm_params = vm_manager.create(instance_id, location, stemcell_id, vm_properties, network_configurator, env)
             expect(vm_params[:name]).to eq(vm_name)
           end
         end
@@ -137,7 +143,7 @@ describe Bosh::AzureCloud::VMManager do
             expect(client2).not_to receive(:delete_network_interface)
             expect(client2).to receive(:create_virtual_machine)
               .with(resource_group_name, vm_params, network_interfaces, nil)
-            result = vm_manager2.create(instance_id, location, stemcell_info, vm_properties, network_configurator, env)
+            result = vm_manager2.create(instance_id, location, stemcell_id, vm_properties, network_configurator, env)
             expect(result[:name]).to eq(vm_name)
           end
         end
@@ -183,7 +189,7 @@ describe Bosh::AzureCloud::VMManager do
               .with(resource_group_name, vm_params, network_interfaces, nil)
             expect(SecureRandom).to receive(:uuid).exactly(3).times
             expect do
-              vm_manager2.create(instance_id, location, stemcell_info, vm_properties, network_configurator, env)
+              vm_manager2.create(instance_id, location, stemcell_id, vm_properties, network_configurator, env)
             end.not_to raise_error
           end
         end
@@ -210,7 +216,7 @@ describe Bosh::AzureCloud::VMManager do
             expect(client2).not_to receive(:delete_network_interface)
 
             expect do
-              vm_manager.create(instance_id, location, stemcell_info, vm_properties, network_configurator, env)
+              vm_manager.create(instance_id, location, stemcell_id, vm_properties, network_configurator, env)
             end.not_to raise_error
           end
         end
@@ -233,7 +239,7 @@ describe Bosh::AzureCloud::VMManager do
             expect(client2).not_to receive(:delete_network_interface)
 
             expect do
-              vm_manager2.create(instance_id, location, stemcell_info, vm_properties, network_configurator, env)
+              vm_manager2.create(instance_id, location, stemcell_id, vm_properties, network_configurator, env)
             end.not_to raise_error
           end
         end

--- a/src/bosh_azure_cpi/spec/unit/vm_manager/create/ip_forwarding_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/vm_manager/create/ip_forwarding_spec.rb
@@ -13,6 +13,7 @@ describe Bosh::AzureCloud::VMManager do
     context 'when VM is created' do
       before do
         allow(client2).to receive(:create_virtual_machine)
+        allow(vm_manager).to receive(:get_stemcell_info).and_return(stemcell_info)
       end
 
       # IP Forwarding
@@ -35,7 +36,7 @@ describe Bosh::AzureCloud::VMManager do
               expect(client2).to receive(:create_network_interface)
                 .with(resource_group_name, hash_including(enable_ip_forwarding: false), any_args).twice
               expect do
-                vm_manager.create(instance_id, location, stemcell_info, vm_properties, network_configurator, env)
+                vm_manager.create(instance_id, location, stemcell_id, vm_properties, network_configurator, env)
               end.not_to raise_error
             end
           end
@@ -53,7 +54,7 @@ describe Bosh::AzureCloud::VMManager do
               expect(client2).to receive(:create_network_interface)
                 .with(resource_group_name, hash_including(enable_ip_forwarding: false), any_args).twice
               expect do
-                vm_manager.create(instance_id, location, stemcell_info, vm_properties, network_configurator, env)
+                vm_manager.create(instance_id, location, stemcell_id, vm_properties, network_configurator, env)
               end.not_to raise_error
             end
           end
@@ -71,7 +72,7 @@ describe Bosh::AzureCloud::VMManager do
               expect(client2).to receive(:create_network_interface)
                 .with(resource_group_name, hash_including(enable_ip_forwarding: true), any_args).twice
               expect do
-                vm_manager.create(instance_id, location, stemcell_info, vm_properties, network_configurator, env)
+                vm_manager.create(instance_id, location, stemcell_id, vm_properties, network_configurator, env)
               end.not_to raise_error
             end
           end
@@ -95,7 +96,7 @@ describe Bosh::AzureCloud::VMManager do
               expect(client2).to receive(:create_network_interface)
                 .with(resource_group_name, hash_including(enable_ip_forwarding: true), any_args).twice
               expect do
-                vm_manager.create(instance_id, location, stemcell_info, vm_properties, network_configurator, env)
+                vm_manager.create(instance_id, location, stemcell_id, vm_properties, network_configurator, env)
               end.not_to raise_error
             end
           end
@@ -113,7 +114,7 @@ describe Bosh::AzureCloud::VMManager do
               expect(client2).to receive(:create_network_interface)
                 .with(resource_group_name, hash_including(enable_ip_forwarding: false), any_args).twice
               expect do
-                vm_manager.create(instance_id, location, stemcell_info, vm_properties, network_configurator, env)
+                vm_manager.create(instance_id, location, stemcell_id, vm_properties, network_configurator, env)
               end.not_to raise_error
             end
           end
@@ -131,7 +132,7 @@ describe Bosh::AzureCloud::VMManager do
               expect(client2).to receive(:create_network_interface)
                 .with(resource_group_name, hash_including(enable_ip_forwarding: true), any_args).twice
               expect do
-                vm_manager.create(instance_id, location, stemcell_info, vm_properties, network_configurator, env)
+                vm_manager.create(instance_id, location, stemcell_id, vm_properties, network_configurator, env)
               end.not_to raise_error
             end
           end

--- a/src/bosh_azure_cpi/spec/unit/vm_manager/create/resource_group_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/vm_manager/create/resource_group_spec.rb
@@ -10,6 +10,10 @@ describe Bosh::AzureCloud::VMManager do
   #   - resource_group_name
   #   - default_security_group
   describe '#create' do
+    before do
+      allow(vm_manager).to receive(:get_stemcell_info).and_return(stemcell_info)
+    end
+
     context 'when VM is created' do
       before do
         allow(client2).to receive(:create_virtual_machine)
@@ -28,7 +32,7 @@ describe Bosh::AzureCloud::VMManager do
           expect(client2).to receive(:create_resource_group)
             .with(resource_group_name, location)
 
-          vm_params = vm_manager.create(instance_id, location, stemcell_info, vm_properties, network_configurator, env)
+          vm_params = vm_manager.create(instance_id, location, stemcell_id, vm_properties, network_configurator, env)
           expect(vm_params[:name]).to eq(vm_name)
         end
       end

--- a/src/bosh_azure_cpi/spec/unit/vm_manager/create/shared_stuff.rb
+++ b/src/bosh_azure_cpi/spec/unit/vm_manager/create/shared_stuff.rb
@@ -14,15 +14,19 @@ shared_context 'shared stuff for vm manager' do
   let(:disk_manager2) { instance_double(Bosh::AzureCloud::DiskManager2) }
   let(:client2) { instance_double(Bosh::AzureCloud::AzureClient) }
   let(:storage_account_manager) { instance_double(Bosh::AzureCloud::StorageAccountManager) }
+  let(:stemcell_manager) { instance_double(Bosh::AzureCloud::StemcellManager) }
+  let(:stemcell_manager2) { instance_double(Bosh::AzureCloud::StemcellManager2) }
+  let(:light_stemcell_manager) { instance_double(Bosh::AzureCloud::LightStemcellManager) }
 
   # VM manager for unmanaged disks
-  let(:vm_manager) { Bosh::AzureCloud::VMManager.new(azure_config, registry_endpoint, disk_manager, disk_manager2, client2, storage_account_manager) }
+  let(:vm_manager) { Bosh::AzureCloud::VMManager.new(azure_config, registry_endpoint, disk_manager, disk_manager2, client2, storage_account_manager, stemcell_manager, stemcell_manager2, light_stemcell_manager) }
   # VM manager for managed disks
-  let(:vm_manager2) { Bosh::AzureCloud::VMManager.new(azure_config_managed, registry_endpoint, disk_manager, disk_manager2, client2, storage_account_manager) }
+  let(:vm_manager2) { Bosh::AzureCloud::VMManager.new(azure_config_managed, registry_endpoint, disk_manager, disk_manager2, client2, storage_account_manager, stemcell_manager, stemcell_manager2, light_stemcell_manager) }
 
   # Parameters of create
   let(:instance_id) { instance_double(Bosh::AzureCloud::InstanceId) }
   let(:location) { 'fake-location' }
+  let(:stemcell_id) { 'fake-stemcell-id' }
   let(:stemcell_info) { instance_double(Bosh::AzureCloud::Helpers::StemcellInfo) }
   let(:vm_properties) do
     {

--- a/src/bosh_azure_cpi/spec/unit/vm_manager/create/stemcell_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/vm_manager/create/stemcell_spec.rb
@@ -13,6 +13,7 @@ describe Bosh::AzureCloud::VMManager do
     context 'when VM is created' do
       before do
         allow(client2).to receive(:create_virtual_machine)
+        allow(vm_manager).to receive(:get_stemcell_info).and_return(stemcell_info)
       end
 
       # Stemcell
@@ -55,6 +56,159 @@ describe Bosh::AzureCloud::VMManager do
             vm_params = vm_manager.create(instance_id, location, stemcell_info, vm_properties, network_configurator, env)
             expect(vm_params[:name]).to eq(vm_name)
             expect(vm_params[:os_type]).to eq(os_type)
+          end
+        end
+      end
+    end
+  end
+
+  describe '#get_stemcell_info' do
+    context 'when managed disks are used' do
+      context 'when light stemcell is used' do
+        let(:stemcell_id) { 'bosh-light-stemcell-xxx' }
+
+        context 'when stemcell does not exist' do
+          before do
+            allow(light_stemcell_manager).to receive(:has_stemcell?).with(location, stemcell_id).and_return(false)
+          end
+
+          it 'should raise an error' do
+            expect do
+              vm_manager2.send(:get_stemcell_info, stemcell_id, vm_properties, location)
+            end.to raise_error("Given stemcell '#{stemcell_id}' does not exist")
+          end
+        end
+
+        context 'when stemcell exists' do
+          let(:stemcell_info) { double('stemcell-info') }
+
+          before do
+            allow(light_stemcell_manager).to receive(:has_stemcell?).with(location, stemcell_id).and_return(true)
+            allow(light_stemcell_manager).to receive(:get_stemcell_info).with(stemcell_id).and_return(stemcell_info)
+          end
+
+          it 'should return the stemcell info' do
+            expect(
+              vm_manager2.send(:get_stemcell_info, stemcell_id, vm_properties, location)
+            ).to be(stemcell_info)
+          end
+        end
+      end
+
+      context 'when heavy stemcell is used' do
+        let(:stemcell_id) { 'bosh-stemcell-xxx' }
+
+        context 'when it gets user image successfully' do
+          let(:stemcell_info) { double('stemcell-info') }
+
+          before do
+            allow(stemcell_manager2).to receive(:get_user_image_info)
+              .with(stemcell_id, 'Standard_LRS', location)
+              .and_return(stemcell_info)
+          end
+
+          it 'should return the stemcell info' do
+            expect(
+              vm_manager2.send(:get_stemcell_info, stemcell_id, vm_properties, location)
+            ).to be(stemcell_info)
+          end
+        end
+
+        context 'when it fails to user image successfully' do
+          let(:stemcell_info) { double('stemcell-info') }
+
+          before do
+            allow(stemcell_manager2).to receive(:get_user_image_info)
+              .with(stemcell_id, 'Standard_LRS', location)
+              .and_raise('fake-error')
+          end
+
+          it 'should return the stemcell info' do
+            expect do
+              vm_manager2.send(:get_stemcell_info, stemcell_id, vm_properties, location)
+            end.to raise_error(/Failed to get the user image information for the stemcell '#{stemcell_id}'/)
+          end
+        end
+      end
+    end
+
+    context 'when unmanaged disks are used' do
+      let(:storage_account) do
+        {
+          name: 'fake-storage-account-name'
+        }
+      end
+
+      before do
+        allow(storage_account_manager).to receive(:get_storage_account_from_vm_properties)
+          .with(vm_properties, location)
+          .and_return(storage_account)
+      end
+
+      context 'when light stemcell is used' do
+        let(:stemcell_id) { 'bosh-light-stemcell-xxx' }
+
+        context 'when stemcell does not exist' do
+          before do
+            allow(light_stemcell_manager).to receive(:has_stemcell?).with(location, stemcell_id).and_return(false)
+          end
+
+          it 'should raise an error' do
+            expect do
+              vm_manager.send(:get_stemcell_info, stemcell_id, vm_properties, location)
+            end.to raise_error("Given stemcell '#{stemcell_id}' does not exist")
+          end
+        end
+
+        context 'when stemcell exists' do
+          let(:stemcell_info) { double('stemcell-info') }
+
+          before do
+            allow(light_stemcell_manager).to receive(:has_stemcell?).with(location, stemcell_id).and_return(true)
+            allow(light_stemcell_manager).to receive(:get_stemcell_info).with(stemcell_id).and_return(stemcell_info)
+          end
+
+          it 'should return the stemcell info' do
+            expect(
+              vm_manager.send(:get_stemcell_info, stemcell_id, vm_properties, location)
+            ).to be(stemcell_info)
+          end
+        end
+      end
+
+      context 'when heavy stemcell is used' do
+        let(:stemcell_id) { 'bosh-stemcell-xxx' }
+
+        context 'when it fails to get stemcell' do
+          before do
+            allow(stemcell_manager).to receive(:has_stemcell?)
+              .with('fake-storage-account-name', stemcell_id)
+              .and_return(false)
+          end
+
+          it 'should raise an error' do
+            expect do
+              vm_manager.send(:get_stemcell_info, stemcell_id, vm_properties, location)
+            end.to raise_error("Given stemcell '#{stemcell_id}' does not exist")
+          end
+        end
+
+        context 'when it gets the stemcell successfully' do
+          let(:stemcell_info) { double('stemcell-info') }
+
+          before do
+            allow(stemcell_manager).to receive(:has_stemcell?)
+              .with('fake-storage-account-name', stemcell_id)
+              .and_return(true)
+            allow(stemcell_manager).to receive(:get_stemcell_info)
+              .with('fake-storage-account-name', stemcell_id)
+              .and_return(stemcell_info)
+          end
+
+          it 'should return stemcell info' do
+            expect(
+              vm_manager.send(:get_stemcell_info, stemcell_id, vm_properties, location)
+            ).to be(stemcell_info)
           end
         end
       end

--- a/src/bosh_azure_cpi/spec/unit/vm_manager/create/tags_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/vm_manager/create/tags_spec.rb
@@ -10,6 +10,10 @@ describe Bosh::AzureCloud::VMManager do
   #   - resource_group_name
   #   - default_security_group
   describe '#create' do
+    before do
+      allow(vm_manager).to receive(:get_stemcell_info).and_return(stemcell_info)
+    end
+
     context 'when VM is created' do
       # Tags
       context '#tags' do
@@ -32,7 +36,7 @@ describe Bosh::AzureCloud::VMManager do
             expect(client2).to receive(:create_virtual_machine)
               .with(resource_group_name, hash_including(tags: custom_tags.merge(Bosh::AzureCloud::Helpers::AZURE_TAGS)), any_args)
             expect do
-              vm_manager.create(instance_id, location, stemcell_info, vm_properties, network_configurator, env)
+              vm_manager.create(instance_id, location, stemcell_id, vm_properties, network_configurator, env)
             end.not_to raise_error
           end
         end

--- a/src/bosh_azure_cpi/spec/unit/vm_manager/delete_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/vm_manager/delete_spec.rb
@@ -10,7 +10,10 @@ describe Bosh::AzureCloud::VMManager do
     let(:client2) { instance_double(Bosh::AzureCloud::AzureClient) }
     let(:storage_account_manager) { instance_double(Bosh::AzureCloud::StorageAccountManager) }
     let(:azure_config) { mock_azure_config }
-    let(:vm_manager) { Bosh::AzureCloud::VMManager.new(azure_config, registry_endpoint, disk_manager, disk_manager2, client2, storage_account_manager) }
+    let(:stemcell_manager) { instance_double(Bosh::AzureCloud::StemcellManager) }
+    let(:stemcell_manager2) { instance_double(Bosh::AzureCloud::StemcellManager2) }
+    let(:light_stemcell_manager) { instance_double(Bosh::AzureCloud::LightStemcellManager) }
+    let(:vm_manager) { Bosh::AzureCloud::VMManager.new(azure_config, registry_endpoint, disk_manager, disk_manager2, client2, storage_account_manager, stemcell_manager, stemcell_manager2, light_stemcell_manager) }
 
     let(:resource_group_name) { 'fake-resource-group-name' }
     let(:storage_account_name) { 'fake-storage-account-name' }
@@ -32,6 +35,19 @@ describe Bosh::AzureCloud::VMManager do
 
     let(:instance_id) { instance_double(Bosh::AzureCloud::InstanceId) }
 
+    let(:network_interfaces) do
+      [
+        {
+          name: 'fake-nic-1',
+          tags: {}
+        },
+        {
+          name: 'fake-nic-2',
+          tags: {}
+        }
+      ]
+    end
+
     before do
       allow(instance_id).to receive(:resource_group_name)
         .and_return(resource_group_name)
@@ -46,6 +62,9 @@ describe Bosh::AzureCloud::VMManager do
         .with(resource_group_name, vm_name).and_return(network_interface)
       allow(client2).to receive(:get_public_ip_by_name)
         .with(resource_group_name, vm_name).and_return(public_ip)
+
+      allow(client2).to receive(:list_network_interfaces_by_keyword)
+        .with(resource_group_name, vm_name).and_return(network_interfaces)
     end
 
     context 'When vm is not nil' do
@@ -70,6 +89,7 @@ describe Bosh::AzureCloud::VMManager do
             ]
           }
         end
+
         before do
           allow(client2).to receive(:get_virtual_machine_by_name)
             .with(resource_group_name, vm_name).and_return(vm)

--- a/src/bosh_azure_cpi/spec/unit/vm_manager/detach_disk_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/vm_manager/detach_disk_spec.rb
@@ -10,7 +10,10 @@ describe Bosh::AzureCloud::VMManager do
     let(:client2) { instance_double(Bosh::AzureCloud::AzureClient) }
     let(:storage_account_manager) { instance_double(Bosh::AzureCloud::StorageAccountManager) }
     let(:azure_config) { mock_azure_config }
-    let(:vm_manager) { Bosh::AzureCloud::VMManager.new(azure_config, registry_endpoint, disk_manager, disk_manager2, client2, storage_account_manager) }
+    let(:stemcell_manager) { instance_double(Bosh::AzureCloud::StemcellManager) }
+    let(:stemcell_manager2) { instance_double(Bosh::AzureCloud::StemcellManager2) }
+    let(:light_stemcell_manager) { instance_double(Bosh::AzureCloud::LightStemcellManager) }
+    let(:vm_manager) { Bosh::AzureCloud::VMManager.new(azure_config, registry_endpoint, disk_manager, disk_manager2, client2, storage_account_manager, stemcell_manager, stemcell_manager2, light_stemcell_manager) }
 
     let(:instance_id) { instance_double(Bosh::AzureCloud::InstanceId) }
     let(:disk_id) { instance_double(Bosh::AzureCloud::DiskId) }

--- a/src/bosh_azure_cpi/spec/unit/vm_manager/find_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/vm_manager/find_spec.rb
@@ -10,7 +10,10 @@ describe Bosh::AzureCloud::VMManager do
     let(:client2) { instance_double(Bosh::AzureCloud::AzureClient) }
     let(:storage_account_manager) { instance_double(Bosh::AzureCloud::StorageAccountManager) }
     let(:azure_config) { mock_azure_config }
-    let(:vm_manager) { Bosh::AzureCloud::VMManager.new(azure_config, registry_endpoint, disk_manager, disk_manager2, client2, storage_account_manager) }
+    let(:stemcell_manager) { instance_double(Bosh::AzureCloud::StemcellManager) }
+    let(:stemcell_manager2) { instance_double(Bosh::AzureCloud::StemcellManager2) }
+    let(:light_stemcell_manager) { instance_double(Bosh::AzureCloud::LightStemcellManager) }
+    let(:vm_manager) { Bosh::AzureCloud::VMManager.new(azure_config, registry_endpoint, disk_manager, disk_manager2, client2, storage_account_manager, stemcell_manager, stemcell_manager2, light_stemcell_manager) }
 
     let(:instance_id) { instance_double(Bosh::AzureCloud::InstanceId) }
 

--- a/src/bosh_azure_cpi/spec/unit/vm_manager/reboot_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/vm_manager/reboot_spec.rb
@@ -10,7 +10,10 @@ describe Bosh::AzureCloud::VMManager do
     let(:client2) { instance_double(Bosh::AzureCloud::AzureClient) }
     let(:storage_account_manager) { instance_double(Bosh::AzureCloud::StorageAccountManager) }
     let(:azure_config) { mock_azure_config }
-    let(:vm_manager) { Bosh::AzureCloud::VMManager.new(azure_config, registry_endpoint, disk_manager, disk_manager2, client2, storage_account_manager) }
+    let(:stemcell_manager) { instance_double(Bosh::AzureCloud::StemcellManager) }
+    let(:stemcell_manager2) { instance_double(Bosh::AzureCloud::StemcellManager2) }
+    let(:light_stemcell_manager) { instance_double(Bosh::AzureCloud::LightStemcellManager) }
+    let(:vm_manager) { Bosh::AzureCloud::VMManager.new(azure_config, registry_endpoint, disk_manager, disk_manager2, client2, storage_account_manager, stemcell_manager, stemcell_manager2, light_stemcell_manager) }
 
     let(:instance_id) { instance_double(Bosh::AzureCloud::InstanceId) }
 

--- a/src/bosh_azure_cpi/spec/unit/vm_manager/set_metadata_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/vm_manager/set_metadata_spec.rb
@@ -10,7 +10,10 @@ describe Bosh::AzureCloud::VMManager do
     let(:client2) { instance_double(Bosh::AzureCloud::AzureClient) }
     let(:storage_account_manager) { instance_double(Bosh::AzureCloud::StorageAccountManager) }
     let(:azure_config) { mock_azure_config }
-    let(:vm_manager) { Bosh::AzureCloud::VMManager.new(azure_config, registry_endpoint, disk_manager, disk_manager2, client2, storage_account_manager) }
+    let(:stemcell_manager) { instance_double(Bosh::AzureCloud::StemcellManager) }
+    let(:stemcell_manager2) { instance_double(Bosh::AzureCloud::StemcellManager2) }
+    let(:light_stemcell_manager) { instance_double(Bosh::AzureCloud::LightStemcellManager) }
+    let(:vm_manager) { Bosh::AzureCloud::VMManager.new(azure_config, registry_endpoint, disk_manager, disk_manager2, client2, storage_account_manager, stemcell_manager, stemcell_manager2, light_stemcell_manager) }
 
     let(:instance_id) { instance_double(Bosh::AzureCloud::InstanceId) }
 


### PR DESCRIPTION
Code relocated:
1. checks stemcell_info in vm_manager
2. decouples creating/deleting VM and availability set

- [x] Please check this box and fill the data as below once you have run the unit tests.
      Code coverage before your change: `869 examples, 0 failures. 3445 / 3498 LOC (98.48%) covered.`
      Code coverage with your change:   `871 examples, 0 failures. 3467 / 3520 LOC (98.49%) covered.`

  ```
  pushd src/bosh_azure_cpi
    ./bin/test-unit
  popd
  ```

  NOTE: Please see how to setup dev environment and run unit tests in docs/development.md.

### Changelog

* relocate codes
