### PR TITLE
Support application security groups in Azure USGov Cloud and Azure German Cloud

### DIFF
--- a/src/bosh_azure_cpi/lib/cloud/azure/helpers.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/helpers.rb
@@ -42,7 +42,7 @@ module Bosh::AzureCloud
         'activeDirectoryEndpointUrl' => 'https://login.microsoftonline.us',
         'apiVersion' => {
           AZURE_RESOURCE_PROVIDER_COMPUTE          => '2016-04-30-preview',
-          AZURE_RESOURCE_PROVIDER_NETWORK          => '2015-06-15',
+          AZURE_RESOURCE_PROVIDER_NETWORK          => '2017-09-01',
           AZURE_RESOURCE_PROVIDER_STORAGE          => '2017-10-01',
           AZURE_RESOURCE_PROVIDER_GROUP            => '2016-06-01',
           AZURE_RESOURCE_PROVIDER_ACTIVEDIRECTORY  => '2015-06-15'
@@ -62,7 +62,7 @@ module Bosh::AzureCloud
         'activeDirectoryEndpointUrl' => 'https://login.microsoftonline.de',
         'apiVersion' => {
           AZURE_RESOURCE_PROVIDER_COMPUTE          => '2016-04-30-preview',
-          AZURE_RESOURCE_PROVIDER_NETWORK          => '2015-06-15',
+          AZURE_RESOURCE_PROVIDER_NETWORK          => '2017-09-01',
           AZURE_RESOURCE_PROVIDER_STORAGE          => '2017-10-01',
           AZURE_RESOURCE_PROVIDER_GROUP            => '2016-06-01',
           AZURE_RESOURCE_PROVIDER_ACTIVEDIRECTORY  => '2015-06-15'


### PR DESCRIPTION
Fixes #449 
Azure China Cloud still doesn't support application security groups.