### PR TITLE
Create a task to upload stemcell

### DIFF
--- a/ci/pipeline-develop.yml
+++ b/ci/pipeline-develop.yml
@@ -72,6 +72,17 @@ shared:
       BAT_NETWORKING:                     manual
       BAT_RSPEC_FLAGS:                    "--tag ~raw_ephemeral_storage"
 
+  - &run-az-bats
+    task: run-az-bats
+    file: bosh-cpi-src/ci/tasks/run-az-bats.yml
+    params: &run-az-bats-params
+      INFRASTRUCTURE:                     azure
+      STEMCELL_NAME:                      bosh-azure-hyperv-ubuntu-trusty-go_agent
+      BAT_INFRASTRUCTURE:                 azure
+      BAT_NETWORKING:                     manual
+      BAT_RSPEC_FLAGS:                    "--tag ~raw_ephemeral_storage"
+      AZURE_BATS_ZONE:                    {{azure_bats_zone}}
+
   - &teardown
     task: teardown
     file: pipelines/shared/tasks/teardown.yml
@@ -92,6 +103,12 @@ shared:
     get_params:
       action: destroy
 
+  - &upload-stemcell
+    task: upload-stemcell
+    file: bosh-cpi-src/ci/tasks/upload-stemcell.yml
+    params: &upload-stemcell-params
+      <<: *azure-environment-params
+
   - &run-integration
     task: run-integration
     file: bosh-cpi-src/ci/tasks/run-integration.yml
@@ -110,17 +127,6 @@ shared:
     file: bosh-cpi-src/ci/tasks/ensure-cleanup.yml
     params:
       <<: *azure-environment-params
-
-  - &run-az-bats
-    task: run-az-bats
-    file: bosh-cpi-src/ci/tasks/run-az-bats.yml
-    params: &run-az-bats-params
-      INFRASTRUCTURE:                     azure
-      STEMCELL_NAME:                      bosh-azure-hyperv-ubuntu-trusty-go_agent
-      BAT_INFRASTRUCTURE:                 azure
-      BAT_NETWORKING:                     manual
-      BAT_RSPEC_FLAGS:                    "--tag ~raw_ephemeral_storage"
-      AZURE_BATS_ZONE:                    {{azure_bats_zone}}
 
 jobs:
   - name: build-candidate
@@ -146,10 +152,12 @@ jobs:
         - {get: bosh-cpi-src,     trigger: false, resource: bosh-cpi-src-in,        passed: [build-candidate]}
         - {get: stemcell,         trigger: false, resource: azure-ubuntu-stemcell}
       - <<: *create-integration-environment
-      - <<: *run-integration
-        params:
-          <<: *run-integration-params
-          AZURE_USE_MANAGED_DISKS: false
+      - do:
+        - <<: *upload-stemcell
+        - <<: *run-integration
+          params:
+            <<: *run-integration-params
+            AZURE_USE_MANAGED_DISKS: false
         ensure:
           do:
             - <<: *destroy-integration-environment
@@ -165,10 +173,12 @@ jobs:
         - {get: bosh-cpi-src,     trigger: false, resource: bosh-cpi-src-in,        passed: [build-candidate]}
         - {get: stemcell,         trigger: false, resource: azure-ubuntu-stemcell}
       - <<: *create-integration-environment
-      - <<: *run-integration
-        params:
-          <<: *run-integration-params
-          AZURE_USE_MANAGED_DISKS: true
+      - do:
+        - <<: *upload-stemcell
+        - <<: *run-integration
+          params:
+            <<: *run-integration-params
+            AZURE_USE_MANAGED_DISKS: true
         ensure:
           do:
             - <<: *destroy-integration-environment
@@ -184,10 +194,15 @@ jobs:
         - {get: bosh-cpi-src,     trigger: false, resource: bosh-cpi-src-in,        passed: [build-candidate]}
         - {get: stemcell,         trigger: false, resource: azure-windows-stemcell}
       - <<: *create-integration-environment
-      - <<: *run-integration-windows
-        params:
-          <<: *run-integration-windows-params
-          AZURE_USE_MANAGED_DISKS: false
+      - do:
+        - <<: *upload-stemcell
+          params:
+            <<: *azure-environment-params
+            IS_HEAVY_STEMCELL: false
+        - <<: *run-integration-windows
+          params:
+            <<: *run-integration-windows-params
+            AZURE_USE_MANAGED_DISKS: false
         ensure:
           do:
             - <<: *destroy-integration-environment
@@ -203,10 +218,15 @@ jobs:
         - {get: bosh-cpi-src,     trigger: false, resource: bosh-cpi-src-in,        passed: [build-candidate]}
         - {get: stemcell,         trigger: false, resource: azure-windows-stemcell}
       - <<: *create-integration-environment
-      - <<: *run-integration-windows
-        params:
-          <<: *run-integration-windows-params
-          AZURE_USE_MANAGED_DISKS: true
+      - do:
+        - <<: *upload-stemcell
+          params:
+            <<: *azure-environment-params
+            IS_HEAVY_STEMCELL: false
+        - <<: *run-integration-windows
+          params:
+            <<: *run-integration-windows-params
+            AZURE_USE_MANAGED_DISKS: true
         ensure:
           do:
             - <<: *destroy-integration-environment

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -75,6 +75,17 @@ shared:
       BAT_NETWORKING:                     manual
       BAT_RSPEC_FLAGS:                    "--tag ~raw_ephemeral_storage"
 
+  - &run-az-bats
+    task: run-az-bats
+    file: bosh-cpi-src/ci/tasks/run-az-bats.yml
+    params: &run-az-bats-params
+      INFRASTRUCTURE:                     azure
+      STEMCELL_NAME:                      bosh-azure-hyperv-ubuntu-trusty-go_agent
+      BAT_INFRASTRUCTURE:                 azure
+      BAT_NETWORKING:                     manual
+      BAT_RSPEC_FLAGS:                    "--tag ~raw_ephemeral_storage"
+      AZURE_BATS_ZONE:                    {{azure_bats_zone}}
+
   - &teardown
     task: teardown
     file: pipelines/shared/tasks/teardown.yml
@@ -95,6 +106,12 @@ shared:
     get_params:
       action: destroy
 
+  - &upload-stemcell
+    task: upload-stemcell
+    file: bosh-cpi-src/ci/tasks/upload-stemcell.yml
+    params: &upload-stemcell-params
+      <<: *azure-environment-params
+
   - &run-integration
     task: run-integration
     file: bosh-cpi-src/ci/tasks/run-integration.yml
@@ -113,17 +130,6 @@ shared:
     file: bosh-cpi-src/ci/tasks/ensure-cleanup.yml
     params:
       <<: *azure-environment-params
-
-  - &run-az-bats
-    task: run-az-bats
-    file: bosh-cpi-src/ci/tasks/run-az-bats.yml
-    params: &run-az-bats-params
-      INFRASTRUCTURE:                     azure
-      STEMCELL_NAME:                      bosh-azure-hyperv-ubuntu-trusty-go_agent
-      BAT_INFRASTRUCTURE:                 azure
-      BAT_NETWORKING:                     manual
-      BAT_RSPEC_FLAGS:                    "--tag ~raw_ephemeral_storage"
-      AZURE_BATS_ZONE:                    {{azure_bats_zone}}
 
 jobs:
   - name: build-candidate
@@ -148,10 +154,12 @@ jobs:
         - {get: bosh-cpi-src,     trigger: false, resource: bosh-cpi-src-in,        passed: [build-candidate]}
         - {get: stemcell,         trigger: false, resource: azure-ubuntu-stemcell}
       - <<: *create-integration-environment
-      - <<: *run-integration
-        params:
-          <<: *run-integration-params
-          AZURE_USE_MANAGED_DISKS: false
+      - do:
+        - <<: *upload-stemcell
+        - <<: *run-integration
+          params:
+            <<: *run-integration-params
+            AZURE_USE_MANAGED_DISKS: false
         ensure:
           do:
             - <<: *destroy-integration-environment
@@ -167,10 +175,12 @@ jobs:
         - {get: bosh-cpi-src,     trigger: false, resource: bosh-cpi-src-in,        passed: [build-candidate]}
         - {get: stemcell,         trigger: false, resource: azure-ubuntu-stemcell}
       - <<: *create-integration-environment
-      - <<: *run-integration
-        params:
-          <<: *run-integration-params
-          AZURE_USE_MANAGED_DISKS: true
+      - do:
+        - <<: *upload-stemcell
+        - <<: *run-integration
+          params:
+            <<: *run-integration-params
+            AZURE_USE_MANAGED_DISKS: true
         ensure:
           do:
             - <<: *destroy-integration-environment
@@ -186,10 +196,15 @@ jobs:
         - {get: bosh-cpi-src,     trigger: false, resource: bosh-cpi-src-in,        passed: [build-candidate]}
         - {get: stemcell,         trigger: false, resource: azure-windows-stemcell}
       - <<: *create-integration-environment
-      - <<: *run-integration-windows
-        params:
-          <<: *run-integration-windows-params
-          AZURE_USE_MANAGED_DISKS: false
+      - do:
+        - <<: *upload-stemcell
+          params:
+            <<: *azure-environment-params
+            IS_HEAVY_STEMCELL: false
+        - <<: *run-integration-windows
+          params:
+            <<: *run-integration-windows-params
+            AZURE_USE_MANAGED_DISKS: false
         ensure:
           do:
             - <<: *destroy-integration-environment
@@ -205,10 +220,15 @@ jobs:
         - {get: bosh-cpi-src,     trigger: false, resource: bosh-cpi-src-in,        passed: [build-candidate]}
         - {get: stemcell,         trigger: false, resource: azure-windows-stemcell}
       - <<: *create-integration-environment
-      - <<: *run-integration-windows
-        params:
-          <<: *run-integration-windows-params
-          AZURE_USE_MANAGED_DISKS: true
+      - do:
+        - <<: *upload-stemcell
+          params:
+            <<: *azure-environment-params
+            IS_HEAVY_STEMCELL: false
+        - <<: *run-integration-windows
+          params:
+            <<: *run-integration-windows-params
+            AZURE_USE_MANAGED_DISKS: true
         ensure:
           do:
             - <<: *destroy-integration-environment

--- a/ci/tasks/run-integration-windows.yml
+++ b/ci/tasks/run-integration-windows.yml
@@ -7,7 +7,7 @@ image_resource:
 inputs:
   - name: environment
   - name: bosh-cpi-src
-  - name: stemcell
+  - name: stemcell-state
 
 run:
   path: bosh-cpi-src/ci/tasks/run-integration-windows.sh

--- a/ci/tasks/run-integration.sh
+++ b/ci/tasks/run-integration.sh
@@ -35,19 +35,7 @@ export BOSH_AZURE_APPLICATION_SECURITY_GROUP=$(echo ${metadata} | jq -e --raw-ou
 export BOSH_AZURE_APPLICATION_GATEWAY_NAME=$(echo ${metadata} | jq -e --raw-output ".application_gateway_name")
 export BOSH_AZURE_SSH_PUBLIC_KEY=${SSH_PUBLIC_KEY}
 
-az cloud set --name ${AZURE_ENVIRONMENT}
-az login --service-principal -u ${AZURE_CLIENT_ID} -p ${AZURE_CLIENT_SECRET} --tenant ${AZURE_TENANT_ID}
-az account set -s ${AZURE_SUBSCRIPTION_ID}
-
-export BOSH_AZURE_STEMCELL_ID="bosh-stemcell-00000000-0000-0000-0000-0AZURECPICI0"
-export BOSH_AZURE_STEMCELL_PATH="/tmp/image"
-account_name=${BOSH_AZURE_STORAGE_ACCOUNT_NAME}
-account_key=$(az storage account keys list --account-name ${account_name} --resource-group ${BOSH_AZURE_DEFAULT_RESOURCE_GROUP_NAME} | jq '.[0].value' -r)
-# Always upload the latest stemcell for lifecycle test
-tar -xf $(realpath stemcell/*.tgz) -C /tmp/
-tar -xf ${BOSH_AZURE_STEMCELL_PATH} -C /tmp/
-az storage blob upload --file /tmp/root.vhd --container-name stemcell --name ${BOSH_AZURE_STEMCELL_ID}.vhd --type page --account-name ${account_name} --account-key ${account_key}
-
+source stemcell-state/stemcell.env
 source /etc/profile.d/chruby.sh
 chruby ${RUBY_VERSION}
 

--- a/ci/tasks/run-integration.yml
+++ b/ci/tasks/run-integration.yml
@@ -7,7 +7,7 @@ image_resource:
 inputs:
   - name: environment
   - name: bosh-cpi-src
-  - name: stemcell
+  - name: stemcell-state
 
 run:
   path: bosh-cpi-src/ci/tasks/run-integration.sh

--- a/ci/tasks/upload-stemcell.sh
+++ b/ci/tasks/upload-stemcell.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+
+set -e
+
+: ${AZURE_ENVIRONMENT:?}
+: ${AZURE_TENANT_ID:?}
+: ${AZURE_SUBSCRIPTION_ID:?}
+: ${AZURE_CLIENT_ID:?}
+: ${AZURE_CLIENT_SECRET:?}
+
+: ${METADATA_FILE:=environment/metadata}
+
+# outputs
+output_dir=$(realpath stemcell-state/)
+
+metadata=$(cat ${METADATA_FILE})
+
+az cloud set --name ${AZURE_ENVIRONMENT}
+az login --service-principal -u ${AZURE_CLIENT_ID} -p ${AZURE_CLIENT_SECRET} --tenant ${AZURE_TENANT_ID}
+az account set -s ${AZURE_SUBSCRIPTION_ID}
+
+DEFAULT_RESOURCE_GROUP_NAME=$(echo ${metadata} | jq -e --raw-output ".default_resource_group_name")
+STORAGE_ACCOUNT_NAME=$(echo ${metadata} | jq -e --raw-output ".storage_account_name")
+
+account_name=${STORAGE_ACCOUNT_NAME}
+account_key=$(az storage account keys list --account-name ${account_name} --resource-group ${DEFAULT_RESOURCE_GROUP_NAME} | jq '.[0].value' -r)
+
+if [ "${IS_HEAVY_STEMCELL}" == "true" ]; then
+  stemcell_id="bosh-stemcell-00000000-0000-0000-0000-0AZURECPICI0"
+  stemcell_path="/tmp/image"
+  # Always upload the latest stemcell for lifecycle test
+  tar -xf $(realpath stemcell/*.tgz) -C /tmp/
+  tar -xf ${stemcell_path} -C /tmp/
+  az storage blob upload --file /tmp/root.vhd --container-name stemcell --name ${stemcell_id}.vhd --type page --account-name ${account_name} --account-key ${account_key}
+  cat > "${output_dir}/stemcell.env" <<EOF
+export BOSH_AZURE_STEMCELL_ID="${stemcell_id}"
+export BOSH_AZURE_STEMCELL_PATH="${stemcell_path}"
+EOF
+else
+  stemcell_id="bosh-light-stemcell-00000000-0000-0000-0000-0AZURECPICI0"
+  # Use the light stemcell cloud properties to generate metadata in space-separated key=value pairs
+  tar -xf $(realpath stemcell/*.tgz) -C /tmp/
+  stemcell_metadata=$(ruby -r yaml -r json -e '
+    data = YAML::load(STDIN.read)
+    stemcell_properties = data["cloud_properties"]
+    stemcell_properties["hypervisor"]="hyperv"
+    metadata=""
+    stemcell_properties.each do |key, value|
+      if key == "image"
+        metadata += "#{key}=#{JSON.dump(value)} "
+      else
+        metadata += "#{key}=#{value} "
+      end
+    end
+    puts metadata' < /tmp/stemcell.MF)
+  dd if=/dev/zero of=/tmp/root.vhd bs=1K count=1
+  az storage blob upload --file /tmp/root.vhd --container-name stemcell --name ${stemcell_id}.vhd --type page --metadata ${stemcell_metadata} --account-name ${account_name} --account-key ${account_key}
+  image_sku=$(ruby -r yaml -r json -e '
+    data = YAML::load(STDIN.read)
+    stemcell_properties = data["cloud_properties"]
+    stemcell_properties.each do |key, value|
+      if key == "image"
+        value.each do |k, v|
+          if k == "sku"
+            puts v
+            break
+          end
+        end
+      end
+    end' < /tmp/stemcell.MF)
+  image_version=$(ruby -r yaml -r json -e '
+    data = YAML::load(STDIN.read)
+    stemcell_properties = data["cloud_properties"]
+    stemcell_properties.each do |key, value|
+      if key == "image"
+        value.each do |k, v|
+          if k == "version"
+            puts v
+            break
+          end
+        end
+      end
+    end' < /tmp/stemcell.MF)
+  # Accept legal terms
+  image_urn="pivotal:bosh-windows-server:${image_sku}:${image_version}"
+  echo "Accepting the legal terms of image ${image_urn}"
+  az vm image accept-terms --urn ${image_urn}
+  cat > "${output_dir}/stemcell.env" <<EOF
+export BOSH_AZURE_STEMCELL_ID="${stemcell_id}"
+export BOSH_AZURE_WINDOWS_LIGHT_STEMCELL_SKU=${image_sku}
+export BOSH_AZURE_WINDOWS_LIGHT_STEMCELL_VERSION=${image_version}
+EOF
+fi

--- a/ci/tasks/upload-stemcell.yml
+++ b/ci/tasks/upload-stemcell.yml
@@ -1,0 +1,24 @@
+---
+platform: linux
+image_resource:
+  type: docker-image
+  source: {repository: boshcpi/azure-cpi-release}
+
+inputs:
+  - name: environment
+  - name: bosh-cpi-src
+  - name: stemcell
+
+outputs:
+  - name: stemcell-state
+
+run:
+  path: bosh-cpi-src/ci/tasks/upload-stemcell.sh
+
+params:
+  AZURE_ENVIRONMENT:     ""
+  AZURE_TENANT_ID:       ""
+  AZURE_SUBSCRIPTION_ID: ""
+  AZURE_CLIENT_ID:       ""
+  AZURE_CLIENT_SECRET:   ""
+  IS_HEAVY_STEMCELL:     true


### PR DESCRIPTION
Uploading stemcell in a separate task can make `run-integration.sh/run-integration-windows.sh` much more clear.