### PR TITLE
Refine CPI methods according to bosh.io doc

### DIFF
--- a/src/bosh_azure_cpi/lib/cloud/azure/models/bosh_vm_meta.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/models/bosh_vm_meta.rb
@@ -2,14 +2,14 @@
 
 module Bosh::AzureCloud
   class BoshVMMeta
-    attr_reader :agent_id, :stemcell_id
-    def initialize(agent_id, stemcell_id)
+    attr_reader :agent_id, :stemcell_cid
+    def initialize(agent_id, stemcell_cid)
       @agent_id = agent_id
-      @stemcell_id = stemcell_id
+      @stemcell_cid = stemcell_cid
     end
 
     def to_s
-      "agent_id: #{@agent_id}, stemcell_id: #{@stemcell_id}"
+      "agent_id: #{@agent_id}, stemcell_cid: #{@stemcell_cid}"
     end
   end
 end

--- a/src/bosh_azure_cpi/lib/cloud/azure/utils/bosh_agent_util.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/utils/bosh_agent_util.rb
@@ -3,8 +3,31 @@
 module Bosh::AzureCloud
   class BoshAgentUtil
     # Example -
-    # For Linux:     {"registry":{"endpoint":"http://registry:ba42b9e9-fe2c-4d7d-47fb-3eeb78ff49b1@127.0.0.1:6901"},"server":{"name":"<instance-id>"},"dns":{"nameserver":["168.63.129.16","8.8.8.8"]}}
-    # For Windows:   {"registry":{"endpoint":"http://registry:ba42b9e9-fe2c-4d7d-47fb-3eeb78ff49b1@127.0.0.1:6901"},"instance-id":"<instance-id>","server":{"name":"<randomgeneratedname>"},"dns":{"nameserver":["168.63.129.16","8.8.8.8"]}}
+    # For Linux:
+    # {
+    #   "registry": {
+    #     "endpoint": "http://registry:ba42b9e9-fe2c-4d7d-47fb-3eeb78ff49b1@127.0.0.1:6901"
+    #   },
+    #   "server": {
+    #     "name": "<instance-id>"
+    #   },
+    #   "dns": {
+    #     "nameserver": ["168.63.129.16","8.8.8.8"]
+    #   }
+    # }
+    # For Windows:
+    # {
+    #   "registry": {
+    #     "endpoint": "http://registry:ba42b9e9-fe2c-4d7d-47fb-3eeb78ff49b1@127.0.0.1:6901"
+    #   },
+    #   "instance-id": "<instance-id>",
+    #   "server": {
+    #     "name": "<randomgeneratedname>"
+    #   },
+    #   "dns": {
+    #     "nameserver": ["168.63.129.16","8.8.8.8"]
+    #   }
+    # }
     def self.get_encoded_user_data(registry_endpoint, instance_id, dns, computer_name = nil)
       user_data = get_user_data_obj(registry_endpoint, instance_id, dns, computer_name)
       Base64.strict_encode64(JSON.dump(user_data))

--- a/src/bosh_azure_cpi/lib/cloud/azure/utils/helpers.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/utils/helpers.rb
@@ -599,8 +599,8 @@ module Bosh::AzureCloud
       stemcell_properties.key?(LIGHT_STEMCELL_PROPERTY)
     end
 
-    def is_light_stemcell_id?(stemcell_id)
-      stemcell_id.start_with?(LIGHT_STEMCELL_PREFIX)
+    def is_light_stemcell_cid?(stemcell_cid)
+      stemcell_cid.start_with?(LIGHT_STEMCELL_PREFIX)
     end
 
     # use timestamp and process id to generate a unique string for computer name of Windows

--- a/src/bosh_azure_cpi/lib/cloud/azure/vms/instance_type_mapper.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/vms/instance_type_mapper.rb
@@ -39,12 +39,12 @@ module Bosh::AzureCloud
       ]
     ].freeze
 
-    def map(vm_resources, available_vm_sizes)
+    def map(desired_instance_size, available_vm_sizes)
       @logger = Bosh::Clouds::Config.logger
 
-      possible_vm_sizes = find_possible_vm_sizes(vm_resources, available_vm_sizes)
+      possible_vm_sizes = find_possible_vm_sizes(desired_instance_size, available_vm_sizes)
       if possible_vm_sizes.empty?
-        raise ["Unable to meet requested vm_resources: #{vm_resources['cpu']} CPU, #{vm_resources['ram']} MB RAM.\n",
+        raise ["Unable to meet requested desired_instance_size: #{desired_instance_size['cpu']} CPU, #{desired_instance_size['ram']} MB RAM.\n",
                "Available VM sizes:\n",
                available_vm_sizes.map { |vm_size| "#{vm_size[:name]}: #{vm_size[:number_of_cores]} CPU, #{vm_size[:memory_in_mb]} MB RAM\n" }].join
       end
@@ -58,10 +58,10 @@ module Bosh::AzureCloud
 
     private
 
-    def find_possible_vm_sizes(vm_resources, available_vm_sizes)
+    def find_possible_vm_sizes(desired_instance_size, available_vm_sizes)
       available_vm_sizes.select do |vm_size|
-        vm_size[:number_of_cores] >= vm_resources['cpu'] &&
-          vm_size[:memory_in_mb] >= vm_resources['ram']
+        vm_size[:number_of_cores] >= desired_instance_size['cpu'] &&
+          vm_size[:memory_in_mb] >= desired_instance_size['ram']
       end
     end
 

--- a/src/bosh_azure_cpi/lib/cloud/azure/vms/vm_manager.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/vms/vm_manager.rb
@@ -46,7 +46,7 @@ module Bosh::AzureCloud
 
       tasks.push(
         task_get_stemcell_info = Concurrent::Future.execute do
-          _get_stemcell_info(bosh_vm_meta.stemcell_id, vm_props, location)
+          _get_stemcell_info(bosh_vm_meta.stemcell_cid, vm_props, location)
         end
       )
 
@@ -388,33 +388,33 @@ module Bosh::AzureCloud
       instance_id
     end
 
-    def _get_stemcell_info(stemcell_id, vm_props, location)
+    def _get_stemcell_info(stemcell_cid, vm_props, location)
       stemcell_info = nil
       if @use_managed_disks
-        if is_light_stemcell_id?(stemcell_id)
-          raise Bosh::Clouds::VMCreationFailed.new(false), "Given stemcell '#{stemcell_id}' does not exist" unless @light_stemcell_manager.has_stemcell?(location, stemcell_id)
+        if is_light_stemcell_cid?(stemcell_cid)
+          raise Bosh::Clouds::VMCreationFailed.new(false), "Given stemcell '#{stemcell_cid}' does not exist" unless @light_stemcell_manager.has_stemcell?(location, stemcell_cid)
 
-          stemcell_info = @light_stemcell_manager.get_stemcell_info(stemcell_id)
+          stemcell_info = @light_stemcell_manager.get_stemcell_info(stemcell_cid)
         else
           begin
             storage_account_type = _get_root_disk_type(vm_props)
             # Treat user_image_info as stemcell_info
-            stemcell_info = @stemcell_manager2.get_user_image_info(stemcell_id, storage_account_type, location)
+            stemcell_info = @stemcell_manager2.get_user_image_info(stemcell_cid, storage_account_type, location)
           rescue StandardError => e
-            raise Bosh::Clouds::VMCreationFailed.new(false), "Failed to get the user image information for the stemcell '#{stemcell_id}': #{e.inspect}\n#{e.backtrace.join("\n")}"
+            raise Bosh::Clouds::VMCreationFailed.new(false), "Failed to get the user image information for the stemcell '#{stemcell_cid}': #{e.inspect}\n#{e.backtrace.join("\n")}"
           end
         end
       else
         storage_account = get_storage_account_from_vm_properties(vm_props, location)
 
-        if is_light_stemcell_id?(stemcell_id)
-          raise Bosh::Clouds::VMCreationFailed.new(false), "Given stemcell '#{stemcell_id}' does not exist" unless @light_stemcell_manager.has_stemcell?(location, stemcell_id)
+        if is_light_stemcell_cid?(stemcell_cid)
+          raise Bosh::Clouds::VMCreationFailed.new(false), "Given stemcell '#{stemcell_cid}' does not exist" unless @light_stemcell_manager.has_stemcell?(location, stemcell_cid)
 
-          stemcell_info = @light_stemcell_manager.get_stemcell_info(stemcell_id)
+          stemcell_info = @light_stemcell_manager.get_stemcell_info(stemcell_cid)
         else
-          raise Bosh::Clouds::VMCreationFailed.new(false), "Given stemcell '#{stemcell_id}' does not exist" unless @stemcell_manager.has_stemcell?(storage_account[:name], stemcell_id)
+          raise Bosh::Clouds::VMCreationFailed.new(false), "Given stemcell '#{stemcell_cid}' does not exist" unless @stemcell_manager.has_stemcell?(storage_account[:name], stemcell_cid)
 
-          stemcell_info = @stemcell_manager.get_stemcell_info(storage_account[:name], stemcell_id)
+          stemcell_info = @stemcell_manager.get_stemcell_info(storage_account[:name], stemcell_cid)
         end
       end
 

--- a/src/bosh_azure_cpi/spec/unit/cloud/calculate_vm_cloud_properties_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/cloud/calculate_vm_cloud_properties_spec.rb
@@ -25,8 +25,8 @@ describe Bosh::AzureCloud::Cloud do
       let(:cloud_properties_with_location) { mock_cloud_properties_merge('azure' => { 'location' => location }) }
       let(:cloud_with_location) { mock_cloud(cloud_properties_with_location) }
 
-      context 'when some keys are missing in vm_resources' do
-        let(:vm_resources) do
+      context 'when some keys are missing in desired_instance_size' do
+        let(:desired_instance_size) do
           {
             'cpu' => 1
           }
@@ -34,7 +34,7 @@ describe Bosh::AzureCloud::Cloud do
 
         it 'should raise an error' do
           expect do
-            cloud_with_location.calculate_vm_cloud_properties(vm_resources)
+            cloud_with_location.calculate_vm_cloud_properties(desired_instance_size)
           end.to raise_error(/Missing VM cloud properties: 'ram', 'ephemeral_disk_size'/)
         end
       end
@@ -45,7 +45,7 @@ describe Bosh::AzureCloud::Cloud do
         let(:instance_type) { double('instance-type') }
 
         context 'when the ephemeral_disk_size is N * 1024' do
-          let(:vm_resources) do
+          let(:desired_instance_size) do
             {
               'cpu' => 1,
               'ram' => 1024,
@@ -55,9 +55,9 @@ describe Bosh::AzureCloud::Cloud do
           it 'should return the cloud_properties' do
             expect(azure_client).to receive(:list_available_virtual_machine_sizes).with(location).and_return(available_vm_sizes)
             expect(instance_type_mapper).to receive(:map)
-              .with(vm_resources, available_vm_sizes)
+              .with(desired_instance_size, available_vm_sizes)
               .and_return(instance_type)
-            expect(cloud_with_location.calculate_vm_cloud_properties(vm_resources)).to eq(
+            expect(cloud_with_location.calculate_vm_cloud_properties(desired_instance_size)).to eq(
               'instance_type' => instance_type,
               'ephemeral_disk' => {
                 'size' => size_in_gb * 1024
@@ -67,7 +67,7 @@ describe Bosh::AzureCloud::Cloud do
         end
 
         context 'when the ephemeral_disk_size is not N * 1024' do
-          let(:vm_resources) do
+          let(:desired_instance_size) do
             {
               'cpu' => 1,
               'ram' => 1024,
@@ -77,9 +77,9 @@ describe Bosh::AzureCloud::Cloud do
           it 'should return the cloud_properties' do
             expect(azure_client).to receive(:list_available_virtual_machine_sizes).with(location).and_return(available_vm_sizes)
             expect(instance_type_mapper).to receive(:map)
-              .with(vm_resources, available_vm_sizes)
+              .with(desired_instance_size, available_vm_sizes)
               .and_return(instance_type)
-            expect(cloud_with_location.calculate_vm_cloud_properties(vm_resources)).to eq(
+            expect(cloud_with_location.calculate_vm_cloud_properties(desired_instance_size)).to eq(
               'instance_type' => instance_type,
               'ephemeral_disk' => {
                 'size' => (size_in_gb + 1) * 1024

--- a/src/bosh_azure_cpi/spec/unit/cloud/create_disk_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/cloud/create_disk_spec.rb
@@ -8,7 +8,7 @@ describe Bosh::AzureCloud::Cloud do
 
   describe '#create_disk' do
     let(:cloud_properties) { {} }
-    let(:instance_id) { 'e55144a3-0c06-4240-8f15-9a7bc7b35d1f' }
+    let(:vm_cid) { 'e55144a3-0c06-4240-8f15-9a7bc7b35d1f' }
     let(:instance_id_object) { instance_double(Bosh::AzureCloud::InstanceId) }
     let(:disk_id_object) { instance_double(Bosh::AzureCloud::DiskId) }
     let(:default_resource_group_name) { MOCK_RESOURCE_GROUP_NAME }
@@ -23,7 +23,7 @@ describe Bosh::AzureCloud::Cloud do
       allow(instance_id_object).to receive(:vm_name)
         .and_return(vm_name)
       allow(telemetry_manager).to receive(:monitor)
-        .with('create_disk', id: instance_id, extras: { 'disk_size' => disk_size })
+        .with('create_disk', id: vm_cid, extras: { 'disk_size' => disk_size })
         .and_call_original
     end
 
@@ -33,7 +33,7 @@ describe Bosh::AzureCloud::Cloud do
 
         it 'should raise an error' do
           expect do
-            cloud.create_disk(disk_size, cloud_properties, instance_id)
+            cloud.create_disk(disk_size, cloud_properties, vm_cid)
           end.to raise_error(
             ArgumentError,
             "The disk size needs to be an integer. The current value is '#{disk_size}'."
@@ -46,7 +46,7 @@ describe Bosh::AzureCloud::Cloud do
 
         it 'should raise an error' do
           expect do
-            cloud.create_disk(disk_size, cloud_properties, instance_id)
+            cloud.create_disk(disk_size, cloud_properties, vm_cid)
           end.to raise_error /Azure CPI minimum disk size is 1 GiB/
         end
       end
@@ -63,7 +63,7 @@ describe Bosh::AzureCloud::Cloud do
 
         it 'should raise an error' do
           expect do
-            cloud.create_disk(disk_size, cloud_properties, instance_id)
+            cloud.create_disk(disk_size, cloud_properties, vm_cid)
           end.to raise_error /Unknown disk caching/
         end
       end
@@ -79,8 +79,8 @@ describe Bosh::AzureCloud::Cloud do
         }
       end
 
-      context 'when instance_id is nil' do
-        let(:instance_id) { nil }
+      context 'when vm_cid is nil' do
+        let(:vm_cid) { nil }
         let(:rg_location) { 'fake-resource-group-location' }
         let(:resource_group) do
           {
@@ -104,12 +104,12 @@ describe Bosh::AzureCloud::Cloud do
             .and_call_original
 
           expect do
-            managed_cloud.create_disk(disk_size, cloud_properties, instance_id)
+            managed_cloud.create_disk(disk_size, cloud_properties, vm_cid)
           end.not_to raise_error
         end
       end
 
-      context 'when instance_id is not nil' do
+      context 'when vm_cid is not nil' do
         context 'when the instance is an unmanaged vm' do
           before do
             allow(instance_id_object).to receive(:use_managed_disks?)
@@ -118,7 +118,7 @@ describe Bosh::AzureCloud::Cloud do
 
           it "can't create a managed disk for a VM with unmanaged disks" do
             expect do
-              managed_cloud.create_disk(disk_size, cloud_properties, instance_id)
+              managed_cloud.create_disk(disk_size, cloud_properties, vm_cid)
             end.to raise_error /Cannot create a managed disk for a VM with unmanaged disks/
           end
         end
@@ -151,7 +151,7 @@ describe Bosh::AzureCloud::Cloud do
                 .with(disk_id_object, vm_location, disk_size_in_gib, 'Premium_LRS', vm_zone)
 
               expect do
-                managed_cloud.create_disk(disk_size, cloud_properties, instance_id)
+                managed_cloud.create_disk(disk_size, cloud_properties, vm_cid)
               end.not_to raise_error
             end
           end
@@ -171,7 +171,7 @@ describe Bosh::AzureCloud::Cloud do
                 .with(disk_id_object, vm_location, disk_size_in_gib, 'Standard_LRS', vm_zone)
 
               expect do
-                managed_cloud.create_disk(disk_size, cloud_properties, instance_id)
+                managed_cloud.create_disk(disk_size, cloud_properties, vm_cid)
               end.not_to raise_error
             end
           end
@@ -190,7 +190,7 @@ describe Bosh::AzureCloud::Cloud do
         }
       end
 
-      context 'when instance_id is not nil' do
+      context 'when vm_cid is not nil' do
         let(:vm_storage_account_name) { 'vmstorageaccountname' }
 
         before do
@@ -206,13 +206,13 @@ describe Bosh::AzureCloud::Cloud do
             .with(disk_id_object, disk_size_in_gib)
 
           expect do
-            cloud.create_disk(disk_size, cloud_properties, instance_id)
+            cloud.create_disk(disk_size, cloud_properties, vm_cid)
           end.not_to raise_error
         end
       end
 
-      context 'when instance_id is nil' do
-        let(:instance_id) { nil }
+      context 'when vm_cid is nil' do
+        let(:vm_cid) { nil }
 
         it 'should create an unmanaged disk in the default storage account of global configuration' do
           expect(Bosh::AzureCloud::DiskId).to receive(:create)
@@ -225,7 +225,7 @@ describe Bosh::AzureCloud::Cloud do
             .and_call_original
 
           expect do
-            cloud.create_disk(disk_size, cloud_properties, instance_id)
+            cloud.create_disk(disk_size, cloud_properties, vm_cid)
           end.not_to raise_error
         end
       end

--- a/src/bosh_azure_cpi/spec/unit/cloud/create_stemcell_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/cloud/create_stemcell_spec.rb
@@ -7,11 +7,11 @@ describe Bosh::AzureCloud::Cloud do
   include_context 'shared stuff'
 
   describe '#create_stemcell' do
-    let(:stemcell_id) { 'fake-stemcell-id' }
     let(:image_path) { 'fake-image-path' }
+    let(:stemcell_cid) { 'fake-stemcell-cid' }
 
     context 'when a light stemcell is used' do
-      let(:stemcell_properties) { { 'image' => 'fake-image' } }
+      let(:cloud_properties) { { 'image' => 'fake-image' } }
 
       it 'should succeed' do
         expect(telemetry_manager).to receive(:monitor)
@@ -19,16 +19,16 @@ describe Bosh::AzureCloud::Cloud do
           .and_call_original
 
         expect(light_stemcell_manager).to receive(:create_stemcell)
-          .with(stemcell_properties).and_return(stemcell_id)
+          .with(cloud_properties).and_return(stemcell_cid)
 
         expect(
-          cloud.create_stemcell(image_path, stemcell_properties)
-        ).to eq(stemcell_id)
+          cloud.create_stemcell(image_path, cloud_properties)
+        ).to eq(stemcell_cid)
       end
     end
 
     context 'when a heavy stemcell is used' do
-      let(:stemcell_properties) { {} }
+      let(:cloud_properties) { {} }
 
       context 'and use_managed_disks is false' do
         it 'should succeed' do
@@ -37,11 +37,11 @@ describe Bosh::AzureCloud::Cloud do
             .and_call_original
 
           expect(stemcell_manager).to receive(:create_stemcell)
-            .with(image_path, stemcell_properties).and_return(stemcell_id)
+            .with(image_path, cloud_properties).and_return(stemcell_cid)
 
           expect(
-            cloud.create_stemcell(image_path, stemcell_properties)
-          ).to eq(stemcell_id)
+            cloud.create_stemcell(image_path, cloud_properties)
+          ).to eq(stemcell_cid)
         end
       end
 
@@ -52,19 +52,19 @@ describe Bosh::AzureCloud::Cloud do
             .and_call_original
 
           expect(stemcell_manager2).to receive(:create_stemcell)
-            .with(image_path, stemcell_properties).and_return(stemcell_id)
+            .with(image_path, cloud_properties).and_return(stemcell_cid)
 
           expect(
-            managed_cloud.create_stemcell(image_path, stemcell_properties)
-          ).to eq(stemcell_id)
+            managed_cloud.create_stemcell(image_path, cloud_properties)
+          ).to eq(stemcell_cid)
         end
       end
     end
 
-    context 'when a stcmell name ane version are specified in stemcell_properties' do
+    context 'when a stcmell name ane version are specified in cloud_properties' do
       let(:stemcell_name) { 'fake-name' }
       let(:stemcell_version) { 'fake-version' }
-      let(:stemcell_properties) do
+      let(:cloud_properties) do
         {
           'name' => stemcell_name,
           'version' => stemcell_version
@@ -77,11 +77,11 @@ describe Bosh::AzureCloud::Cloud do
           .and_call_original
 
         expect(stemcell_manager).to receive(:create_stemcell)
-          .with(image_path, stemcell_properties).and_return(stemcell_id)
+          .with(image_path, cloud_properties).and_return(stemcell_cid)
 
         expect(
-          cloud.create_stemcell(image_path, stemcell_properties)
-        ).to eq(stemcell_id)
+          cloud.create_stemcell(image_path, cloud_properties)
+        ).to eq(stemcell_cid)
       end
     end
   end

--- a/src/bosh_azure_cpi/spec/unit/cloud/current_vm_id_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/cloud/current_vm_id_spec.rb
@@ -6,13 +6,10 @@ require 'unit/cloud/shared_stuff.rb'
 describe Bosh::AzureCloud::Cloud do
   include_context 'shared stuff'
 
-  describe '#configure_networks' do
-    let(:instance_id) { 'e55144a3-0c06-4240-8f15-9a7bc7b35d1f' }
-    let(:networks) { 'networks' }
-
+  describe '#current_vm_id' do
     it 'should raise a NotSupported error' do
       expect do
-        cloud.configure_networks(instance_id, networks)
+        cloud.current_vm_id
       end.to raise_error(Bosh::Clouds::NotSupported)
     end
   end

--- a/src/bosh_azure_cpi/spec/unit/cloud/delete_disk_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/cloud/delete_disk_spec.rb
@@ -7,18 +7,18 @@ describe Bosh::AzureCloud::Cloud do
   include_context 'shared stuff'
 
   describe '#delete_disk' do
-    let(:disk_id) { 'fake-disk-id' }
+    let(:disk_cid) { 'fake-disk-id' }
     let(:disk_id_object) { instance_double(Bosh::AzureCloud::DiskId) }
 
     before do
       allow(telemetry_manager).to receive(:monitor)
-        .with('delete_disk', id: disk_id).and_call_original
+        .with('delete_disk', id: disk_cid).and_call_original
     end
 
     context 'when use_managed_disks is true' do
       before do
         allow(Bosh::AzureCloud::DiskId).to receive(:parse)
-          .with(disk_id, azure_config_managed.resource_group_name)
+          .with(disk_cid, azure_config_managed.resource_group_name)
           .and_return(disk_id_object)
       end
 
@@ -33,7 +33,7 @@ describe Bosh::AzureCloud::Cloud do
         it 'should delete the managed disk' do
           expect(disk_manager2).to receive(:delete_data_disk).with(disk_id_object)
           expect do
-            managed_cloud.delete_disk(disk_id)
+            managed_cloud.delete_disk(disk_cid)
           end.not_to raise_error
         end
       end
@@ -52,7 +52,7 @@ describe Bosh::AzureCloud::Cloud do
           expect(disk_manager2).to receive(:delete_data_disk).with(disk_id_object)
           expect(disk_manager).not_to receive(:delete_data_disk)
           expect do
-            managed_cloud.delete_disk(disk_id)
+            managed_cloud.delete_disk(disk_cid)
           end.not_to raise_error
         end
       end
@@ -70,7 +70,7 @@ describe Bosh::AzureCloud::Cloud do
           expect(disk_manager2).not_to receive(:delete_data_disk)
           expect(disk_manager).to receive(:delete_data_disk).with(disk_id_object)
           expect do
-            managed_cloud.delete_disk(disk_id)
+            managed_cloud.delete_disk(disk_cid)
           end.not_to raise_error
         end
       end
@@ -79,14 +79,14 @@ describe Bosh::AzureCloud::Cloud do
     context 'when use_managed_disks is false' do
       before do
         allow(Bosh::AzureCloud::DiskId).to receive(:parse)
-          .with(disk_id, azure_config.resource_group_name)
+          .with(disk_cid, azure_config.resource_group_name)
           .and_return(disk_id_object)
       end
 
       it 'should delete the unmanaged disk' do
         expect(disk_manager).to receive(:delete_data_disk).with(disk_id_object)
         expect do
-          cloud.delete_disk(disk_id)
+          cloud.delete_disk(disk_cid)
         end.not_to raise_error
       end
     end

--- a/src/bosh_azure_cpi/spec/unit/cloud/delete_snapshot_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/cloud/delete_snapshot_spec.rb
@@ -7,13 +7,13 @@ describe Bosh::AzureCloud::Cloud do
   include_context 'shared stuff'
 
   describe '#delete_snapshot' do
-    let(:snapshot_id) { 'fake-snapshot-id' }
+    let(:snapshot_cid) { 'fake-snapshot-cid' }
     let(:snapshot_id_object) { instance_double(Bosh::AzureCloud::DiskId) }
     before do
       allow(telemetry_manager).to receive(:monitor)
-        .with('delete_snapshot', id: snapshot_id).and_call_original
+        .with('delete_snapshot', id: snapshot_cid).and_call_original
       allow(Bosh::AzureCloud::DiskId).to receive(:parse)
-        .with(snapshot_id, MOCK_RESOURCE_GROUP_NAME)
+        .with(snapshot_cid, MOCK_RESOURCE_GROUP_NAME)
         .and_return(snapshot_id_object)
     end
 
@@ -29,7 +29,7 @@ describe Bosh::AzureCloud::Cloud do
         expect(disk_manager2).to receive(:delete_snapshot).with(snapshot_id_object)
 
         expect do
-          cloud.delete_snapshot(snapshot_id)
+          cloud.delete_snapshot(snapshot_cid)
         end.not_to raise_error
       end
     end
@@ -46,7 +46,7 @@ describe Bosh::AzureCloud::Cloud do
         expect(disk_manager).to receive(:delete_snapshot).with(snapshot_id_object)
 
         expect do
-          cloud.delete_snapshot(snapshot_id)
+          cloud.delete_snapshot(snapshot_cid)
         end.not_to raise_error
       end
     end

--- a/src/bosh_azure_cpi/spec/unit/cloud/delete_stemcell_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/cloud/delete_stemcell_spec.rb
@@ -9,32 +9,32 @@ describe Bosh::AzureCloud::Cloud do
   describe '#delete_stemcell' do
     before do
       allow(telemetry_manager).to receive(:monitor)
-        .with('delete_stemcell', id: stemcell_id).and_call_original
+        .with('delete_stemcell', id: stemcell_cid).and_call_original
     end
 
     context 'when a light stemcell is used' do
-      let(:stemcell_id) { 'bosh-light-stemcell-xxx' }
+      let(:stemcell_cid) { 'bosh-light-stemcell-98cc8a2d-6e33-409a-91f5-fb32e320f5c1' }
 
       it 'should succeed' do
         expect(light_stemcell_manager).to receive(:delete_stemcell)
-          .with(stemcell_id)
+          .with(stemcell_cid)
 
         expect do
-          cloud.delete_stemcell(stemcell_id)
+          cloud.delete_stemcell(stemcell_cid)
         end.not_to raise_error
       end
     end
 
     context 'when a heavy stemcell is used' do
-      let(:stemcell_id) { 'bosh-stemcell-xxx' }
+      let(:stemcell_cid) { 'bosh-stemcell-eb365f8d-c069-4795-a6fc-3fb93dee6f0c' }
 
       context 'and use_managed_disks is false' do
         it 'should succeed' do
           expect(stemcell_manager).to receive(:delete_stemcell)
-            .with(stemcell_id)
+            .with(stemcell_cid)
 
           expect do
-            cloud.delete_stemcell(stemcell_id)
+            cloud.delete_stemcell(stemcell_cid)
           end.not_to raise_error
         end
       end
@@ -42,10 +42,10 @@ describe Bosh::AzureCloud::Cloud do
       context 'and use_managed_disks is true' do
         it 'should succeed' do
           expect(stemcell_manager2).to receive(:delete_stemcell)
-            .with(stemcell_id)
+            .with(stemcell_cid)
 
           expect do
-            managed_cloud.delete_stemcell(stemcell_id)
+            managed_cloud.delete_stemcell(stemcell_cid)
           end.not_to raise_error
         end
       end

--- a/src/bosh_azure_cpi/spec/unit/cloud/delete_vm_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/cloud/delete_vm_spec.rb
@@ -8,23 +8,23 @@ describe Bosh::AzureCloud::Cloud do
 
   describe '#delete_vm' do
     # Parameters
-    let(:instance_id) { 'e55144a3-0c06-4240-8f15-9a7bc7b35d1f' }
+    let(:vm_cid) { 'e55144a3-0c06-4240-8f15-9a7bc7b35d1f' }
     let(:instance_id_object) { instance_double(Bosh::AzureCloud::InstanceId) }
 
     before do
       allow(telemetry_manager).to receive(:monitor)
-        .with('delete_vm', id: instance_id).and_call_original
+        .with('delete_vm', id: vm_cid).and_call_original
     end
 
     it 'should delete an instance' do
       expect(Bosh::AzureCloud::InstanceId).to receive(:parse)
-        .with(instance_id, azure_config.resource_group_name)
+        .with(vm_cid, azure_config.resource_group_name)
         .and_return(instance_id_object)
 
       expect(vm_manager).to receive(:delete).with(instance_id_object)
 
       expect do
-        cloud.delete_vm(instance_id)
+        cloud.delete_vm(vm_cid)
       end.not_to raise_error
     end
   end

--- a/src/bosh_azure_cpi/spec/unit/cloud/detach_disk_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/cloud/detach_disk_spec.rb
@@ -7,21 +7,21 @@ describe Bosh::AzureCloud::Cloud do
   include_context 'shared stuff'
 
   describe '#detach_disk' do
-    let(:instance_id) { 'fake-instance-id' }
-    let(:disk_id) { 'fake-disk-id' }
+    let(:vm_cid) { 'fake-vm-cid' }
+    let(:disk_cid) { 'fake-disk-cid' }
     let(:host_device_id) { 'fake-host-device-id' }
     let(:disk_id_object) { instance_double(Bosh::AzureCloud::DiskId) }
     let(:instance_id_object) { instance_double(Bosh::AzureCloud::InstanceId) }
 
     before do
       allow(Bosh::AzureCloud::DiskId).to receive(:parse)
-        .with(disk_id, MOCK_RESOURCE_GROUP_NAME)
+        .with(disk_cid, MOCK_RESOURCE_GROUP_NAME)
         .and_return(disk_id_object)
       allow(Bosh::AzureCloud::InstanceId).to receive(:parse)
-        .with(instance_id, MOCK_RESOURCE_GROUP_NAME)
+        .with(vm_cid, MOCK_RESOURCE_GROUP_NAME)
         .and_return(instance_id_object)
       allow(telemetry_manager).to receive(:monitor)
-        .with('detach_disk', id: instance_id).and_call_original
+        .with('detach_disk', id: vm_cid).and_call_original
     end
 
     it 'detaches the disk from the vm' do
@@ -29,7 +29,7 @@ describe Bosh::AzureCloud::Cloud do
         'foo' => 'bar',
         'disks' => {
           'persistent' => {
-            'fake-disk-id' =>  {
+            disk_cid =>  {
               'lun' => '1',
               'host_device_id' => host_device_id
             },
@@ -54,15 +54,15 @@ describe Bosh::AzureCloud::Cloud do
       }
 
       expect(registry_client).to receive(:read_settings)
-        .with(instance_id)
+        .with(vm_cid)
         .and_return(old_settings)
       expect(registry_client).to receive(:update_settings)
-        .with(instance_id, new_settings)
+        .with(vm_cid, new_settings)
 
       expect(vm_manager).to receive(:detach_disk).with(instance_id_object, disk_id_object)
 
       expect do
-        cloud.detach_disk(instance_id, disk_id)
+        cloud.detach_disk(vm_cid, disk_cid)
       end.not_to raise_error
     end
   end

--- a/src/bosh_azure_cpi/spec/unit/cloud/get_disks_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/cloud/get_disks_spec.rb
@@ -7,7 +7,7 @@ describe Bosh::AzureCloud::Cloud do
   include_context 'shared stuff'
 
   describe '#get_disks' do
-    let(:instance_id) { 'fake-instance-id' }
+    let(:vm_cid) { 'fake-vm-cid' }
     let(:instance_id_object) { instance_double(Bosh::AzureCloud::InstanceId) }
 
     let(:data_disks) do
@@ -40,7 +40,7 @@ describe Bosh::AzureCloud::Cloud do
         .and_return(instance_id_object)
 
       allow(telemetry_manager).to receive(:monitor)
-        .with('get_disks', id: instance_id).and_call_original
+        .with('get_disks', id: vm_cid).and_call_original
     end
 
     context 'when the instance has data disks' do
@@ -49,7 +49,7 @@ describe Bosh::AzureCloud::Cloud do
           .with(instance_id_object)
           .and_return(instance)
 
-        expect(cloud.get_disks(instance_id)).to eq(['fake-id-1', 'fake-id-2', 'fake-id-3'])
+        expect(cloud.get_disks(vm_cid)).to eq(['fake-id-1', 'fake-id-2', 'fake-id-3'])
       end
     end
 
@@ -59,7 +59,7 @@ describe Bosh::AzureCloud::Cloud do
           .with(instance_id_object)
           .and_return(instance_no_disks)
 
-        expect(cloud.get_disks(instance_id)).to eq([])
+        expect(cloud.get_disks(vm_cid)).to eq([])
       end
     end
   end

--- a/src/bosh_azure_cpi/spec/unit/cloud/has_disk_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/cloud/has_disk_spec.rb
@@ -7,16 +7,16 @@ describe Bosh::AzureCloud::Cloud do
   include_context 'shared stuff'
 
   describe '#has_disk?' do
-    let(:disk_id) { 'fake-disk-id' }
+    let(:disk_cid) { 'fake-disk-id' }
     let(:disk_id_object) { instance_double(Bosh::AzureCloud::DiskId) }
 
     before do
       allow(Bosh::AzureCloud::DiskId).to receive(:parse)
-        .with(disk_id, MOCK_RESOURCE_GROUP_NAME)
+        .with(disk_cid, MOCK_RESOURCE_GROUP_NAME)
         .and_return(disk_id_object)
 
       allow(telemetry_manager).to receive(:monitor)
-        .with('has_disk?', id: disk_id).and_call_original
+        .with('has_disk?', id: disk_cid).and_call_original
     end
 
     context 'when disk name starts with DATA_DISK_PREFIX' do
@@ -32,7 +32,7 @@ describe Bosh::AzureCloud::Cloud do
           end
 
           it 'should return true' do
-            expect(managed_cloud.has_disk?(disk_id)).to be(true)
+            expect(managed_cloud.has_disk?(disk_cid)).to be(true)
           end
         end
 
@@ -48,7 +48,7 @@ describe Bosh::AzureCloud::Cloud do
 
             it 'should return false' do
               expect(disk_manager).not_to receive(:has_data_disk?)
-              expect(managed_cloud.has_disk?(disk_id)).to be(false)
+              expect(managed_cloud.has_disk?(disk_cid)).to be(false)
             end
           end
 
@@ -63,7 +63,7 @@ describe Bosh::AzureCloud::Cloud do
               end
 
               it 'should return true' do
-                expect(managed_cloud.has_disk?(disk_id)).to be(true)
+                expect(managed_cloud.has_disk?(disk_cid)).to be(true)
               end
             end
 
@@ -73,7 +73,7 @@ describe Bosh::AzureCloud::Cloud do
               end
 
               it 'should return false' do
-                expect(managed_cloud.has_disk?(disk_id)).to be(false)
+                expect(managed_cloud.has_disk?(disk_cid)).to be(false)
               end
             end
           end
@@ -87,7 +87,7 @@ describe Bosh::AzureCloud::Cloud do
           end
 
           it 'should return true' do
-            expect(cloud.has_disk?(disk_id)).to be(true)
+            expect(cloud.has_disk?(disk_cid)).to be(true)
           end
         end
 
@@ -97,7 +97,7 @@ describe Bosh::AzureCloud::Cloud do
           end
 
           it 'should return false' do
-            expect(cloud.has_disk?(disk_id)).to be(false)
+            expect(cloud.has_disk?(disk_cid)).to be(false)
           end
         end
       end
@@ -115,7 +115,7 @@ describe Bosh::AzureCloud::Cloud do
         end
 
         it 'should return true' do
-          expect(managed_cloud.has_disk?(disk_id)).to be(true)
+          expect(managed_cloud.has_disk?(disk_cid)).to be(true)
         end
       end
 
@@ -125,7 +125,7 @@ describe Bosh::AzureCloud::Cloud do
         end
 
         it 'should return false' do
-          expect(managed_cloud.has_disk?(disk_id)).to be(false)
+          expect(managed_cloud.has_disk?(disk_cid)).to be(false)
         end
       end
     end

--- a/src/bosh_azure_cpi/spec/unit/cloud/has_vm_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/cloud/has_vm_spec.rb
@@ -7,17 +7,17 @@ describe Bosh::AzureCloud::Cloud do
   include_context 'shared stuff'
 
   describe '#has_vm?' do
-    let(:instance_id) { 'e55144a3-0c06-4240-8f15-9a7bc7b35d1f' }
+    let(:vm_cid) { 'e55144a3-0c06-4240-8f15-9a7bc7b35d1f' }
     let(:instance_id_object) { instance_double(Bosh::AzureCloud::InstanceId) }
     let(:instance) { double('instance') }
 
     before do
       allow(Bosh::AzureCloud::InstanceId).to receive(:parse)
-        .with(instance_id, azure_config.resource_group_name)
+        .with(vm_cid, azure_config.resource_group_name)
         .and_return(instance_id_object)
 
       allow(telemetry_manager).to receive(:monitor)
-        .with('has_vm?', id: instance_id).and_call_original
+        .with('has_vm?', id: vm_cid).and_call_original
     end
 
     context 'when the instance exists' do
@@ -29,7 +29,7 @@ describe Bosh::AzureCloud::Cloud do
       end
 
       it 'should return true' do
-        expect(cloud.has_vm?(instance_id)).to be(true)
+        expect(cloud.has_vm?(vm_cid)).to be(true)
       end
     end
 
@@ -39,7 +39,7 @@ describe Bosh::AzureCloud::Cloud do
       end
 
       it 'should return false' do
-        expect(cloud.has_vm?(instance_id)).to be(false)
+        expect(cloud.has_vm?(vm_cid)).to be(false)
       end
     end
 
@@ -52,7 +52,7 @@ describe Bosh::AzureCloud::Cloud do
       end
 
       it 'should return false' do
-        expect(cloud.has_vm?(instance_id)).to be(false)
+        expect(cloud.has_vm?(vm_cid)).to be(false)
       end
     end
   end

--- a/src/bosh_azure_cpi/spec/unit/cloud/reboot_vm_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/cloud/reboot_vm_spec.rb
@@ -7,22 +7,22 @@ describe Bosh::AzureCloud::Cloud do
   include_context 'shared stuff'
 
   describe '#reboot_vm' do
-    let(:instance_id) { 'e55144a3-0c06-4240-8f15-9a7bc7b35d1f' }
+    let(:vm_cid) { 'e55144a3-0c06-4240-8f15-9a7bc7b35d1f' }
     let(:instance_id_object) { instance_double(Bosh::AzureCloud::InstanceId) }
 
     before do
       allow(Bosh::AzureCloud::InstanceId).to receive(:parse)
-        .with(instance_id, azure_config.resource_group_name)
+        .with(vm_cid, azure_config.resource_group_name)
         .and_return(instance_id_object)
       allow(telemetry_manager).to receive(:monitor)
-        .with('reboot_vm', id: instance_id).and_call_original
+        .with('reboot_vm', id: vm_cid).and_call_original
     end
 
     it 'reboot an instance' do
       expect(vm_manager).to receive(:reboot).with(instance_id_object)
 
       expect do
-        cloud.reboot_vm(instance_id)
+        cloud.reboot_vm(vm_cid)
       end.not_to raise_error
     end
   end

--- a/src/bosh_azure_cpi/spec/unit/cloud/resize_disk_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/cloud/resize_disk_spec.rb
@@ -6,13 +6,13 @@ require 'unit/cloud/shared_stuff.rb'
 describe Bosh::AzureCloud::Cloud do
   include_context 'shared stuff'
 
-  describe '#configure_networks' do
-    let(:instance_id) { 'e55144a3-0c06-4240-8f15-9a7bc7b35d1f' }
-    let(:networks) { 'networks' }
+  describe '#resize_disk' do
+    let(:vm_cid) { 'e55144a3-0c06-4240-8f15-9a7bc7b35d1f' }
+    let(:new_size) { double('size') }
 
     it 'should raise a NotSupported error' do
       expect do
-        cloud.configure_networks(instance_id, networks)
+        cloud.resize_disk(vm_cid, new_size)
       end.to raise_error(Bosh::Clouds::NotSupported)
     end
   end

--- a/src/bosh_azure_cpi/spec/unit/cloud/set_disk_metadata_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/cloud/set_disk_metadata_spec.rb
@@ -7,12 +7,12 @@ describe Bosh::AzureCloud::Cloud do
   include_context 'shared stuff'
 
   describe '#set_disk_metadata' do
-    let(:disk_id) { 'fake-disk-id' }
+    let(:disk_cid) { 'fake-disk-cid' }
     let(:metadata) { {} }
 
     it 'should raise a NotSupported error' do
       expect do
-        cloud.set_disk_metadata(disk_id, metadata)
+        cloud.set_disk_metadata(disk_cid, metadata)
       end.to raise_error {
         Bosh::Clouds::NotSupported
       }

--- a/src/bosh_azure_cpi/spec/unit/cloud/set_vm_metadata_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/cloud/set_vm_metadata_spec.rb
@@ -7,15 +7,15 @@ describe Bosh::AzureCloud::Cloud do
   include_context 'shared stuff'
 
   describe '#set_vm_metadata' do
-    let(:instance_id) { 'e55144a3-0c06-4240-8f15-9a7bc7b35d1f' }
+    let(:vm_cid) { 'e55144a3-0c06-4240-8f15-9a7bc7b35d1f' }
     let(:instance_id_object) { instance_double(Bosh::AzureCloud::InstanceId) }
 
     before do
       allow(Bosh::AzureCloud::InstanceId).to receive(:parse)
-        .with(instance_id, azure_config.resource_group_name)
+        .with(vm_cid, azure_config.resource_group_name)
         .and_return(instance_id_object)
       allow(telemetry_manager).to receive(:monitor)
-        .with('set_vm_metadata', id: instance_id).and_call_original
+        .with('set_vm_metadata', id: vm_cid).and_call_original
     end
 
     context 'when the metadata is not encoded' do
@@ -25,7 +25,7 @@ describe Bosh::AzureCloud::Cloud do
         expect(vm_manager).to receive(:set_metadata).with(instance_id_object, metadata)
 
         expect do
-          cloud.set_vm_metadata(instance_id, metadata)
+          cloud.set_vm_metadata(vm_cid, metadata)
         end.not_to raise_error
       end
     end
@@ -48,7 +48,7 @@ describe Bosh::AzureCloud::Cloud do
         expect(vm_manager).to receive(:set_metadata).with(instance_id_object, encoded_metadata)
 
         expect do
-          cloud.set_vm_metadata(instance_id, metadata)
+          cloud.set_vm_metadata(vm_cid, metadata)
         end.not_to raise_error
       end
     end

--- a/src/bosh_azure_cpi/spec/unit/cloud/shared_stuff.rb
+++ b/src/bosh_azure_cpi/spec/unit/cloud/shared_stuff.rb
@@ -18,9 +18,6 @@ shared_context 'shared stuff' do
   let(:vm_manager) { instance_double('Bosh::AzureCloud::VMManager') }
   let(:instance_type_mapper) { instance_double('Bosh::AzureCloud::InstanceTypeMapper') }
   let(:telemetry_manager) { MockTelemetryManager.new }
-  let(:agent_id) { 'e55144a3-0c06-4240-8f15-9a7bc7b35d1f' }
-  let(:stemcell_id) { 'bosh-stemcell-xxx' }
-  let(:bosh_vm_meta) { Bosh::AzureCloud::BoshVMMeta.new(agent_id, stemcell_id) }
 
   before do
     allow(Bosh::Cpi::RegistryClient).to receive(:new)

--- a/src/bosh_azure_cpi/spec/unit/cloud/snapshot_disk_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/cloud/snapshot_disk_spec.rb
@@ -8,20 +8,20 @@ describe Bosh::AzureCloud::Cloud do
 
   describe '#snapshot_disk' do
     let(:metadata) { {} }
-    let(:snapshot_id) { 'fake-snapshot-id' }
+    let(:snapshot_cid) { 'fake-snapshot-cid' }
     let(:snapshot_id_object) { instance_double(Bosh::AzureCloud::DiskId) }
     let(:resource_group_name) { 'fake-resource-group-name' }
     let(:caching) { 'fake-cacing' }
-    let(:disk_id) { 'fake-disk-id' }
+    let(:disk_cid) { 'fake-disk-cid' }
     let(:disk_id_object) { instance_double(Bosh::AzureCloud::DiskId) }
 
     before do
       allow(Bosh::AzureCloud::DiskId).to receive(:parse)
-        .with(disk_id, MOCK_RESOURCE_GROUP_NAME)
+        .with(disk_cid, MOCK_RESOURCE_GROUP_NAME)
         .and_return(disk_id_object)
 
       allow(snapshot_id_object).to receive(:to_s)
-        .and_return(snapshot_id)
+        .and_return(snapshot_cid)
 
       allow(disk_id_object).to receive(:resource_group_name)
         .and_return(resource_group_name)
@@ -29,7 +29,7 @@ describe Bosh::AzureCloud::Cloud do
         .and_return(caching)
 
       allow(telemetry_manager).to receive(:monitor)
-        .with('snapshot_disk', id: disk_id).and_call_original
+        .with('snapshot_disk', id: disk_cid).and_call_original
     end
 
     context 'when the disk is a managed disk' do
@@ -48,7 +48,7 @@ describe Bosh::AzureCloud::Cloud do
           expect(disk_manager2).to receive(:snapshot_disk)
             .with(snapshot_id_object, disk_name, metadata)
 
-          expect(cloud.snapshot_disk(disk_id, metadata)).to eq(snapshot_id)
+          expect(cloud.snapshot_disk(disk_cid, metadata)).to eq(snapshot_cid)
         end
       end
 
@@ -60,7 +60,7 @@ describe Bosh::AzureCloud::Cloud do
             .and_return(disk_name)
           expect(disk_manager2).to receive(:get_data_disk)
             .with(disk_id_object)
-            .and_return(name: disk_id)
+            .and_return(name: disk_cid)
         end
 
         it 'should take a managed snapshot of the disk' do
@@ -70,7 +70,7 @@ describe Bosh::AzureCloud::Cloud do
           expect(disk_manager2).to receive(:snapshot_disk)
             .with(snapshot_id_object, disk_name, metadata)
 
-          expect(cloud.snapshot_disk(disk_id, metadata)).to eq(snapshot_id)
+          expect(cloud.snapshot_disk(disk_cid, metadata)).to eq(snapshot_cid)
         end
       end
     end
@@ -98,7 +98,7 @@ describe Bosh::AzureCloud::Cloud do
           .with(caching, false, disk_name: snapshot_name, storage_account_name: storage_account_name)
           .and_return(snapshot_id_object)
 
-        expect(cloud.snapshot_disk(disk_id, metadata)).to eq(snapshot_id)
+        expect(cloud.snapshot_disk(disk_cid, metadata)).to eq(snapshot_cid)
       end
     end
   end

--- a/src/bosh_azure_cpi/spec/unit/helpers_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/helpers_spec.rb
@@ -1148,23 +1148,23 @@ describe Bosh::AzureCloud::Helpers do
     end
   end
 
-  describe '#is_light_stemcell_id?' do
+  describe '#is_light_stemcell_cid?' do
     context 'when stemcell is light' do
-      let(:stemcell_id) { 'bosh-light-stemcell-xxx' }
+      let(:stemcell_cid) { 'bosh-light-stemcell-xxx' }
 
       it 'should return true' do
         expect(
-          helpers_tester.is_light_stemcell_id?(stemcell_id)
+          helpers_tester.is_light_stemcell_cid?(stemcell_cid)
         ).to be(true)
       end
     end
 
     context 'when stemcell is heavy' do
-      let(:stemcell_id) { 'bosh-stemcell-xxx' }
+      let(:stemcell_cid) { 'bosh-stemcell-xxx' }
 
       it 'should return false' do
         expect(
-          helpers_tester.is_light_stemcell_id?(stemcell_id)
+          helpers_tester.is_light_stemcell_cid?(stemcell_cid)
         ).to be(false)
       end
     end

--- a/src/bosh_azure_cpi/spec/unit/instance_type_mapper_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/instance_type_mapper_spec.rb
@@ -6,7 +6,7 @@ describe Bosh::AzureCloud::InstanceTypeMapper do
   subject { described_class.new }
 
   context 'when no possible VM sizes are found' do
-    let(:vm_resources) do
+    let(:desired_instance_size) do
       {
         'cpu' => 3200,
         'ram' => 102_400
@@ -29,13 +29,13 @@ describe Bosh::AzureCloud::InstanceTypeMapper do
 
     it 'raise an error' do
       expect do
-        subject.map(vm_resources, available_vm_sizes)
-      end.to raise_error(/Unable to meet requested vm_resources: 3200 CPU, 102400 MB RAM/)
+        subject.map(desired_instance_size, available_vm_sizes)
+      end.to raise_error(/Unable to meet requested desired_instance_size: 3200 CPU, 102400 MB RAM/)
     end
   end
 
   context 'when the closest matched VM sizes are not found' do
-    let(:vm_resources) do
+    let(:desired_instance_size) do
       {
         'cpu' => 1,
         'ram' => 512
@@ -58,13 +58,13 @@ describe Bosh::AzureCloud::InstanceTypeMapper do
 
     it 'raise an error' do
       expect do
-        subject.map(vm_resources, available_vm_sizes)
+        subject.map(desired_instance_size, available_vm_sizes)
       end.to raise_error(/Unable to find the closest matched VM sizes/)
     end
   end
 
   context 'when the closest matched VM sizes are found' do
-    let(:vm_resources) do
+    let(:desired_instance_size) do
       {
         'cpu' => 1,
         'ram' => 512
@@ -86,7 +86,7 @@ describe Bosh::AzureCloud::InstanceTypeMapper do
     end
 
     it 'return the instance type' do
-      expect(subject.map(vm_resources, available_vm_sizes)).to eq('Standard_F1')
+      expect(subject.map(desired_instance_size, available_vm_sizes)).to eq('Standard_F1')
     end
   end
 end


### PR DESCRIPTION
This PR follows the each CPI method of https://bosh.io/docs/cpi-api-v1-rpc/#methods, and update the CPI method's description, arguments and results.